### PR TITLE
feat: notify terminusd /v1/new_items after posix upload completes

### DIFF
--- a/cmd/backend/app/root.go
+++ b/cmd/backend/app/root.go
@@ -14,6 +14,7 @@ import (
 	"files/pkg/hertz/biz/dal"
 	"files/pkg/img"
 	"files/pkg/integration"
+	"files/pkg/integration/terminusd"
 	"files/pkg/models"
 	"files/pkg/redisutils"
 	"files/pkg/samba"
@@ -175,6 +176,7 @@ user created with the credentials from options "username" and "password".`,
 
 		// step8: integration
 		integration.NewIntegrationManager()
+		terminusd.Start()
 
 		// step9: watcher
 		var w = watchers.NewWatchers(context.Background(), config)

--- a/pkg/drivers/posix/upload/handlefunc.go
+++ b/pkg/drivers/posix/upload/handlefunc.go
@@ -5,6 +5,7 @@ import (
 	"files/pkg/common"
 	"files/pkg/files"
 	"files/pkg/global"
+	"files/pkg/integration/terminusd"
 	"files/pkg/models"
 	"fmt"
 	"os"
@@ -442,6 +443,14 @@ func HandleUploadChunks(fileParam *models.FileParam, uploadId string, resumableI
 		}
 
 		FileInfoManager.DelFileInfo(innerIdentifier, tmpName, uploadTempPath) // handlerfunc
+
+		terminusd.Enqueue(terminusd.NewItem{
+			Path:        terminusd.BuildFrontendPath(fileParam, &resumableInfo),
+			StoragePath: info.FullPath,
+			Mime:        terminusd.GuessMime(info.FullPath),
+			UploadedAt:  terminusd.NowMillis(),
+			Owner:       fileParam.Owner,
+		})
 
 		return true, data, nil
 	}

--- a/pkg/integration/terminusd/notify.go
+++ b/pkg/integration/terminusd/notify.go
@@ -1,0 +1,217 @@
+// Package terminusd notifies terminusd asynchronously when new files are
+// produced by this service (e.g. after a successful upload).
+//
+// Design summary:
+//   - Disabled by default; gated by env var TERMINUSD_NOTIFY_ENABLED.
+//   - Producers call Enqueue(item), which is a non-blocking select send onto
+//     a bounded channel. The upload request path is never blocked.
+//   - A single background worker drains the channel, opportunistically batches
+//     up to maxBatchSize items per outgoing request, and POSTs them to
+//     http://<terminusd_ip>:18832/v1/new_items.
+//   - No per-request timeout (intentional). Bounded memory and exactly one
+//     in-flight request guarantee resource bounds even when terminusd is slow.
+package terminusd
+
+import (
+	"bytes"
+	"encoding/json"
+	"files/pkg/models"
+	"io"
+	"mime"
+	"net"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+const (
+	envEnabled  = "TERMINUSD_NOTIFY_ENABLED"
+	envHost     = "TERMINUSD_HOST"
+	notifyPort  = "18832"
+	notifyPath  = "/v1/new_items"
+	queueCap    = 4096
+	maxBatchSiz = 100
+)
+
+// NewItem is the metadata for a single newly created file.
+type NewItem struct {
+	Path        string `json:"path"`         // frontend logical path, e.g. /drive/Home/photos/IMG.jpg
+	StoragePath string `json:"storage_path"` // backend on-disk path, e.g. /data/<pvc>/Home/photos/IMG.jpg
+	Mime        string `json:"mime"`
+	UploadedAt  int64  `json:"uploaded_at"` // unix milliseconds
+	Owner       string `json:"owner"`
+}
+
+type newItemsBody struct {
+	Items []NewItem `json:"items"`
+}
+
+var (
+	queue      chan NewItem
+	startOnce  sync.Once
+	httpClient = &http.Client{} // intentionally no Timeout; keep-alive enabled by default transport
+	dropped    uint64           // atomic counter; updated when the queue is full
+)
+
+func enabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(envEnabled))) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
+}
+
+// Start launches the single background worker. Idempotent. No-op when the
+// feature flag is not set to a truthy value.
+func Start() {
+	if !enabled() {
+		klog.Infof("[terminusd] notify disabled (set %s=true to enable)", envEnabled)
+		return
+	}
+	startOnce.Do(func() {
+		queue = make(chan NewItem, queueCap)
+		go runWorker()
+		klog.Infof("[terminusd] notify enabled, queueCap=%d, maxBatchSize=%d, url=%s",
+			queueCap, maxBatchSiz, notifyURL())
+	})
+}
+
+// Enqueue is non-blocking. Drops the item (with a throttled warning) when
+// either the feature is disabled or the queue is full. This call is safe to
+// invoke from any request goroutine and is guaranteed not to block.
+func Enqueue(item NewItem) {
+	if queue == nil {
+		return
+	}
+	select {
+	case queue <- item:
+	default:
+		n := atomic.AddUint64(&dropped, 1)
+		// Throttle the warning so a sustained outage doesn't flood logs.
+		if n == 1 || n%100 == 0 {
+			klog.Warningf("[terminusd] queue full (cap=%d), dropped item path=%s total_dropped=%d",
+				queueCap, item.Path, n)
+		}
+	}
+}
+
+func runWorker() {
+	defer func() {
+		if r := recover(); r != nil {
+			klog.Errorf("[terminusd] worker panic: %v; restarting", r)
+			go runWorker()
+		}
+	}()
+
+	batch := make([]NewItem, 0, maxBatchSiz)
+	for first := range queue {
+		batch = append(batch[:0], first)
+
+	drain:
+		for len(batch) < maxBatchSiz {
+			select {
+			case it := <-queue:
+				batch = append(batch, it)
+			default:
+				break drain
+			}
+		}
+		post(batch)
+	}
+}
+
+func post(items []NewItem) {
+	if os.Getenv(envHost) == "" {
+		klog.Warningf("[terminusd] %s empty, skip %d item(s)", envHost, len(items))
+		return
+	}
+
+	body, err := json.Marshal(newItemsBody{Items: items})
+	if err != nil {
+		klog.Warningf("[terminusd] marshal failed: %v (skip %d item(s))", err, len(items))
+		return
+	}
+
+	url := notifyURL()
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		klog.Warningf("[terminusd] build request failed: %v", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		klog.Warningf("[terminusd] POST %s failed: %v (dropped %d item(s))", url, err, len(items))
+		return
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode >= 300 {
+		klog.Warningf("[terminusd] POST %s status=%d (dropped %d item(s))", url, resp.StatusCode, len(items))
+		return
+	}
+	klog.Infof("[terminusd] POST %s ok, items=%d", url, len(items))
+}
+
+// notifyURL builds http://<ip>:18832/v1/new_items by extracting the host
+// portion of TERMINUSD_HOST (which is normally "host:port" with no scheme)
+// and forcing port 18832.
+func notifyURL() string {
+	host := os.Getenv(envHost)
+	if h, _, err := net.SplitHostPort(host); err == nil && h != "" {
+		host = h
+	}
+	return "http://" + net.JoinHostPort(host, notifyPort) + notifyPath
+}
+
+// BuildFrontendPath reconstructs the frontend logical path that mirrors what
+// models.CreateFileParam would have parsed (i.e. the inverse of
+// (*FileParam).convert). For share uploads, we re-derive from (Shareby,
+// ParentDir) so the returned path resolves the same tree as info.FullPath
+// (which is share-rewritten in handlefunc.go before MoveFileByInfo).
+func BuildFrontendPath(fp *models.FileParam, ri *models.ResumableInfo) string {
+	if fp == nil || ri == nil {
+		return ""
+	}
+	fileType := fp.FileType
+	extend := fp.Extend
+	base := fp.Path
+	if ri.Share != "" && ri.Shareby != "" {
+		if shared, err := models.CreateFileParam(ri.Shareby, ri.ParentDir); err == nil {
+			fileType, extend, base = shared.FileType, shared.Extend, shared.Path
+		}
+	}
+	return path.Join("/", fileType, extend, base, ri.ResumableRelativePath)
+}
+
+// GuessMime returns a best-effort MIME type derived from the filename
+// extension. We deliberately do not use the multipart chunk's Content-Type
+// header because that's typically application/octet-stream.
+func GuessMime(fullPath string) string {
+	ext := strings.ToLower(filepath.Ext(fullPath))
+	if ext == "" {
+		return "application/octet-stream"
+	}
+	if t := mime.TypeByExtension(ext); t != "" {
+		// Strip any "; charset=..." parameters for a cleaner value.
+		if idx := strings.Index(t, ";"); idx >= 0 {
+			t = strings.TrimSpace(t[:idx])
+		}
+		return t
+	}
+	return "application/octet-stream"
+}
+
+// NowMillis returns the current unix time in milliseconds. Exposed so callers
+// can compute the timestamp at the precise moment the file is committed to
+// disk rather than when this package finally posts it.
+func NowMillis() int64 { return time.Now().UnixMilli() }


### PR DESCRIPTION
## Summary

Adds an opt-in webhook to terminusd whenever a file finishes uploading via the local (posix) backend, so terminusd can index newly created items without polling.

- New `pkg/integration/terminusd` package: bounded queue (cap=4096) + single background worker that batches up to 100 items per POST. `Enqueue` is non-blocking; the upload request path is never blocked or slowed down by terminusd latency.
- **Disabled by default**, gated by env var `TERMINUSD_NOTIFY_ENABLED` (truthy: `1` / `true` / `yes` / `on`). When disabled, `Start()` and `Enqueue()` are zero-cost no-ops.
- URL is built from `TERMINUSD_HOST`: takes the host portion and forces port `18832`, hitting `http://<ip>:18832/v1/new_items`.
- Hook lives at the end of `HandleUploadChunks` success branch in `pkg/drivers/posix/upload/handlefunc.go`, after `MoveFileByInfo` succeeds, so the on-disk path includes any share rewrite. The frontend logical path is reconstructed via `BuildFrontendPath` (re-derived from `Shareby`/`ParentDir` for share uploads to match the rewritten `info.FullPath`).
- No per-request timeout (intentional). Resource bounds come from the queue cap and exactly-one-in-flight worker design, not from timeouts.

### JSON sent

```json
{
  "items": [
    {
      "path": "/drive/Home/photos/IMG.jpg",
      "storage_path": "/data/pvc-userdata-xxx/Home/photos/IMG.jpg",
      "mime": "image/jpeg",
      "uploaded_at": 1745396400000,
      "owner": "alice"
    }
  ]
}
```

### Backpressure semantics

- **Slow terminusd**: at most one request is in flight; subsequent items sit in the bounded channel. Memory is `O(queueCap)` regardless of how slow terminusd is.
- **Upload faster than webhook**: producer does a non-blocking `select` send. If the queue is full, items are dropped + counted + warned (throttled to 1 in 100). Crucially, no goroutine is spawned per upload, so goroutine count stays flat regardless of upload throughput. Bursty uploads are absorbed by the worker's opportunistic batching.

## Files changed

- `pkg/integration/terminusd/notify.go` (new) — `NewItem`, `Start`, `Enqueue`, worker, `notifyURL`, `BuildFrontendPath`, `GuessMime`.
- `cmd/backend/app/root.go` — call `terminusd.Start()` once during init (after `integration.NewIntegrationManager()`).
- `pkg/drivers/posix/upload/handlefunc.go` — call `terminusd.Enqueue(...)` right before `return true, data, nil` on the success branch.

## Test plan

- [ ] Default behavior (no env var): backend starts; logs `[terminusd] notify disabled (set TERMINUSD_NOTIFY_ENABLED=true to enable)`. Uploading a file works normally and no outbound HTTP is attempted.
- [ ] With `TERMINUSD_NOTIFY_ENABLED=true` and `TERMINUSD_HOST` pointing at a stub HTTP server on `:18832`: upload a file via `/upload/upload-link/:uid` and confirm a `POST /v1/new_items` arrives with the expected JSON shape.
- [ ] Stub server delays response by 30s; upload many files quickly. Confirm: backend goroutine count stays flat, queue drops a few items with a throttled warning, all eventually-sent items are batched into ≤100-item POSTs.
- [ ] Stop the stub server; confirm POSTs log warnings but uploads themselves still succeed.
- [ ] Share upload: file uploaded into a shared directory results in the expected `storage_path` (shareby's tree) and a `path` consistent with that tree.

Made with [Cursor](https://cursor.com)