### PR TITLE
fix sync dir rename bug

### DIFF
--- a/pkg/drives/sync.go
+++ b/pkg/drives/sync.go
@@ -1995,6 +1995,8 @@ func ResourceSyncPatch(action, src, dst string, r *http.Request) (int, []byte, e
 	var apiName = "/file/"
 	if strings.HasSuffix(src, "/") {
 		apiName = "/dir/"
+		src = strings.TrimSuffix(src, "/")
+		dst = strings.TrimSuffix(dst, "/")
 	}
 
 	repoID, prefix, filename := ParseSyncPath(src)


### PR DESCRIPTION
fix a sync dir rename bug because new name is parsed as empty string