### PR TITLE
fix: stream response body in ShareMiddleware to prevent OOM on large file downloads

### DIFF
--- a/pkg/hertz/biz/router/middleware.go
+++ b/pkg/hertz/biz/router/middleware.go
@@ -67,6 +67,13 @@ var (
 	ShareApiUploadedPath   = "/upload/file-uploaded-bytes"
 )
 
+var shareProxyClient = &http.Client{
+	Transport: &http.Transport{
+		MaxIdleConnsPerHost: 64,
+		DisableCompression:  true,
+	},
+}
+
 func Cors() app.HandlerFunc {
 	return func(ctx context.Context, c *app.RequestContext) {
 		c.Response.Header.Set("Access-Control-Allow-Origin", string(c.Request.Header.Get("Origin")))
@@ -398,7 +405,7 @@ func ShareMiddleware() app.HandlerFunc {
 		req.Body = io.NopCloser(bytes.NewReader(body))
 		req.ContentLength = int64(len(body))
 
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := shareProxyClient.Do(req)
 		if err != nil {
 			handler.RespError(c, fmt.Sprintf("proxy error: %v", err))
 			return
@@ -412,10 +419,6 @@ func ShareMiddleware() app.HandlerFunc {
 		c.Status(resp.StatusCode)
 
 		if shareAccess.Raw || shareAccess.Download || shareAccess.Preview {
-			// Stream the response body directly to avoid loading the entire
-			// file into memory, which would cause OOM for large files.
-			// Do NOT defer resp.Body.Close() here — Hertz reads from the body
-			// stream after the handler returns when flushing to the connection.
 			contentLength := int(resp.ContentLength)
 			if contentLength < 0 {
 				contentLength = -1
@@ -712,7 +715,7 @@ func proxySharePaste(c *app.RequestContext, owner string, action string, src, ds
 	})
 	req.Header.Set(common.REQUEST_HEADER_OWNER, owner)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := shareProxyClient.Do(req)
 	if err != nil {
 		handler.RespError(c, fmt.Sprintf("proxy error: %v", err))
 		return

--- a/pkg/hertz/biz/router/middleware.go
+++ b/pkg/hertz/biz/router/middleware.go
@@ -403,7 +403,6 @@ func ShareMiddleware() app.HandlerFunc {
 			handler.RespError(c, fmt.Sprintf("proxy error: %v", err))
 			return
 		}
-		defer resp.Body.Close()
 
 		for k, vv := range resp.Header {
 			for _, v := range vv {
@@ -411,8 +410,22 @@ func ShareMiddleware() app.HandlerFunc {
 			}
 		}
 		c.Status(resp.StatusCode)
-		bodyRes, _ := io.ReadAll(resp.Body)
-		c.Write(bodyRes)
+
+		if shareAccess.Raw || shareAccess.Download || shareAccess.Preview {
+			// Stream the response body directly to avoid loading the entire
+			// file into memory, which would cause OOM for large files.
+			// Do NOT defer resp.Body.Close() here — Hertz reads from the body
+			// stream after the handler returns when flushing to the connection.
+			contentLength := int(resp.ContentLength)
+			if contentLength < 0 {
+				contentLength = -1
+			}
+			c.SetBodyStream(resp.Body, contentLength)
+		} else {
+			bodyRes, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			c.Write(bodyRes)
+		}
 		c.Abort()
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In `ShareMiddleware`, when proxying share link requests for `/api/raw/` (file downloads and inline previews) and `/api/preview/`, the entire upstream response body is read into memory with `io.ReadAll(resp.Body)` before being written to the client via `c.Write(bodyRes)`. For large files, this allocates the full file content in memory, causing OOM crashes.

**Only share link requests are affected.** Non-share requests (e.g. `/api/raw/drive/...`) are not proxied — they pass through the middleware via `c.Next(ctx)` and are handled directly by `RawMethod`, which already uses streaming via `c.SetBodyStream()`.

The proxy path is:
1. Client requests `/api/raw/share/{shareId}/path/to/file`
2. `ShareMiddleware` rewrites URL to `/api/raw/{realFileType}/{realExtend}/...?share=1` and self-proxies to `127.0.0.1:8080`
3. `RawMethod` handles the internal request with streaming (`SetBodyStream`)
4. **Middleware reads the entire response into memory with `io.ReadAll`** ← OOM root cause
5. Middleware writes buffered body to the original client

## Fix

### 1. Stream response body for file-serving proxy paths

For Raw/Download/Preview share requests, replace `io.ReadAll` + `c.Write` with `c.SetBodyStream(resp.Body, contentLength)`, streaming the response body directly from upstream to client without buffering.

Non-streaming requests (Resource listings, Upload metadata) continue using `io.ReadAll` since their responses are small JSON payloads.

Hertz automatically calls `resp.Body.Close()` after reading all data from the body stream (documented behavior for `io.Closer` implementors), so the HTTP response body is properly cleaned up.

### 2. Dedicated HTTP client for share proxy

Replace `http.DefaultClient` with a purpose-built `shareProxyClient`:

```go
var shareProxyClient = &http.Client{
    Transport: &http.Transport{
        MaxIdleConnsPerHost: 64,
        DisableCompression:  true,
    },
}
```

- **`MaxIdleConnsPerHost: 64`**: The default is 2, which is too low for concurrent share downloads through the self-proxy to `127.0.0.1:8080`. With streaming, connections stay open for the duration of the client download.
- **`DisableCompression: true`**: Self-proxy doesn't benefit from gzip. Disabling it also ensures `resp.ContentLength` stays accurate (Go's default transport transparently decompresses and resets ContentLength to -1).

Applied to both `ShareMiddleware` and `proxySharePaste`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d7bcac1-cd81-4bdb-ab75-9b951efacf8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d7bcac1-cd81-4bdb-ab75-9b951efacf8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

