### PR TITLE
fix: a bug when listing external if any smb folder is stated as host is down

### DIFF
--- a/cmd/backend/app/root.go
+++ b/cmd/backend/app/root.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"files/pkg/background_task"
 	"files/pkg/crontab"
+	"files/pkg/drives"
 	"files/pkg/fileutils"
 	"files/pkg/pool"
 	"files/pkg/postgres"
@@ -163,6 +164,8 @@ user created with the credentials from options "username" and "password".`,
 		// step5: BackgroundTask
 		// 		- initRpcServer
 		//		- initWatcher
+		drives.GetMountedData(nil)
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		background_task.InitBackgroundTaskManager(ctx)

--- a/pkg/background_task/background_task.go
+++ b/pkg/background_task/background_task.go
@@ -163,7 +163,7 @@ func InitBackgroundTaskManager(ctx context.Context) {
 		name:     "GetMountedData",
 		taskFunc: drives.GetMountedData,
 		taskType: PeriodicTask,
-		interval: 2 * time.Minute,
+		interval: 5 * time.Minute,
 		ticker:   drives.MountedTicker,
 	})
 

--- a/pkg/drives/drive.go
+++ b/pkg/drives/drive.go
@@ -27,7 +27,7 @@ import (
 var (
 	MountedData   []files.DiskInfo = nil
 	mu            sync.Mutex
-	MountedTicker = time.NewTicker(2 * time.Minute)
+	MountedTicker = time.NewTicker(5 * time.Minute)
 )
 
 // if cache logic is same as drive, it will be written in this file


### PR DESCRIPTION
fix: 
- a bug when listing external if any smb folder is stated as host is down which is fixed by a second method using filepath.Walk