### PR TITLE
fix: add appropriate timeouts to remaining &http.Client{} sites

### DIFF
--- a/pkg/drivers/clouds/rclone/utils/utils.go
+++ b/pkg/drivers/clouds/rclone/utils/utils.go
@@ -16,6 +16,14 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// rcloneHTTPClient is shared across all rclone control-API requests so a
+// single retry burst doesn't allocate one client per attempt. The 5-minute
+// Timeout is a safety net; the per-call context.Context passed via
+// http.NewRequestWithContext is the primary deadline.
+var rcloneHTTPClient = &http.Client{
+	Timeout: 5 * time.Minute,
+}
+
 func Request(ctx context.Context, u string, method string, header *http.Header, requestParams []byte) ([]byte, error) {
 	var backoff = wait.Backoff{
 		Duration: 1 * time.Second,
@@ -55,9 +63,8 @@ func Request(ctx context.Context, u string, method string, header *http.Header, 
 
 		// newRequest.Header.Add("Content-Type", "application/octet-stream")
 
-		client := &http.Client{}
 		start := time.Now()
-		resp, err := client.Do(newRequest)
+		resp, err := rcloneHTTPClient.Do(newRequest)
 		if err != nil {
 			klog.Errorf("[request] do error: %v", err)
 			return err

--- a/pkg/drivers/sync/sync.go
+++ b/pkg/drivers/sync/sync.go
@@ -30,6 +30,13 @@ import (
 
 var previewSemaphore = make(chan struct{}, 10)
 
+// syncEditHTTPClient is reused for seafile edit-upload calls. The 60s
+// Timeout matches typical small-file edit semantics; large-file uploads
+// use the chunked path elsewhere with its own timeout.
+var syncEditHTTPClient = &http.Client{
+	Timeout: 60 * time.Second,
+}
+
 type SyncStorage struct {
 	handler *base.HandlerParam
 	paste   *models.PasteParam
@@ -664,7 +671,6 @@ func (s *SyncStorage) Edit(contextArgs *models.HttpContextArgs) (*models.EditHan
 	boundary := writer.Boundary()
 	contentType := "multipart/form-data; boundary=" + boundary
 
-	client := &http.Client{}
 	req, err := http.NewRequest("POST", updateUrl, bytes.NewReader(body.Bytes()))
 	if err != nil {
 		klog.Errorf("Sync edit, create request error: %v, path: %s", err, fileParam.Path)
@@ -673,7 +679,7 @@ func (s *SyncStorage) Edit(contextArgs *models.HttpContextArgs) (*models.EditHan
 	req.Header = contextArgs.QueryParam.Header.Clone()
 	req.Header.Set("Content-Type", contentType)
 
-	resp, err := client.Do(req)
+	resp, err := syncEditHTTPClient.Do(req)
 	if err != nil {
 		klog.Errorf("Sync edit, http request error: %v, path: %s", err, fileParam.Path)
 		return nil, err

--- a/pkg/files/file.go
+++ b/pkg/files/file.go
@@ -85,10 +85,11 @@ type FileOptions struct {
 var TerminusdHost = os.Getenv("TERMINUSD_HOST")
 var ExternalPrefix = os.Getenv("EXTERNAL_PREFIX")
 
-// terminusdHTTPClient is reused for all calls to TERMINUSD_HOST so that
+// TerminusdHTTPClient is reused for all calls to TERMINUSD_HOST so that
 // connections are pooled and a global timeout is enforced. Without a
-// timeout, a hung Terminusd would leak goroutines indefinitely.
-var terminusdHTTPClient = &http.Client{
+// timeout, a hung Terminusd would leak goroutines indefinitely. Exported
+// so other packages (e.g. pkg/hertz/.../external) can share the same pool.
+var TerminusdHTTPClient = &http.Client{
 	Timeout: 30 * time.Second,
 }
 
@@ -143,7 +144,7 @@ func MountPathIncluster(r *http.Request) (map[string]interface{}, error) {
 		}
 		req.Header = headers
 
-		resp, err := terminusdHTTPClient.Do(req)
+		resp, err := TerminusdHTTPClient.Do(req)
 		if err != nil {
 			return nil, err
 		}
@@ -221,7 +222,7 @@ func UnmountPathIncluster(r *http.Request, path string) (map[string]interface{},
 		return nil, err
 	}
 	req.Header = headers
-	resp, err := terminusdHTTPClient.Do(req)
+	resp, err := TerminusdHTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/hertz/biz/handler/api/external/external_service.go
+++ b/pkg/hertz/biz/handler/api/external/external_service.go
@@ -84,7 +84,6 @@ func MountMethod(ctx context.Context, c *app.RequestContext) {
 			return
 		}
 
-		client := &http.Client{}
 		request, err := http.NewRequest("POST", url, bytes.NewReader(bodyBytes))
 		if err != nil {
 			c.AbortWithStatusJSON(consts.StatusBadRequest, utils.H{"error": err.Error()})
@@ -96,7 +95,7 @@ func MountMethod(ctx context.Context, c *app.RequestContext) {
 		request.Header.Set("Content-Type", "application/json")
 		request.Header.Set("X-Signature", "temp_signature")
 
-		resp, err := client.Do(request)
+		resp, err := files.TerminusdHTTPClient.Do(request)
 		if err != nil {
 			c.AbortWithStatusJSON(consts.StatusInternalServerError, utils.H{"error": err.Error()})
 			return
@@ -246,14 +245,13 @@ func UnmountMethod(ctx context.Context, c *app.RequestContext) {
 	klog.Infoln("body (byte slice):", body)
 	klog.Infoln("body (string):", string(body))
 
-	client := &http.Client{}
 	request, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
 	c.Request.Header.VisitAll(func(key []byte, value []byte) {
 		request.Header.Set(string(key), string(value))
 	})
 	request.Header.Set("Content-Type", "application/json")
 	request.Header.Set("X-Signature", "temp_signature")
-	response, err := client.Do(request)
+	response, err := files.TerminusdHTTPClient.Do(request)
 	if err != nil {
 		c.AbortWithStatusJSON(consts.StatusInternalServerError, utils.H{"error": err.Error()})
 		return

--- a/pkg/hertz/biz/router/middleware.go
+++ b/pkg/hertz/biz/router/middleware.go
@@ -67,10 +67,19 @@ var (
 	ShareApiUploadedPath   = "/upload/file-uploaded-bytes"
 )
 
+// shareProxyClient is used to reverse-proxy share-API requests. Bodies on
+// either side may be GB-scale (file uploads/downloads), so Client.Timeout is
+// intentionally NOT set; that would clip legitimate long transfers.
+// ResponseHeaderTimeout instead guards against an origin that never starts
+// sending headers, while idle-conn and TLS-handshake timeouts cap dead
+// connection reuse and slow handshakes.
 var shareProxyClient = &http.Client{
 	Transport: &http.Transport{
-		MaxIdleConnsPerHost: 64,
-		DisableCompression:  true,
+		MaxIdleConnsPerHost:   64,
+		DisableCompression:    true,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 60 * time.Second,
 	},
 }
 

--- a/pkg/tasks/httpclient.go
+++ b/pkg/tasks/httpclient.go
@@ -1,0 +1,24 @@
+package tasks
+
+import (
+	"net/http"
+	"time"
+)
+
+// streamHTTPClient is shared by task paths that download large bodies (file
+// downloads, SSE-style file lists). Client.Timeout is intentionally NOT set
+// because it covers the entire response body read; for multi-GB downloads
+// that would clip legitimate transfers. ResponseHeaderTimeout instead
+// guards against an origin that never starts sending headers, while the
+// per-request context.Context (passed via http.NewRequestWithContext)
+// remains the primary deadline a caller can use to cancel.
+var streamHTTPClient = &http.Client{
+	Transport: &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		MaxIdleConns:          10,
+		MaxIdleConnsPerHost:   5,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 60 * time.Second,
+	},
+}

--- a/pkg/tasks/task_paste_download.go
+++ b/pkg/tasks/task_paste_download.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"path"
 	"strings"
-	"time"
 
 	"k8s.io/klog/v2"
 )
@@ -39,14 +38,6 @@ func (t *Task) DownloadFromFiles() error {
 		return err
 	}
 
-	client := &http.Client{
-		Transport: &http.Transport{
-			MaxIdleConns:        10,
-			MaxIdleConnsPerHost: 5,
-			IdleConnTimeout:     60 * time.Second,
-		},
-	}
-
 	var srcFileName, isSrcFile = files.GetFileNameFromPath(src.Path)
 	var srcFilePrefix, srcFileExt = common.SplitNameExt(srcFileName)
 	var filesServerIp = filesServer.Status.PodIP
@@ -59,7 +50,7 @@ func (t *Task) DownloadFromFiles() error {
 	filesListsReq.Header.Set(common.REQUEST_HEADER_OWNER, src.Owner)
 	filesListsReq.Header.Set("Cache-Control", "no-cache")
 
-	filesListsResp, err := client.Do(filesListsReq)
+	filesListsResp, err := streamHTTPClient.Do(filesListsReq)
 	if err != nil {
 		return err
 	}

--- a/pkg/tasks/task_paste_sync.go
+++ b/pkg/tasks/task_paste_sync.go
@@ -535,9 +535,7 @@ func (t *Task) DownloadFileFromSync(src, dst *models.FileParam, root bool) error
 		return fmt.Errorf("url: %s, error: %v", dlUrl, err)
 	}
 
-	client := http.Client{}
-
-	response, err := client.Do(request)
+	response, err := streamHTTPClient.Do(request)
 	if err != nil {
 		return err
 	}

--- a/pkg/webhook/upload/notify.go
+++ b/pkg/webhook/upload/notify.go
@@ -13,10 +13,11 @@
 //   - A single background worker drains the channel, opportunistically batches
 //     up to maxBatchSize items per outgoing request, and POSTs them to
 //     http://<host_ip>:18832/v1/new_items.
-//   - No per-request timeout (intentional). Bounded memory and exactly one
-//     in-flight request guarantee resource bounds even when the webhook is
-//     slow. On any failure (network error, non-2xx, marshal error) the batch
-//     is dropped with a warning; there is no retry.
+//   - Per-request timeout of 30s. The batches are tiny (~KB JSON), so a stuck
+//     TCP connection that never errors must not be allowed to block the worker
+//     forever; without a timeout the queue would silently fill until items
+//     start dropping. On any failure (timeout, network error, non-2xx, marshal
+//     error) the batch is dropped with a warning; there is no retry.
 package upload
 
 import (
@@ -64,7 +65,7 @@ type newItemsBody struct {
 var (
 	queue      chan NewItem
 	startOnce  sync.Once
-	httpClient = &http.Client{} // intentionally no Timeout; keep-alive enabled by default transport
+	httpClient = &http.Client{Timeout: 30 * time.Second} // ~KB JSON POST: prevent a TCP-stuck connection from deadlocking the single worker
 	dropped    uint64           // atomic counter; updated when the queue is full
 )
 


### PR DESCRIPTION
## Summary

Adds the right kind of timeout to every remaining `&http.Client{}` on `main`. The mode (`Client.Timeout` vs `Transport.ResponseHeaderTimeout`) is chosen per call site by body shape: short RPCs get `Client.Timeout`; streaming downloads and the share reverse-proxy get header-stage timeouts so legitimate large bodies are never clipped.

7 commits, 9 files, +68/-33.

## Commits

| # | Commit | What |
|---|---|---|
| 1 | `fix(files): export TerminusdHTTPClient for cross-package reuse` | Renames the existing `terminusdHTTPClient` to `TerminusdHTTPClient` so other packages can share the 30s-timeout pool instead of allocating their own. |
| 2 | `fix(external): reuse TerminusdHTTPClient for mount/unmount` | [pkg/hertz/biz/handler/api/external/external_service.go:87,249](pkg/hertz/biz/handler/api/external/external_service.go) — both Terminusd RPCs now go through the shared client. |
| 3 | `fix(rclone): add 5m safety-net timeout and reuse control client` | [pkg/drivers/clouds/rclone/utils/utils.go](pkg/drivers/clouds/rclone/utils/utils.go) — `Request()` previously allocated a fresh client *inside the retry loop*. Promoted to a package-level singleton with `Timeout: 5m` as a safety net; the per-call `context.Context` is the primary deadline. |
| 4 | `fix(drivers/sync): add 60s timeout to seafile edit upload` | [pkg/drivers/sync/sync.go:667](pkg/drivers/sync/sync.go) — package-level `syncEditHTTPClient` with 60s timeout. |
| 5 | `fix(tasks): use shared streaming client for sync download paths` | New [pkg/tasks/httpclient.go](pkg/tasks/httpclient.go) defines `streamHTTPClient` with `Transport.ResponseHeaderTimeout=60s`, `IdleConnTimeout=90s`, `TLSHandshakeTimeout=10s`, and **no** `Client.Timeout` (bodies can be GB-scale). Used by [task_paste_sync.go:538](pkg/tasks/task_paste_sync.go) (file body) and [task_paste_download.go:42](pkg/tasks/task_paste_download.go) (SSE-style file list). The unrelated chunk upload at task_paste_sync.go:965 already had a 30s `Client.Timeout` (per-chunk bounded body) and was left alone. |
| 6 | `fix(webhook/upload): add 30s timeout to notify client` | [pkg/webhook/upload/notify.go:67](pkg/webhook/upload/notify.go) — explicitly overrides the previous "intentionally no Timeout" comment. The original reasoning ("bounded memory + exactly one in-flight request") only holds when each request eventually returns; a TCP connection that hangs without erroring blocks the single worker forever and items pile up silently. The package doc is updated to match. |
| 7 | `fix(hertz/router): add per-stage timeouts to shareProxyClient` | [pkg/hertz/biz/router/middleware.go:70](pkg/hertz/biz/router/middleware.go) — `ResponseHeaderTimeout=60s`, `IdleConnTimeout=90s`, `TLSHandshakeTimeout=10s`. No `Client.Timeout` (it reverse-proxies file uploads/downloads of arbitrary size). |

## Why two flavors of timeout

`Client.Timeout` covers the *entire* response, including body read. For multi-GB downloads or streamed reverse-proxy bodies it would clip legitimate transfers. The streaming sites in this PR therefore use `Transport.ResponseHeaderTimeout` (server must start sending headers within 60s) plus the per-call `context.Context` for total-deadline control. Short-RPC sites where the response body is bounded (Terminusd command responses, rclone control API, seafile edit, webhook JSON) keep using `Client.Timeout` for simplicity.

## Test plan

- [ ] CI `Update Server` workflow succeeds.
- [ ] `GOOS=linux go vet` on the modified packages locally — clean other than pre-existing `pkg/files/listing.go` "passes lock by value" warnings (unrelated, tracked as a separate follow-up).
- [ ] Smoke test: trigger an external SMB mount/unmount and confirm the request still works through the shared `TerminusdHTTPClient`.
- [ ] Smoke test: paste-sync of a multi-GB file from a sync repo continues to complete without hitting the new header timeouts (should not, since the body phase is no longer covered by `Client.Timeout`).
- [ ] Smoke test: simulate a stuck Terminusd / webhook target (e.g. block port with iptables) and confirm the request errors at the configured timeout instead of the goroutine wedging forever.

## Out of scope (intentionally not addressed here)

- The pre-existing `pkg/files/listing.go` "passes lock by value" vet warnings.
- Replacing the `X-Signature: temp_signature` placeholder with real signing — orthogonal to timeouts; deserves its own PR.
- Introducing a single `pkg/common/httpclients` factory — kept clients package-local on purpose so a future tweak to one site can't accidentally affect unrelated callers.
