### PR TITLE
fix: stop killing the backend on recoverable runtime errors

### DIFF
--- a/cmd/backend/app/crontab.go
+++ b/cmd/backend/app/crontab.go
@@ -28,7 +28,7 @@ func InitCrontabs() {
 		tasks.TaskManager.ClearCacheFiles()
 	})
 	if err != nil {
-		klog.Fatalf("AddFunc CleanupOldFilesAndRedisEntries err:%v", err)
+		klog.Errorf("AddFunc CleanupOldFilesAndRedisEntries err: %v", err)
 	} else {
 		klog.Info("Crontab task: CleanupOldFilesAndRedisEntries added successfully.")
 	}
@@ -40,7 +40,7 @@ func InitCrontabs() {
 		global.GlobalMounted.Updated()
 	})
 	if err != nil {
-		klog.Fatalf("AddFunc GetMountedData err:%v", err)
+		klog.Errorf("AddFunc GetMountedData err: %v", err)
 	} else {
 		klog.Info("Crontab task: GetMountedData added successfully.")
 	}

--- a/pkg/global/external.go
+++ b/pkg/global/external.go
@@ -87,16 +87,16 @@ func (m *Mount) watchMounted() {
 	if externalWatcher == nil {
 		externalWatcher, err = fsnotify.NewWatcher()
 		if err != nil {
-			klog.Fatalf("Failed to initialize watcher: %v", err)
-			panic(err)
+			klog.Errorf("failed to initialize external mount watcher: %v; external mount notifications disabled", err)
+			return
 		}
 	}
 
 	path := "/data/External"
 	err = externalWatcher.Add(path)
 	if err != nil {
-		klog.Errorln("watcher add error:", err)
-		panic(err)
+		klog.Errorf("external mount watcher add %q failed: %v; notifications disabled", path, err)
+		return
 	}
 	klog.Infof("watcher initialized at: %s", path)
 

--- a/pkg/media/utils/logger.go
+++ b/pkg/media/utils/logger.go
@@ -56,11 +56,11 @@ func (l *Logger) Errorf(format string, v ...interface{}) {
 }
 
 func (l *Logger) Fatal(format string, v ...interface{}) {
-        klog.Fatalf("[FATAL] "+format, v...)
+        klog.Errorf("[FATAL] "+format, v...)
 }
 
 func (l *Logger) Fatalf(format string, v ...interface{}) {
-        klog.Fatalf("[FATAL] "+format, v...)
+        klog.Errorf("[FATAL] "+format, v...)
 }
 
 func (l *Logger) LogDebug(format string, v ...interface{}) {


### PR DESCRIPTION
## Summary

Three small, independently-revertable fixes that stop the backend from killing itself on recoverable runtime errors. Genuine startup-only Fatals are left alone.

| Commit | File | Why |
|---|---|---|
| `fix(cron): don't kill backend when cron AddFunc fails` | [cmd/backend/app/crontab.go](cmd/backend/app/crontab.go) | `InitCrontabs` registered two hard-coded cron expressions and `klog.Fatalf`'d on `AddFunc` errors. A single broken expression would prevent the rest of the cron tasks (and the subsequent `upload.Init(c)` call) from being scheduled at all. Downgraded to `klog.Errorf`. |
| `fix(global): downgrade Fatal/panic in external mount watcher` | [pkg/global/external.go](pkg/global/external.go) | `watchMounted` called `klog.Fatalf` followed by `panic(err)` (the `panic` was dead code because `klog.Fatalf` already calls `os.Exit(255)`), and panicked outright when adding `/data/External` to the inotify watch list. As a result a missing mount path or an exhausted inotify quota would crash the whole backend. Now logs and returns; the rest of the service stays up and simply runs without external-mount change notifications. Matches the `klog.Errorf+return` pattern already used in `getMounted`. |
| `fix(media/logger): remove klog.Fatalf from Logger wrapper` | [pkg/media/utils/logger.go](pkg/media/utils/logger.go) | `Logger.Fatal/Fatalf` were thin wrappers around `klog.Fatalf`. There are no callers of those methods today (verified via repo-wide grep), but as part of a `Logger` interface they are a foot-gun: the first time a future contributor writes `t.Logger.Fatal("transcoding failed")` the entire media service goes down. Downgraded to `klog.Errorf`; the `[FATAL]` prefix is kept so perceived severity in the logs is preserved. |

3 files changed, +8 / -8.

## Out of scope (intentional `klog.Fatal` left in place)

These are all genuine startup paths where exit-on-failure is the right behavior, so they were not touched:

- `cmd/backend/app/cmd.go:10` — top-level `Execute()`
- `cmd/backend/app/utils.go:15,56,58` — `checkErr` and the `python(...)` cobra wrapper (config init only)
- `cmd/backend/app/root.go:137,144,162,167` — `RemoveAll(/data/buffer)`, invalid `--img-processors`, k8s factory/clientconfig errors during boot
- `cmd/samba/main.go:25,30,50` — same boot pattern + top-level `Execute()`
- `cmd/seahub/main.go:297,303,342` — one-shot DB migration tool; crash-on-failure is correct
- `pkg/media/mediabrowser/.../transcoding_job.go:133` — sits inside a `/* */` block, not compiled

## Test plan

- [ ] CI `Update Server` / `Update Samba` workflows succeed.
- [ ] Boot the backend with `/data/External` missing or with the inotify limit exhausted; backend should log an error about the watcher and continue serving HTTP instead of crash-looping.
- [ ] Re-confirm cron tasks still register on a normal boot (`Crontab task: ... added successfully.` info lines appear).
