### PR TITLE
fix: rename and cut/paste of smb bugfix 

### DIFF
--- a/pkg/drives/drive.go
+++ b/pkg/drives/drive.go
@@ -25,7 +25,10 @@ type DriveResourceService struct {
 }
 
 func (rs *DriveResourceService) PasteSame(action, src, dst string, rename bool, fileCache fileutils.FileCache, w http.ResponseWriter, r *http.Request) error {
-	return common.PatchAction(r.Context(), action, src, dst, fileCache)
+	mountedData := GetMountedData(r)
+	srcExternalType := files.GetExternalType(src, mountedData)
+	dstExternalType := files.GetExternalType(dst, mountedData)
+	return common.PatchAction(r.Context(), action, src, dst, srcExternalType, dstExternalType, fileCache)
 }
 
 func (rs *DriveResourceService) PasteDirFrom(fs afero.Fs, srcType, src, dstType, dst string, d *common.Data,


### PR DESCRIPTION
- add smb readonly field (not used by frontend for the time being)
- add del all thumbs and renaming try to the beginning of moving folder
- use rm -rf with ls retry for only smb when deleting at the ending of moveing folder