### PR TITLE
fix: same logic of getting mounted data for 1.11 and 1.12

### DIFF
--- a/packages/backend/http/resource.go
+++ b/packages/backend/http/resource.go
@@ -189,44 +189,36 @@ var resourceGetHandler = withUser(func(w http.ResponseWriter, r *http.Request, d
 	xBflUser := r.Header.Get("X-Bfl-User")
 	fmt.Println("X-Bfl-User: ", xBflUser)
 
-	olaresVersion := os.Getenv("OLARES_VERSION")
-	if olaresVersion == "" {
-		olaresVersion = "1.11"
-	}
-
-	olaresVersionFloat, err := strconv.ParseFloat(olaresVersion, 64)
-	if err != nil {
-		fmt.Println("Error parsing version:", err)
-		return http.StatusBadRequest, err
-	}
+	//olaresVersion := os.Getenv("OLARES_VERSION")
+	//if olaresVersion == "" {
+	//	olaresVersion = "1.11"
+	//}
+	//
+	//olaresVersionFloat, err := strconv.ParseFloat(olaresVersion, 64)
+	//if err != nil {
+	//	fmt.Println("Error parsing version:", err)
+	//	return http.StatusBadRequest, err
+	//}
 
 	var mountedData []files.DiskInfo = nil
 	if files.TerminusdHost != "" {
-		if olaresVersionFloat >= 1.12 {
-			url := "http://" + files.TerminusdHost + "/system/mounted-path-incluster"
+		//if olaresVersionFloat >= 1.12 {
+		// for 1.12: path-incluster URL exists, won't err in normal condition
+		// for 1.11: path-incluster URL may not exist, if err, use usb-incluster and hdd-incluster for system functional
+		url := "http://" + files.TerminusdHost + "/system/mounted-path-incluster"
 
-			headers := r.Header.Clone()
-			headers.Set("Content-Type", "application/json")
-			headers.Set("X-Signature", "temp_signature")
-			//headers := map[string]string{
-			//	"X-Signature": "temp_signature",
-			//}
+		headers := r.Header.Clone()
+		headers.Set("Content-Type", "application/json")
+		headers.Set("X-Signature", "temp_signature")
 
-			mountedData, err = files.FetchDiskInfo(url, headers)
-			if err != nil {
-				log.Printf("Failed to fetch data from %s: %v", url, err)
-			}
-
-			fmt.Println("Mounted Data:", mountedData)
-		} else {
+		mountedData, err = files.FetchDiskInfo(url, headers)
+		if err != nil {
+			log.Printf("Failed to fetch data from %s: %v", url, err)
 			usbUrl := "http://" + files.TerminusdHost + "/system/mounted-usb-incluster"
 
 			usbHeaders := r.Header.Clone()
 			usbHeaders.Set("Content-Type", "application/json")
 			usbHeaders.Set("X-Signature", "temp_signature")
-			//headers := map[string]string{
-			//	"X-Signature": "temp_signature",
-			//}
 
 			usbData, err := files.FetchDiskInfo(usbUrl, usbHeaders)
 			if err != nil {
@@ -240,9 +232,6 @@ var resourceGetHandler = withUser(func(w http.ResponseWriter, r *http.Request, d
 			hddHeaders := r.Header.Clone()
 			hddHeaders.Set("Content-Type", "application/json")
 			hddHeaders.Set("X-Signature", "temp_signature")
-			//headers := map[string]string{
-			//	"X-Signature": "temp_signature",
-			//}
 
 			hddData, err := files.FetchDiskInfo(hddUrl, hddHeaders)
 			if err != nil {
@@ -260,8 +249,8 @@ var resourceGetHandler = withUser(func(w http.ResponseWriter, r *http.Request, d
 				item.Type = "hdd"
 				mountedData = append(mountedData, item)
 			}
-			fmt.Println("Mounted Data:", mountedData)
 		}
+		fmt.Println("Mounted Data:", mountedData)
 	}
 
 	var file *files.FileInfo


### PR DESCRIPTION
fix: same logic of getting mounted data for 1.11 and 1.12