### PR TITLE
chore: quick-wins fixes (security, concurrency, vet, deprecations)

### DIFF
--- a/cmd/backend/app/root.go
+++ b/cmd/backend/app/root.go
@@ -20,9 +20,11 @@ import (
 	"files/pkg/samba"
 	"files/pkg/tasks"
 	"files/pkg/watchers"
+	"fmt"
 	"io"
 	"net"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/spf13/afero"
@@ -358,13 +360,33 @@ func initConfig() {
 
 	klog.Infof("=== ENVIRONMENT VARIABLES ===")
 	for _, e := range os.Environ() {
-		if strings.HasPrefix(e, "FB_") {
-			klog.Infof("[ENV] %s", e)
+		if !strings.HasPrefix(e, "FB_") {
+			continue
 		}
+		k, val, ok := strings.Cut(e, "=")
+		if !ok {
+			klog.Infof("[ENV] %s", e)
+			continue
+		}
+		klog.Infof("[ENV] %s=%s", k, redactValue(k, val))
 	}
 
 	klog.Infof("=== VIPER SETTINGS ===")
 	for _, key := range v.AllKeys() {
-		klog.Infof("[VIPER] %s = %v", key, v.Get(key))
+		klog.Infof("[VIPER] %s = %v", key, redactValue(key, fmt.Sprintf("%v", v.Get(key))))
 	}
+}
+
+// sensitiveKeyPattern matches config keys whose value should be redacted in logs.
+var sensitiveKeyPattern = regexp.MustCompile(`(?i)(password|passwd|secret|token|apikey|api_key|key|cookie|cred)`)
+
+// redactValue masks values whose key looks sensitive. Empty values pass through.
+func redactValue(key, value string) string {
+	if value == "" {
+		return value
+	}
+	if sensitiveKeyPattern.MatchString(key) {
+		return "***"
+	}
+	return value
 }

--- a/cmd/backend/app/root.go
+++ b/cmd/backend/app/root.go
@@ -200,7 +200,7 @@ user created with the credentials from options "username" and "password".`,
 		samba.NewSambaManager(f)
 
 		// step13: run hertz server
-		hertz.HertzServer()
+		hertz.HertzServer(getRunParams(cmd.Flags()))
 
 	}, pythonConfig{allowNoDB: true}),
 }

--- a/pkg/common/errors.go
+++ b/pkg/common/errors.go
@@ -22,6 +22,7 @@ var (
 	ErrInvalidRequestParams = errors.New("invalid request params")
 	ErrSourceIsParent       = errors.New("source is parent")
 	ErrRootUserDeletion     = errors.New("user with id 1 can't be deleted")
+	ErrFileSizeExceeds4GB   = errors.New("file size exceeds 4GB")
 )
 
 func ErrToStatus(err error) int {
@@ -40,7 +41,7 @@ func ErrToStatus(err error) int {
 		return http.StatusBadRequest
 	case errors.Is(err, ErrRootUserDeletion):
 		return http.StatusForbidden
-	case err.Error() == "file size exceeds 4GB":
+	case errors.Is(err, ErrFileSizeExceeds4GB) || err.Error() == "file size exceeds 4GB":
 		return http.StatusRequestEntityTooLarge
 	default:
 		return http.StatusInternalServerError

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -144,7 +145,7 @@ func CheckDiskSpace(filePath string, needSize int64, considerReserve bool) (int6
 		} else {
 			errorMessage = fmt.Sprintf("Insufficient disk space. %s required, but only %s available. Need to free %s for uploading.", needStr, freeStr, needToFreeStr)
 		}
-		return availableSpace, fmt.Errorf(errorMessage)
+		return availableSpace, errors.New(errorMessage)
 	}
 	return availableSpace, nil
 }

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -15,6 +15,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/shirou/gopsutil/v4/disk"
@@ -33,7 +34,20 @@ var (
 
 var RootPrefix = os.Getenv("ROOT_PREFIX")
 
-var BflCookieCache = make(map[string]string)
+var bflCookieCache sync.Map
+
+func BflCookieGet(name string) (string, bool) {
+	v, ok := bflCookieCache.Load(name)
+	if !ok {
+		return "", false
+	}
+	s, ok := v.(string)
+	return s, ok
+}
+
+func BflCookieSet(name, cookie string) {
+	bflCookieCache.Store(name, cookie)
+}
 
 func init() {
 	if RootPrefix == "" {

--- a/pkg/drivers/clouds/rclone/utils/utils.go
+++ b/pkg/drivers/clouds/rclone/utils/utils.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"files/pkg/drivers/clouds/rclone/common"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -67,7 +67,7 @@ func Request(ctx context.Context, u string, method string, header *http.Header, 
 			klog.Infof("[request] url: %s, code: %d, elapsed: %s", u, resp.StatusCode, time.Since(start))
 		}
 
-		body, err = ioutil.ReadAll(resp.Body)
+		body, err = io.ReadAll(resp.Body)
 		if err != nil {
 			klog.Errorln("[request] error reading response body:", err)
 			return err

--- a/pkg/drivers/posix/upload/operations.go
+++ b/pkg/drivers/posix/upload/operations.go
@@ -10,7 +10,6 @@ import (
 	"files/pkg/models"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"os"
 	"path"
@@ -241,7 +240,7 @@ func UpdateFileInfo(fileInfo FileInfo, uploadsDir string) error {
 	}
 
 	// Write file information
-	err = ioutil.WriteFile(infoPath, infoJSON, 0644)
+	err = os.WriteFile(infoPath, infoJSON, 0644)
 	if err != nil {
 		return err
 	}

--- a/pkg/drivers/sync/sync.go
+++ b/pkg/drivers/sync/sync.go
@@ -14,7 +14,6 @@ import (
 	"files/pkg/preview"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -685,7 +684,7 @@ func (s *SyncStorage) Edit(contextArgs *models.HttpContextArgs) (*models.EditHan
 		return nil, err
 	}
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		klog.Errorf("Sync edit, read response body error: %v, path: %s", err, fileParam.Path)
 		return nil, err

--- a/pkg/files/file.go
+++ b/pkg/files/file.go
@@ -13,7 +13,6 @@ import (
 	"hash"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"mime"
 	"net/http"
 	"os"
@@ -86,6 +85,13 @@ type FileOptions struct {
 var TerminusdHost = os.Getenv("TERMINUSD_HOST")
 var ExternalPrefix = os.Getenv("EXTERNAL_PREFIX")
 
+// terminusdHTTPClient is reused for all calls to TERMINUSD_HOST so that
+// connections are pooled and a global timeout is enforced. Without a
+// timeout, a hung Terminusd would leak goroutines indefinitely.
+var terminusdHTTPClient = &http.Client{
+	Timeout: 30 * time.Second,
+}
+
 type Response struct {
 	Code    int        `json:"code"`
 	Data    []DiskInfo `json:"data"`
@@ -121,24 +127,23 @@ func MountPathIncluster(r *http.Request) (map[string]interface{}, error) {
 	}
 
 	for _, url := range urls {
-		bodyBytes, err := ioutil.ReadAll(r.Body)
+		bodyBytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			return nil, err
 		}
-		r.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+		r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 
 		headers := r.Header.Clone()
 		headers.Set("Content-Type", "application/json")
 		headers.Set("X-Signature", "temp_signature")
 
-		client := &http.Client{}
 		req, err := http.NewRequest("POST", url, bytes.NewReader(bodyBytes))
 		if err != nil {
 			return nil, err
 		}
 		req.Header = headers
 
-		resp, err := client.Do(req)
+		resp, err := terminusdHTTPClient.Do(req)
 		if err != nil {
 			return nil, err
 		}
@@ -148,7 +153,7 @@ func MountPathIncluster(r *http.Request) (map[string]interface{}, error) {
 			continue
 		}
 
-		respBody, err := ioutil.ReadAll(resp.Body)
+		respBody, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, err
 		}
@@ -211,16 +216,18 @@ func UnmountPathIncluster(r *http.Request, path string) (map[string]interface{},
 	klog.Infoln("body (byte slice):", body)
 	klog.Infoln("body (string):", string(body))
 
-	client := &http.Client{}
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, err
+	}
 	req.Header = headers
-	resp, err := client.Do(req)
+	resp, err := terminusdHTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/hertz/biz/handler/api/external/external_service.go
+++ b/pkg/hertz/biz/handler/api/external/external_service.go
@@ -14,7 +14,7 @@ import (
 	"files/pkg/models"
 	"files/pkg/redisutils"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -107,7 +107,7 @@ func MountMethod(ctx context.Context, c *app.RequestContext) {
 			continue
 		}
 
-		respBody, err := ioutil.ReadAll(resp.Body)
+		respBody, err := io.ReadAll(resp.Body)
 		if err != nil {
 			c.AbortWithStatusJSON(consts.StatusInternalServerError, utils.H{"error": err.Error()})
 			return
@@ -260,7 +260,7 @@ func UnmountMethod(ctx context.Context, c *app.RequestContext) {
 	}
 	defer response.Body.Close()
 
-	respBody, err := ioutil.ReadAll(response.Body)
+	respBody, err := io.ReadAll(response.Body)
 	if err != nil {
 		c.AbortWithStatusJSON(consts.StatusInternalServerError, utils.H{"error": err.Error()})
 		return

--- a/pkg/hertz/biz/router/middleware.go
+++ b/pkg/hertz/biz/router/middleware.go
@@ -128,13 +128,13 @@ func CookieMiddleware() app.HandlerFunc {
 		newCookie := string(c.GetHeader("Cookie"))
 
 		if bflName != "" {
-			oldCookie := common.BflCookieCache[bflName]
+			oldCookie, _ := common.BflCookieGet(bflName)
 			if newCookie != oldCookie {
-				common.BflCookieCache[bflName] = newCookie
+				common.BflCookieSet(bflName, newCookie)
 			}
 		}
 
-		klog.Infof("BflCookieCache= %v", common.BflCookieCache)
+		klog.V(4).Infof("BflCookieCache updated for user=%s", bflName)
 		c.Next(ctx)
 	}
 }

--- a/pkg/hertz/hertz.go
+++ b/pkg/hertz/hertz.go
@@ -3,6 +3,7 @@
 package hertz
 
 import (
+	"files/pkg/common"
 	"files/pkg/hertz/biz/router"
 
 	"time"
@@ -12,9 +13,24 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func HertzServer() {
+// HertzServer starts the Hertz HTTP server. The listen address is derived
+// from cfg (Address/Port). A nil cfg falls back to the legacy 127.0.0.1:8080.
+func HertzServer(cfg *common.Server) {
+	addr := "127.0.0.1"
+	port := "8080"
+	if cfg != nil {
+		if cfg.Address != "" {
+			addr = cfg.Address
+		}
+		if cfg.Port != "" {
+			port = cfg.Port
+		}
+	}
+	hostPort := addr + ":" + port
+	klog.Infof("hertz server listening on %s", hostPort)
+
 	h := server.Default(
-		server.WithHostPorts("127.0.0.1:8080"),
+		server.WithHostPorts(hostPort),
 		server.WithMaxRequestBodySize(20<<20),
 		server.WithTransport(standard.NewTransporter),
 		server.WithReadTimeout(5*time.Minute),

--- a/pkg/samba/samba.go
+++ b/pkg/samba/samba.go
@@ -14,7 +14,6 @@ import (
 	"files/pkg/hertz/biz/model/api/share"
 	"files/pkg/models"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strings"
@@ -386,7 +385,7 @@ func (s *samba) generateConf() {
 
 	klog.Infof("samba conf content: \n%s\n", string(content))
 
-	err = ioutil.WriteFile(common.SambaConfTemplatePath, content, 0700)
+	err = os.WriteFile(common.SambaConfTemplatePath, content, 0700)
 	if err != nil {
 		klog.Errorf("samba write conf error: %v", err)
 		return


### PR DESCRIPTION
## Summary

A first batch of low-risk, independently-reviewable fixes surfaced from a code-level audit. Each item is its own commit so it can be reverted individually if needed.

| Commit | Area | Why |
|---|---|---|
| `refactor(common): introduce ErrFileSizeExceeds4GB sentinel` | `pkg/common/errors.go` | Replaces fragile `err.Error() == "file size exceeds 4GB"` with `errors.Is` against a typed sentinel; falls back to the literal string for backward compatibility. |
| `fix(common): use errors.New for non-constant error string` | `pkg/common/utils.go` | Resolves a `go vet` printf warning where a fully-formatted string was passed to `fmt.Errorf` as the format. Stray `%` from user/host names could be misinterpreted. |
| `fix(common): make BflCookieCache concurrency-safe` | `pkg/common/utils.go`, `pkg/hertz/biz/router/middleware.go` | The cookie cache was a plain `map[string]string` mutated by every request from `CookieMiddleware`, which races under Hertz's concurrent handling. Switched to `sync.Map` with `BflCookieGet/BflCookieSet` helpers and lowered the per-request log line to `V(4)` so cookie material is no longer emitted at default verbosity. |
| `fix(cmd): redact sensitive values in startup config logs` | `cmd/backend/app/root.go` | `initConfig` dumped every `FB_*` env var and viper key at INFO level. Keys containing `password\|secret\|token\|key\|cookie\|cred` (case-insensitive) are now logged as `***`. |
| `fix(files): add timeout and reuse client for Terminusd HTTP calls` | `pkg/files/file.go` | `Mount/UnmountPathIncluster` constructed a fresh `http.Client{}` with no timeout per call, so a stalled Terminusd would deadlock the goroutine and leak connections. Switched to a package-level client with `Timeout: 30s`. Also dropped the deprecated `io/ioutil` usages in this file. |
| `chore: replace deprecated io/ioutil usages` | 5 files | `io/ioutil` has been deprecated since Go 1.16 (project is Go 1.23). Replaced `ioutil.ReadAll/NopCloser/WriteFile` with the `io` / `os` equivalents. After this change, `rg "ioutil\."` returns no matches. |
| `fix(hertz): wire address/port flags into HertzServer` | `pkg/hertz/hertz.go`, `cmd/backend/app/root.go` | The cobra command exposed `--address` / `--port` (and `FB_ADDRESS` / `FB_PORT` via viper) and assembled them through `getRunParams`, but `HertzServer` ignored the result and always bound `127.0.0.1:8080`. `HertzServer` now accepts `*common.Server` and derives `WithHostPorts` from it, defaulting to the previous values when fields are unset so existing deployments keep working. |

11 files changed, +89 / -31.

## Test plan

- [ ] CI passes (build, hz IDL codegen, existing checks).
- [ ] `go vet ./pkg/common/` clean (verified locally).
- [ ] `git diff --check main...HEAD` shows no whitespace errors (verified locally).
- [ ] Smoke test: start backend, confirm Hertz logs `hertz server listening on 127.0.0.1:8080` by default and honors `FB_ADDRESS=0.0.0.0 FB_PORT=8090`.
- [ ] Smoke test: hit any authenticated endpoint and confirm `BflCookieCache` no longer appears in default-level logs (only at `-v=4`).
- [ ] Smoke test: trigger an external mount/unmount path and confirm the request still works end-to-end with the shared client.
- [ ] Confirm sensitive `FB_*` values appear as `***` in startup logs.

## Out of scope

Intentionally deferred to a follow-up PR to keep this one mechanical and easy to review:

- Replacing the `X-Signature: temp_signature` placeholder with real signing.
- Wiring `--cert`/`--key` into Hertz `WithTLS` (only address/port wired here).
- Splitting oversized files (`encoding_helper.go` ~216 KB, `share_service.go` ~93 KB).
- Removing `klog.Fatal` from non-startup paths.
- Adding `/healthz`, `/readyz`, `/metrics`, structured logging, graceful shutdown.
- Fixing the pre-existing `pkg/files/listing.go` "passes lock by value" vet warnings.
