### PR TITLE
revert: roll back mount service replace changes (PR #203 + follow-up)

### DIFF
--- a/pkg/common/constant.go
+++ b/pkg/common/constant.go
@@ -30,7 +30,7 @@ const (
 
 var (
 	TerminusdHost             = os.Getenv("TERMINUSD_HOST")
-	TerminusdMountServicePort = os.Getenv("TERMINUSD_SERVICE_PORT")
+	TerminusdMountServicePort = 18088
 	ExternalPrefix            = os.Getenv("EXTERNAL_PREFIX")
 	NodeName                  = os.Getenv("NODE_NAME")
 	DebugIntegration          = os.Getenv("DEBUG_INTEGRATION")

--- a/pkg/common/constant.go
+++ b/pkg/common/constant.go
@@ -29,11 +29,10 @@ const (
 )
 
 var (
-	TerminusdHost             = os.Getenv("TERMINUSD_HOST")
-	TerminusdMountServicePort = 18088
-	ExternalPrefix            = os.Getenv("EXTERNAL_PREFIX")
-	NodeName                  = os.Getenv("NODE_NAME")
-	DebugIntegration          = os.Getenv("DEBUG_INTEGRATION")
+	OlaresdHost      = os.Getenv("TERMINUSD_HOST")
+	ExternalPrefix   = os.Getenv("EXTERNAL_PREFIX")
+	NodeName         = os.Getenv("NODE_NAME")
+	DebugIntegration = os.Getenv("DEBUG_INTEGRATION")
 )
 
 const (

--- a/pkg/files/file.go
+++ b/pkg/files/file.go
@@ -115,9 +115,7 @@ func MountPathIncluster(r *http.Request) (map[string]interface{}, error) {
 	externalType := r.URL.Query().Get("external_type")
 	var urls []string
 	if externalType == "smb" {
-		urls = []string{
-			"http://" + fmt.Sprintf("%s:%d", common.TerminusdHost, common.TerminusdMountServicePort) + "/command/v2/mount-samba",
-			"http://" + fmt.Sprintf("%s:%d", common.TerminusdHost, common.TerminusdMountServicePort) + "/command/mount-samba"}
+		urls = []string{"http://" + TerminusdHost + "/command/v2/mount-samba", "http://" + TerminusdHost + "/command/mount-samba"}
 	} else {
 		return nil, fmt.Errorf("Unsupported external type: %s", externalType)
 	}

--- a/pkg/files/file.go
+++ b/pkg/files/file.go
@@ -116,8 +116,8 @@ func MountPathIncluster(r *http.Request) (map[string]interface{}, error) {
 	var urls []string
 	if externalType == "smb" {
 		urls = []string{
-			"http://" + fmt.Sprintf("%s:%s", common.TerminusdHost, common.TerminusdMountServicePort) + "/command/v2/mount-samba",
-			"http://" + fmt.Sprintf("%s:%s", common.TerminusdHost, common.TerminusdMountServicePort) + "/command/mount-samba"}
+			"http://" + fmt.Sprintf("%s:%d", common.TerminusdHost, common.TerminusdMountServicePort) + "/command/v2/mount-samba",
+			"http://" + fmt.Sprintf("%s:%d", common.TerminusdHost, common.TerminusdMountServicePort) + "/command/mount-samba"}
 	} else {
 		return nil, fmt.Errorf("Unsupported external type: %s", externalType)
 	}

--- a/pkg/global/external.go
+++ b/pkg/global/external.go
@@ -160,7 +160,7 @@ func (m *Mount) getMounted() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	var host = fmt.Sprintf("%s:%s", common.TerminusdHost, common.TerminusdMountServicePort)
+	var host = fmt.Sprintf("%s:%d", common.TerminusdHost, common.TerminusdMountServicePort)
 
 	if host == "" {
 		klog.Errorf("olaresd host invalid, host: %s", host)

--- a/pkg/global/external.go
+++ b/pkg/global/external.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"files/pkg/common"
 	"files/pkg/files"
-	"fmt"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -160,7 +159,7 @@ func (m *Mount) getMounted() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	var host = fmt.Sprintf("%s:%d", common.TerminusdHost, common.TerminusdMountServicePort)
+	var host = common.OlaresdHost
 
 	if host == "" {
 		klog.Errorf("olaresd host invalid, host: %s", host)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

Roll back the following three commits on `main` so that the code state returns to `a632a17` (right after PR #202):

- `042194c` fix: use terminusd mount service port env
- `001e854` Merge pull request #203 from beclab/fix/mounted_service_host_replace
- `2770d0f` fix: olaresd mount service replace

## Approach

Use `git revert` — does not rewrite history and does not force-push `main`. Two steps:

1. `git revert 042194c`
2. `git revert -m 1 001e854` (this is a merge commit; `-m 1` keeps the first parent `a632a17`, which effectively reverts the entire content of PR #203, so `2770d0f` does not need a separate revert)

## Verification

After this PR is merged, the following three files on `main` will be identical to their state at `a632a17`:

- `pkg/common/constant.go`
- `pkg/files/file.go`
- `pkg/global/external.go`

Verified locally:

```bash
git diff a632a17 HEAD --stat
# (no output — trees are identical)
```

## Note

If these changes need to be reintroduced later, either revert the two revert commits in this PR, or redo the changes on a new branch.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-25131dfb-d971-41ef-86f7-dddc4079e2ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25131dfb-d971-41ef-86f7-dddc4079e2ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

