### PR TITLE
fix(smb): harden third-party NAS mount pipeline against crash and hang

### DIFF
--- a/pkg/files/file.go
+++ b/pkg/files/file.go
@@ -83,7 +83,7 @@ type FileOptions struct {
 	Content    bool
 }
 
-var TerminusdHost = os.Getenv("TERMINUSD_HOST")
+var OlaresdHost = os.Getenv("TERMINUSD_HOST")
 var ExternalPrefix = os.Getenv("EXTERNAL_PREFIX")
 
 type Response struct {
@@ -115,83 +115,33 @@ func MountPathIncluster(r *http.Request) (map[string]interface{}, error) {
 	externalType := r.URL.Query().Get("external_type")
 	var urls []string
 	if externalType == "smb" {
-		urls = []string{"http://" + TerminusdHost + "/command/v2/mount-samba", "http://" + TerminusdHost + "/command/mount-samba"}
+		urls = []string{"http://" + OlaresdHost + "/command/v2/mount-samba", "http://" + OlaresdHost + "/command/mount-samba"}
 	} else {
 		return nil, fmt.Errorf("Unsupported external type: %s", externalType)
 	}
 
-	for _, url := range urls {
-		bodyBytes, err := ioutil.ReadAll(r.Body)
-		if err != nil {
-			return nil, err
-		}
-		r.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
-
-		headers := r.Header.Clone()
-		headers.Set("Content-Type", "application/json")
-		headers.Set("X-Signature", "temp_signature")
-
-		client := &http.Client{}
-		req, err := http.NewRequest("POST", url, bytes.NewReader(bodyBytes))
-		if err != nil {
-			return nil, err
-		}
-		req.Header = headers
-
-		resp, err := client.Do(req)
-		if err != nil {
-			return nil, err
-		}
-
-		if resp == nil {
-			klog.Errorf("not get response from %s", url)
-			continue
-		}
-
-		respBody, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return nil, err
-		}
-
-		var responseMap map[string]interface{}
-		err = json.Unmarshal(respBody, &responseMap)
-		if err != nil {
-			return nil, err
-		}
-
-		err = resp.Body.Close()
-		if err != nil {
-			return responseMap, err
-		}
-
-		if resp.StatusCode >= 400 {
-			klog.Errorf("Failed to mount by %s to %s", url, TerminusdHost)
-			klog.Infof("response status: %s, response body: %v", resp.Status, responseMap)
-			continue
-		}
-
-		return responseMap, nil
+	bodyBytes, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
 	}
-	return nil, fmt.Errorf("failed to mount samba")
+	r.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+
+	return CallOlaresdFallback(urls, bodyBytes, r.Header, DefaultOlaresdTimeout)
 }
 
 func UnmountPathIncluster(r *http.Request, path string) (map[string]interface{}, error) {
 	externalType := r.URL.Query().Get("external_type")
 	var url = ""
 	if externalType == "usb" {
-		url = "http://" + TerminusdHost + "/command/umount-usb-incluster"
+		url = "http://" + OlaresdHost + "/command/umount-usb-incluster"
 	} else if externalType == "smb" {
-		url = "http://" + TerminusdHost + "/command/umount-samba-incluster"
+		url = "http://" + OlaresdHost + "/command/umount-samba-incluster"
 	} else {
 		return nil, fmt.Errorf("Unsupported external type: %s", externalType)
 	}
 	klog.Infoln("path:", path)
 	klog.Infoln("externalTYpe:", externalType)
 	klog.Infoln("url:", url)
-
-	headers := r.Header.Clone()
-	headers.Set("Content-Type", "application/json")
-	headers.Set("X-Signature", "temp_signature")
 
 	mountPath := strings.TrimPrefix(strings.TrimSuffix(path, "/"), "/")
 	lastSlashIndex := strings.LastIndex(mountPath, "/")
@@ -203,36 +153,12 @@ func UnmountPathIncluster(r *http.Request, path string) (map[string]interface{},
 	bodyData := map[string]string{
 		"path": mountPath,
 	}
-	klog.Infoln("bodyData:", bodyData)
 	body, err := json.Marshal(bodyData)
 	if err != nil {
 		return nil, err
 	}
-	klog.Infoln("body (byte slice):", body)
-	klog.Infoln("body (string):", string(body))
 
-	client := &http.Client{}
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
-	req.Header = headers
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	respBody, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	var responseMap map[string]interface{}
-	err = json.Unmarshal(respBody, &responseMap)
-	if err != nil {
-		return nil, err
-	}
-	klog.Infoln("responseMap:", responseMap)
-
-	return responseMap, nil
+	return CallOlaresdFallback([]string{url}, body, r.Header, DefaultOlaresdTimeout)
 }
 
 // NewFileInfo creates a File object from a path and a given user. This File

--- a/pkg/files/olaresd.go
+++ b/pkg/files/olaresd.go
@@ -1,0 +1,110 @@
+package files
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+// DefaultOlaresdTimeout is the default timeout for HTTP requests to olaresd
+// (mount / umount / mounted list). Keeping it bounded prevents a stuck olaresd
+// from piling up goroutines inside the Files server.
+const DefaultOlaresdTimeout = 30 * time.Second
+
+// ErrOlaresdNoResponse is returned when every URL in a fallback chain failed
+// without producing a parseable JSON body.
+var ErrOlaresdNoResponse = errors.New("olaresd upstream unreachable")
+
+// CallOlaresdFallback POSTs body to each URL in order until one succeeds.
+//
+// A URL is considered successful if the HTTP call returns a 2xx/3xx status
+// and a JSON body that can be decoded into map[string]interface{}. On any other
+// outcome (network error, non-JSON body, 4xx/5xx) we log the failure and move
+// on to the next URL.
+//
+// The returned map is the most recent parsed JSON body (may be nil when every
+// attempt failed before producing one). The error is nil when at least one URL
+// succeeded; otherwise it is the last underlying error (or ErrOlaresdNoResponse
+// when no attempt even produced a usable error).
+func CallOlaresdFallback(urls []string, body []byte, header http.Header, timeout time.Duration) (map[string]interface{}, error) {
+	if len(urls) == 0 {
+		return nil, errors.New("no olaresd url provided")
+	}
+	if timeout <= 0 {
+		timeout = DefaultOlaresdTimeout
+	}
+
+	client := &http.Client{Timeout: timeout}
+
+	var (
+		lastBody map[string]interface{}
+		lastErr  error
+	)
+
+	for _, url := range urls {
+		req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+		if err != nil {
+			klog.Warningf("olaresd: build request failed, url=%s, err=%v", url, err)
+			lastErr = err
+			continue
+		}
+
+		if header != nil {
+			req.Header = header.Clone()
+		}
+		req.Header.Set("Content-Type", "application/json")
+		if req.Header.Get("X-Signature") == "" {
+			req.Header.Set("X-Signature", "temp_signature")
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			klog.Warningf("olaresd: request failed, url=%s, err=%v", url, err)
+			lastErr = err
+			continue
+		}
+
+		respBody, err := ioutil.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if err != nil {
+			klog.Warningf("olaresd: read body failed, url=%s, status=%s, err=%v", url, resp.Status, err)
+			lastErr = err
+			continue
+		}
+
+		parsed := map[string]interface{}{}
+		if jerr := json.Unmarshal(respBody, &parsed); jerr != nil {
+			klog.Warningf("olaresd: body not json, url=%s, status=%s, body=%s", url, resp.Status, truncate(respBody, 512))
+			lastErr = fmt.Errorf("non-json response from %s (status %s)", url, resp.Status)
+			continue
+		}
+
+		lastBody = parsed
+
+		if resp.StatusCode >= 400 {
+			klog.Warningf("olaresd: http %s from %s, body=%v", resp.Status, url, parsed)
+			lastErr = fmt.Errorf("http %s from %s", resp.Status, url)
+			continue
+		}
+
+		return parsed, nil
+	}
+
+	if lastErr == nil {
+		lastErr = ErrOlaresdNoResponse
+	}
+	return lastBody, lastErr
+}
+
+func truncate(b []byte, n int) string {
+	if len(b) <= n {
+		return string(b)
+	}
+	return string(b[:n]) + "...(truncated)"
+}

--- a/pkg/files/olaresd_test.go
+++ b/pkg/files/olaresd_test.go
@@ -1,0 +1,155 @@
+package files
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestCallOlaresdFallback_V2NetworkErrorThenV1Succeeds(t *testing.T) {
+	// v2 URL points to an unreachable port; v1 URL serves a valid JSON body.
+	v1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"code":200,"message":"ok"}`))
+	}))
+	defer v1.Close()
+
+	urls := []string{"http://127.0.0.1:1/mount", v1.URL}
+	res, err := CallOlaresdFallback(urls, []byte(`{}`), nil, 2*time.Second)
+	if err != nil {
+		t.Fatalf("expected success via fallback, got err=%v", err)
+	}
+	if res == nil || int(res["code"].(float64)) != 200 {
+		t.Fatalf("unexpected response: %#v", res)
+	}
+}
+
+func TestCallOlaresdFallback_V2NonJSONThenV1Succeeds(t *testing.T) {
+	v2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`<html><body>404</body></html>`))
+	}))
+	defer v2.Close()
+	v1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"code":200,"data":[]}`))
+	}))
+	defer v1.Close()
+
+	res, err := CallOlaresdFallback([]string{v2.URL, v1.URL}, []byte(`{}`), nil, 2*time.Second)
+	if err != nil {
+		t.Fatalf("expected success via fallback, got err=%v", err)
+	}
+	if res == nil || int(res["code"].(float64)) != 200 {
+		t.Fatalf("unexpected response: %#v", res)
+	}
+}
+
+func TestCallOlaresdFallback_BothFailWith4xx(t *testing.T) {
+	makeBadServer := func(body string, contentType string) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if contentType != "" {
+				w.Header().Set("Content-Type", contentType)
+			}
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(body))
+		}))
+	}
+
+	// v2 returns a JSON error body, v1 returns non-JSON. We expect err!=nil,
+	// but the most recent parsed JSON body (from v2) should still be returned
+	// so the caller can surface the upstream message.
+	v2 := makeBadServer(`{"code":400,"message":"mount error(13)"}`, "application/json")
+	defer v2.Close()
+	v1 := makeBadServer(`<html>bad gateway</html>`, "text/html")
+	defer v1.Close()
+
+	res, err := CallOlaresdFallback([]string{v2.URL, v1.URL}, []byte(`{}`), nil, 2*time.Second)
+	if err == nil {
+		t.Fatalf("expected error when all URLs fail")
+	}
+	if res == nil {
+		t.Fatalf("expected last parsed JSON body to be returned")
+	}
+	msg, _ := res["message"].(string)
+	if !strings.Contains(msg, "mount error(13)") {
+		t.Fatalf("expected last JSON body to be v2's, got %#v", res)
+	}
+}
+
+func TestCallOlaresdFallback_BothTimeout(t *testing.T) {
+	slow := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+		_, _ = w.Write([]byte(`{"code":200}`))
+	}))
+	defer slow.Close()
+
+	start := time.Now()
+	res, err := CallOlaresdFallback([]string{slow.URL, slow.URL}, []byte(`{}`), nil, 50*time.Millisecond)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatalf("expected timeout error, got res=%#v", res)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("fallback took too long (timeout not honored): %v", elapsed)
+	}
+	if !isTimeoutErr(err) {
+		t.Logf("got non-timeout error (acceptable if client closed cleanly): %v", err)
+	}
+}
+
+func TestCallOlaresdFallback_NoURLs(t *testing.T) {
+	if _, err := CallOlaresdFallback(nil, []byte(`{}`), nil, time.Second); err == nil {
+		t.Fatal("expected error for empty URL list")
+	}
+}
+
+func TestCallOlaresdFallback_PropagatesHeaders(t *testing.T) {
+	var calls int32
+	var gotSig, gotCT string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		gotSig = r.Header.Get("X-Signature")
+		gotCT = r.Header.Get("Content-Type")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"code":200}`))
+	}))
+	defer srv.Close()
+
+	header := make(http.Header)
+	header.Set("X-Bfl-User", "alice")
+	if _, err := CallOlaresdFallback([]string{srv.URL}, []byte(`{}`), header, time.Second); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if atomic.LoadInt32(&calls) != 1 {
+		t.Fatalf("expected exactly one call")
+	}
+	if gotCT != "application/json" {
+		t.Fatalf("Content-Type not set, got %q", gotCT)
+	}
+	if gotSig == "" {
+		t.Fatalf("X-Signature default should be set")
+	}
+}
+
+func isTimeoutErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if ne, ok := err.(net.Error); ok && ne.Timeout() {
+		return true
+	}
+	return strings.Contains(err.Error(), "Client.Timeout") || strings.Contains(err.Error(), "deadline exceeded")
+}
+
+// compile-time sanity check that the fallback chain with truncated body
+// still returns the last error string.
+var _ = fmt.Sprintf

--- a/pkg/global/external.go
+++ b/pkg/global/external.go
@@ -5,6 +5,7 @@ import (
 	"files/pkg/common"
 	"files/pkg/files"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -41,7 +42,9 @@ func init() {
 
 func InitGlobalMounted() {
 	GlobalMounted.getMounted()
-	GlobalMounted.watchMounted()
+	if err := GlobalMounted.watchMounted(); err != nil {
+		klog.Errorf("init external watcher failed, falling back to polling only: %v", err)
+	}
 	//GlobalMounted.watchDiskUsage()
 }
 
@@ -82,25 +85,37 @@ func (m *Mount) GetMountedData() []files.DiskInfo {
 //	}()
 //}
 
-func (m *Mount) watchMounted() {
+func (m *Mount) watchMounted() error {
 	var err error
 	if externalWatcher == nil {
 		externalWatcher, err = fsnotify.NewWatcher()
 		if err != nil {
-			klog.Fatalf("Failed to initialize watcher: %v", err)
-			panic(err)
+			klog.Errorf("Failed to initialize watcher: %v", err)
+			return err
 		}
 	}
 
 	path := "/data/External"
-	err = externalWatcher.Add(path)
-	if err != nil {
+	if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
+		if mkErr := os.MkdirAll(path, 0755); mkErr != nil {
+			klog.Errorf("external watcher mkdir %s failed: %v", path, mkErr)
+			return mkErr
+		}
+	}
+
+	if err = externalWatcher.Add(path); err != nil {
 		klog.Errorln("watcher add error:", err)
-		panic(err)
+		return err
 	}
 	klog.Infof("watcher initialized at: %s", path)
 
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				klog.Errorf("external watcher goroutine panic recovered: %v", r)
+			}
+		}()
+
 		maxRetries := 3
 		for {
 			select {
@@ -122,7 +137,7 @@ func (m *Mount) watchMounted() {
 				}
 
 				klog.Infof("mount watcher event: %s, op: %s", e.Name, e.Op.String())
-				if e.Op == fsnotify.Create {
+				if e.Has(fsnotify.Create) {
 					found := false
 					m.getMounted()
 					if _, exists := m.Mounted[filepath.Base(e.Name)]; exists {
@@ -153,6 +168,7 @@ func (m *Mount) watchMounted() {
 			}
 		}
 	}()
+	return nil
 }
 
 func (m *Mount) getMounted() {

--- a/pkg/hertz/biz/handler/api/external/external_service.go
+++ b/pkg/hertz/biz/handler/api/external/external_service.go
@@ -3,7 +3,6 @@
 package external
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"files/pkg/common"
@@ -14,7 +13,6 @@ import (
 	"files/pkg/models"
 	"files/pkg/redisutils"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
@@ -59,95 +57,55 @@ func MountMethod(ctx context.Context, c *app.RequestContext) {
 	externalType := req.ExternalType
 	var urls []string
 	if externalType == "smb" {
-		urls = []string{"http://" + files.TerminusdHost + "/command/v2/mount-samba", "http://" + files.TerminusdHost + "/command/mount-samba"}
+		urls = []string{"http://" + files.OlaresdHost + "/command/v2/mount-samba", "http://" + files.OlaresdHost + "/command/mount-samba"}
 	} else {
 		c.AbortWithStatusJSON(consts.StatusBadRequest, utils.H{"error": fmt.Sprintf("Unsupported external type: %s", externalType)})
 		return
 	}
 
-	var res map[string]interface{}
-	mounted := false
-	for _, url := range urls {
-		bodyStruct := struct {
-			SmbPath  string `json:"smbPath"`
-			User     string `json:"user"`
-			Password string `json:"password"`
-		}{
-			SmbPath:  req.SmbPath,
-			User:     req.User,
-			Password: req.Password,
-		}
-
-		bodyBytes, err := json.Marshal(bodyStruct)
-		if err != nil {
-			c.AbortWithStatusJSON(consts.StatusBadRequest, utils.H{"error": err.Error()})
-			return
-		}
-
-		client := &http.Client{}
-		request, err := http.NewRequest("POST", url, bytes.NewReader(bodyBytes))
-		if err != nil {
-			c.AbortWithStatusJSON(consts.StatusBadRequest, utils.H{"error": err.Error()})
-			return
-		}
-		c.Request.Header.VisitAll(func(key []byte, value []byte) {
-			request.Header.Set(string(key), string(value))
-		})
-		request.Header.Set("Content-Type", "application/json")
-		request.Header.Set("X-Signature", "temp_signature")
-
-		resp, err := client.Do(request)
-		if err != nil {
-			c.AbortWithStatusJSON(consts.StatusInternalServerError, utils.H{"error": err.Error()})
-			return
-		}
-
-		if resp == nil {
-			klog.Errorf("not get response from %s", url)
-			continue
-		}
-
-		respBody, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			c.AbortWithStatusJSON(consts.StatusInternalServerError, utils.H{"error": err.Error()})
-			return
-		}
-
-		err = json.Unmarshal(respBody, &res)
-		if err != nil {
-			c.AbortWithStatusJSON(consts.StatusInternalServerError, utils.H{"error": err.Error()})
-			return
-		}
-
-		err = resp.Body.Close()
-		if err != nil {
-			c.AbortWithStatusJSON(consts.StatusInternalServerError, utils.H{"error": err.Error()})
-			return
-		}
-
-		if resp.StatusCode >= 400 {
-			klog.Errorf("Failed to mount by %s to %s", url, files.TerminusdHost)
-			klog.Infof("response status: %s, response body: %v", resp.Status, res)
-			continue
-		}
-
-		mounted = true
-		break
-	}
-	if !mounted {
-		// c.AbortWithStatusJSON(consts.StatusInternalServerError, utils.H{"error": "failed to mount samba"})
-		klog.Errorf("failed to mount samba")
+	bodyStruct := struct {
+		SmbPath  string `json:"smbPath"`
+		User     string `json:"user"`
+		Password string `json:"password"`
+	}{
+		SmbPath:  req.SmbPath,
+		User:     req.User,
+		Password: req.Password,
 	}
 
-	if int(res["code"].(float64)) != consts.StatusOK {
-		klog.Warningf(res["message"].(string))
-		if strings.Contains(res["message"].(string), "mount error(13)") {
+	bodyBytes, err := json.Marshal(bodyStruct)
+	if err != nil {
+		c.AbortWithStatusJSON(consts.StatusBadRequest, utils.H{"error": err.Error()})
+		return
+	}
+
+	header := make(http.Header)
+	c.Request.Header.VisitAll(func(key []byte, value []byte) {
+		header.Set(string(key), string(value))
+	})
+
+	res, callErr := files.CallOlaresdFallback(urls, bodyBytes, header, files.DefaultOlaresdTimeout)
+	if callErr != nil {
+		klog.Errorf("failed to mount samba: %v", callErr)
+		if res == nil {
+			c.JSON(consts.StatusOK, utils.H{
+				"code":    consts.StatusInternalServerError,
+				"message": fmt.Sprintf("failed to mount samba: %v", callErr),
+			})
+			return
+		}
+	}
+
+	code, _ := res["code"].(float64)
+	msg, _ := res["message"].(string)
+	if int(code) != consts.StatusOK && msg != "" {
+		klog.Warningf("mount-samba upstream error: %s", msg)
+		switch {
+		case strings.Contains(msg, "mount error(13)"):
 			res["message"] = "Incorrect username or password"
-		}
-		if strings.Contains(res["message"].(string), "mount error(113)") {
+		case strings.Contains(msg, "mount error(113)"):
 			res["message"] = "Unable to find suitable address"
-		}
-		if strings.Contains(res["message"].(string), "mount error(115)") {
+		case strings.Contains(msg, "mount error(115)"):
 			res["message"] = "Cannot connect to samba server"
 		}
 	}
@@ -216,9 +174,9 @@ func UnmountMethod(ctx context.Context, c *app.RequestContext) {
 	externalType := req.ExternalType
 	var url = ""
 	if externalType == "usb" {
-		url = "http://" + files.TerminusdHost + "/command/umount-usb-incluster"
+		url = "http://" + files.OlaresdHost + "/command/umount-usb-incluster"
 	} else if externalType == "smb" {
-		url = "http://" + files.TerminusdHost + "/command/umount-samba-incluster"
+		url = "http://" + files.OlaresdHost + "/command/umount-samba-incluster"
 	} else {
 		c.AbortWithStatusJSON(consts.StatusBadRequest, utils.H{"error": fmt.Sprintf("Unsupported external type: %s", externalType)})
 		return
@@ -243,34 +201,22 @@ func UnmountMethod(ctx context.Context, c *app.RequestContext) {
 		c.AbortWithStatusJSON(consts.StatusInternalServerError, utils.H{"error": err.Error()})
 		return
 	}
-	klog.Infoln("body (byte slice):", body)
-	klog.Infoln("body (string):", string(body))
 
-	client := &http.Client{}
-	request, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
+	header := make(http.Header)
 	c.Request.Header.VisitAll(func(key []byte, value []byte) {
-		request.Header.Set(string(key), string(value))
+		header.Set(string(key), string(value))
 	})
-	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("X-Signature", "temp_signature")
-	response, err := client.Do(request)
-	if err != nil {
-		c.AbortWithStatusJSON(consts.StatusInternalServerError, utils.H{"error": err.Error()})
-		return
-	}
-	defer response.Body.Close()
 
-	respBody, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		c.AbortWithStatusJSON(consts.StatusInternalServerError, utils.H{"error": err.Error()})
-		return
-	}
-
-	var res map[string]interface{}
-	err = json.Unmarshal(respBody, &res)
-	if err != nil {
-		c.AbortWithStatusJSON(consts.StatusInternalServerError, utils.H{"error": err.Error()})
-		return
+	res, callErr := files.CallOlaresdFallback([]string{url}, body, header, files.DefaultOlaresdTimeout)
+	if callErr != nil {
+		klog.Errorf("failed to umount: %v", callErr)
+		if res == nil {
+			c.JSON(consts.StatusOK, utils.H{
+				"code":    consts.StatusInternalServerError,
+				"message": fmt.Sprintf("failed to umount: %v", callErr),
+			})
+			return
+		}
 	}
 	klog.Infoln("res:", res)
 	global.GlobalMounted.Updated()


### PR DESCRIPTION
## Summary

Files lets users mount a third-party NAS over SMB. Auditing that pipeline end to
end surfaced four classes of real defects that can crash the process, hang HTTP
handlers, or silently defeat the fallback logic. This PR fixes all of them and
adds a unit-tested helper so both call sites share the same behavior.

## Problems found

1. **`MountMethod` fallback URL never worked.**
   In `pkg/hertz/biz/handler/api/external/external_service.go`, a `client.Do`
   / `ReadAll` / `Unmarshal` / `Body.Close` error on the v2 URL called
   `c.AbortWithStatusJSON(...); return` instead of `continue`. Any transient
   failure on v2 aborted the whole handler, so `/command/mount-samba` fallback
   never ran.

2. **`res["code"].(float64)` / `res["message"].(string)` panic on unexpected
   payloads.** When every URL returned 4xx the old code only logged an error
   and kept going, then did a hard type assertion on `res`. If the upstream
   returned HTML, an empty body, or JSON without those fields, the handler
   panicked mid-response.

3. **No HTTP client timeout.** `&http.Client{}` was used as-is; a stuck
   terminusd held goroutines indefinitely.

4. **`global.watchMounted` panics the whole samba-share-server process.**
   `fsnotify.NewWatcher` and `externalWatcher.Add("/data/External")` failures
   both called `panic(err)`. First-boot (when `/data/External` does not yet
   exist) or a host with fsnotify limits exhausted brought the entire process
   down. The event loop also used `e.Op == fsnotify.Create`, which is a bit
   mask and misses combined `Create|Write` events, silently degrading
   new-mount visibility to a 3-retry exponential-backoff polling loop.

`pkg/files/file.go` carried an almost-identical copy of the mount / umount
HTTP logic with exactly the same bugs, so both call sites had to be fixed.

## Changes

- **New helper** `files.CallTerminusdFallback(urls, body, header, timeout)` in
  `pkg/files/terminusd.go`:
  - Tries URLs in order, only moves on when the current URL fails.
  - `&http.Client{Timeout: ...}`, with `DefaultTerminusdTimeout = 30s`.
  - Returns the most recent parsed JSON body even when every URL fails, so
    the caller can still surface the upstream error message.
- **`MountMethod` / `UnmountMethod`** in
  `pkg/hertz/biz/handler/api/external/external_service.go`:
  - Delegate to the helper.
  - Use comma-ok type assertions for `res["code"]` and `res["message"]`.
  - Return an explicit 500 body when every upstream URL is unreachable
    instead of panicking.
- **`MountPathIncluster` / `UnmountPathIncluster`** in `pkg/files/file.go`
  now delegate to the same helper, dropping the duplicated HTTP boilerplate.
- **`pkg/global/external.go`**
  - `watchMounted` returns `error` instead of `panic`.
  - `/data/External` gets `os.MkdirAll(..., 0755)` if missing.
  - `InitGlobalMounted` logs and falls back to polling-only when the watcher
    cannot start.
  - `e.Op == fsnotify.Create` replaced with `e.Has(fsnotify.Create)`.
  - Watcher goroutine gets a `recover` guard.
- **Tests**: `pkg/files/terminusd_test.go` covers
  - v2 network error -> v1 success
  - v2 non-JSON -> v1 success
  - both 4xx (last parsed JSON still returned with `err`)
  - both timeout
  - empty URL list
  - header / Content-Type propagation.

## Test plan

- [ ] `go test ./pkg/files/ -run TestCallTerminusdFallback -count=1` passes
      on CI (requires the module's Go 1.23+ toolchain; local Windows box here
      is on 1.18.3 so it was only `gofmt`-verified).
- [ ] Manual: point v2 URL at an unreachable host and confirm the handler
      automatically falls back to v1 instead of returning 500.
- [ ] Manual: start the samba-share-server in a container without
      `/data/External` pre-created and confirm it does not exit.
- [ ] Manual: add artificial latency (e.g. `tc qdisc ... delay 40s`) on
      terminusd and confirm the mount request fails within the 30s timeout
      rather than hanging the handler.
