### PR TITLE
feat: Cumulative updates for files_drives from 1.12 to feed newest drive_server and 1.11

### DIFF
--- a/packages/backend/cmd/root.go
+++ b/packages/backend/cmd/root.go
@@ -145,8 +145,10 @@ user created with the credentials from options "username" and "password".`,
 
 		// my_redis for watcher
 		my_redis.InitRedis()
-		my_redis.InitFolderAndRedis()
-		go my_redis.StartDailyCleanup()
+		if diskcache.CacheDir != "" {
+			my_redis.InitFolderAndRedis()
+			go my_redis.StartDailyCleanup()
+		}
 
 		// rpcServer for zinc
 		var wg sync.WaitGroup

--- a/packages/backend/diskcache/file_cache.go
+++ b/packages/backend/diskcache/file_cache.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 )
 
-var CacheDir = "/data/file_cache"
+var CacheDir = os.Getenv("FILE_CACHE_DIR") // "/data/file_cache"
 
 type FileCache struct {
 	fs afero.Fs

--- a/packages/backend/http/google_drive.go
+++ b/packages/backend/http/google_drive.go
@@ -48,6 +48,7 @@ type GoogleDriveListResponseFileData struct {
 	CanDownload  bool                             `json:"canDownload"`
 	CanExport    bool                             `json:"canExport"`
 	ExportSuffix string                           `json:"exportSuffix"`
+	IdPath       string                           `json:"id_path,omitempty"`
 }
 
 type GoogleDriveListResponseFileMeta struct {

--- a/packages/backend/http/preview.go
+++ b/packages/backend/http/preview.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/filebrowser/filebrowser/v2/diskcache"
 	"github.com/filebrowser/filebrowser/v2/files"
 	"github.com/filebrowser/filebrowser/v2/img"
 	"github.com/filebrowser/filebrowser/v2/my_redis"
@@ -126,7 +127,9 @@ func handleImagePreview(
 		}
 	}
 
-	my_redis.UpdateFileAccessTimeToRedis(my_redis.GetFileName(cacheKey))
+	if diskcache.CacheDir != "" {
+		my_redis.UpdateFileAccessTimeToRedis(my_redis.GetFileName(cacheKey))
+	}
 
 	w.Header().Set("Cache-Control", "private")
 	http.ServeContent(w, r, file.Name, file.ModTime, bytes.NewReader(resizedImage))

--- a/packages/backend/http/resource.go
+++ b/packages/backend/http/resource.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"context"
 	"fmt"
+	"github.com/filebrowser/filebrowser/v2/diskcache"
 	"github.com/filebrowser/filebrowser/v2/my_redis"
 	"io"
 	"io/ioutil"
@@ -753,9 +754,11 @@ func delThumbs(ctx context.Context, fileCache FileCache, file *files.FileInfo) e
 		if err := fileCache.Delete(ctx, cacheKey); err != nil {
 			return err
 		}
-		err := my_redis.DelThumbRedisKey(my_redis.GetFileName(cacheKey))
-		if err != nil {
-			return err
+		if diskcache.CacheDir != "" {
+			err := my_redis.DelThumbRedisKey(my_redis.GetFileName(cacheKey))
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
feat: add support for new field id_path for google drive stream
fix: add CACHE_DIR to make appdata use the newest version correctly