### PR TITLE
fix: automatically number duplicate files and folders when copying

### DIFF
--- a/pkg/drivers/clouds/cloud.go
+++ b/pkg/drivers/clouds/cloud.go
@@ -275,7 +275,7 @@ func (s *CloudStorage) Create(contextArgs *models.HttpContextArgs) ([]byte, erro
 		Metadata:   false,
 	}
 	var filter = &operations.OperationsFilter{
-		FilterRule: s.service.command.FormatFilter(createName, true),
+		FilterRule: s.service.command.FormatFilter(createName, true, true, true),
 	}
 
 	existsItems, err := s.service.command.GetMatchedItems(fsPrefix+prefixPath, opts, filter)
@@ -430,7 +430,7 @@ func (s *CloudStorage) Rename(contextArgs *models.HttpContextArgs) ([]byte, erro
 	}
 
 	var filter = &operations.OperationsFilter{
-		FilterRule: s.service.command.FormatFilter(dstName, false),
+		FilterRule: s.service.command.FormatFilter(dstName, false, true, true),
 	}
 
 	dstItems, err := s.service.command.GetMatchedItems(fsPrefix+srcPrefixPath, opts, filter)

--- a/pkg/drivers/clouds/rclone/interface.go
+++ b/pkg/drivers/clouds/rclone/interface.go
@@ -34,8 +34,8 @@ type Interface interface {
 	StopJobs() error
 
 	GetMatchedItems(fs string, opt *operations.OperationsOpt, filter *operations.OperationsFilter) (*operations.OperationsList, error)
-
-	FormatFilter(s string, fuzzy bool) []string
+	CheckGoogleDriveDupNames(param *models.FileParam) (bool, string, error)
+	FormatFilter(s string, fuzzy bool, containsDir, containsFile bool) []string
 }
 
 const (

--- a/pkg/drivers/clouds/rclone/operations/vars.go
+++ b/pkg/drivers/clouds/rclone/operations/vars.go
@@ -17,7 +17,9 @@ var (
 	SyncCopyPath = "sync/copy"
 	SyncMovePath = "sync/move"
 
-	FsCacheClearPath = "fscache/clear"
+	FsCacheClearPath   = "fscache/clear"
+	CoreCommandPath    = "core/command"
+	BackendCommandPath = "backend/command"
 )
 
 type OperationsStat struct {
@@ -90,6 +92,18 @@ type OperationsCopyFileResp struct {
 
 type OperationsAsyncJobResp struct {
 	JobId *int `json:"jobid,omitempty"`
+}
+
+type CoreCommandReq struct {
+	Command string   `json:"command"`
+	Args    []string `json:"arg"`
+}
+
+type BackendCommandReq struct {
+	Command string   `json:"command"`
+	Fs      string   `json:"fs"`
+	Args    []string `json:"arg"`
+	Async   *bool    `json:"_async,omitempty"`
 }
 
 /*

--- a/pkg/models/file_param.go
+++ b/pkg/models/file_param.go
@@ -207,6 +207,10 @@ func (r *FileParam) GetFileParam(uri string) error {
 	return nil
 }
 
+func (r *FileParam) IsGoogleDrive() bool {
+	return r.FileType == common.GoogleDrive
+}
+
 func (r *FileParam) IsCloud() bool {
 	return common.ListContains([]string{common.AwsS3, common.TencentCos, common.DropBox, common.GoogleDrive}, r.FileType)
 }

--- a/pkg/tasks/manager.go
+++ b/pkg/tasks/manager.go
@@ -391,7 +391,7 @@ func (t *taskManager) GetCloudOrPosixDupNames(taskId string, action string, uplo
 				NoMimeType: true,
 				Metadata:   false,
 			}
-			var filterRules = cmd.FormatFilter(orgSrcNamePrefix, true)
+			var filterRules = cmd.FormatFilter(orgSrcNamePrefix, true, true, true)
 			var filter = &operations.OperationsFilter{}
 			if filterRules != nil {
 				klog.Infof("[Task] Id: %s, lock, list filter: %v", taskId, filterRules)

--- a/pkg/tasks/task.go
+++ b/pkg/tasks/task.go
@@ -224,7 +224,8 @@ func (t *Task) Execute(fs ...func() error) error {
 
 func (t *Task) updateProgress(progress int, transfer int64) {
 	t.progress = progress
-	t.transfer = transfer
+	// t.transfer = transfer
+	t.transfer += transfer
 	t.details = append(t.details, fmt.Sprintf("rsync files progress: %d, transfer: %d", progress, transfer))
 }
 


### PR DESCRIPTION
Download files from Google Drive by copying them one by one to avoid data loss caused by duplicate names in subfolders or files