### PR TITLE
feat(backend,samba): graceful shutdown phase 1

### DIFF
--- a/cmd/backend/app/crontab.go
+++ b/cmd/backend/app/crontab.go
@@ -15,7 +15,11 @@ import (
 
 var cleanupMux sync.Mutex
 
-func InitCrontabs() {
+// InitCrontabs registers all scheduled jobs and starts the scheduler. It
+// returns the running *cron.Cron so callers can wire its Stop()/ctx into
+// the graceful-shutdown coordinator. The returned value is non-nil even
+// when AddFunc registrations fail — a nil here would defeat shutdown.
+func InitCrontabs() *cron.Cron {
 	c := cron.New()
 
 	_, err := c.AddFunc("5 0 * * *", func() {
@@ -48,4 +52,5 @@ func InitCrontabs() {
 	upload.Init(c)
 
 	c.Start()
+	return c
 }

--- a/cmd/backend/app/root.go
+++ b/cmd/backend/app/root.go
@@ -199,7 +199,7 @@ user created with the credentials from options "username" and "password".`,
 		samba.NewSambaManager(f)
 
 		// step13: run hertz server
-		hertz.HertzServer(getRunParams(cmd.Flags()))
+		hertz.HertzServer(getRunParams(cmd.Flags()), nil)
 
 	}, pythonConfig{allowNoDB: true}),
 }

--- a/cmd/backend/app/root.go
+++ b/cmd/backend/app/root.go
@@ -12,19 +12,23 @@ import (
 	"files/pkg/global"
 	"files/pkg/hertz"
 	"files/pkg/hertz/biz/dal"
+	"files/pkg/hertz/biz/dal/database"
 	"files/pkg/img"
 	"files/pkg/integration"
+	"files/pkg/lifecycle"
 	"files/pkg/models"
-	"files/pkg/webhook/upload"
 	"files/pkg/redisutils"
 	"files/pkg/samba"
 	"files/pkg/tasks"
 	"files/pkg/watchers"
+	"files/pkg/webhook/upload"
 	"fmt"
 	"io"
 	"os"
 	"regexp"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/spf13/afero"
 	"gopkg.in/natefinch/lumberjack.v2"
@@ -179,27 +183,74 @@ user created with the credentials from options "username" and "password".`,
 		integration.NewIntegrationManager()
 		upload.Start()
 
+		coord := lifecycle.New()
+		// Hooks run in reverse-registration order. Register database/redis
+		// first so they survive until every higher-level subsystem is gone.
+		coord.Add("postgres", 5*time.Second, func(context.Context) error {
+			return database.Close()
+		})
+		coord.Add("redis", 5*time.Second, func(context.Context) error {
+			return redisutils.Close()
+		})
+
 		// step9: watcher
-		var w = watchers.NewWatchers(context.Background(), config)
+		watcherCtx, watcherCancel := context.WithCancel(context.Background())
+		var w = watchers.NewWatchers(watcherCtx, config)
 		watchers.AddToWatchers[corev1.Node](w, global.NodeGVR, global.GlobalNode.Handlerevent())
 		watchers.AddToWatchers[appsv1.StatefulSet](w, appsv1.SchemeGroupVersion.WithResource("statefulsets"), global.GlobalData.HandlerEvent())
 		watchers.AddToWatchers[models.User](w, models.UserGVR, integration.IntegrationManager().HandlerEvent())
 
-		go w.Run(1)
+		var watcherWG sync.WaitGroup
+		watcherWG.Add(1)
+		go func() {
+			defer watcherWG.Done()
+			if runErr := w.Run(1); runErr != nil {
+				klog.Errorf("k8s watcher exited with error: %v", runErr)
+			}
+		}()
+		coord.Add("k8s-watcher", 10*time.Second, func(ctx context.Context) error {
+			watcherCancel()
+			done := make(chan struct{})
+			go func() { watcherWG.Wait(); close(done) }()
+			select {
+			case <-done:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		})
 
 		// step10: task manager
 		tasks.NewTaskManager()
 		tasks.TaskManager.GenerateKeepFile()
 
+		// upload webhook worker
+		coord.Add("upload-webhook", 5*time.Second, upload.Stop)
+
+		// fsnotify external mount watcher
+		coord.Add("external-fsnotify", 2*time.Second, func(context.Context) error {
+			return global.ExternalWatcherClose()
+		})
+
 		// step11: Crontab
 		// .	- CleanupOldFilesAndRedisEntries
-		_ = InitCrontabs()
+		cronInst := InitCrontabs()
+		coord.Add("cron", 5*time.Second, func(ctx context.Context) error {
+			stopCtx := cronInst.Stop()
+			select {
+			case <-stopCtx.Done():
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		})
 
 		// step12: samba
 		samba.NewSambaManager(f)
 
-		// step13: run hertz server
-		hertz.HertzServer(getRunParams(cmd.Flags()), nil)
+		// step13: run hertz server (blocks until SIGTERM, then drains, then
+		// runs coord.Run for everything registered above)
+		hertz.HertzServer(getRunParams(cmd.Flags()), coord)
 
 	}, pythonConfig{allowNoDB: true}),
 }

--- a/cmd/backend/app/root.go
+++ b/cmd/backend/app/root.go
@@ -22,7 +22,6 @@ import (
 	"files/pkg/watchers"
 	"fmt"
 	"io"
-	"net"
 	"os"
 	"regexp"
 	"strings"
@@ -203,13 +202,6 @@ user created with the credentials from options "username" and "password".`,
 		hertz.HertzServer(getRunParams(cmd.Flags()))
 
 	}, pythonConfig{allowNoDB: true}),
-}
-
-func cleanupHandler(listener net.Listener, c chan os.Signal) {
-	sig := <-c
-	klog.Infof("Caught signal %s: shutting down.", sig)
-	listener.Close()
-	os.Exit(0)
 }
 
 func getRunParams(flags *pflag.FlagSet) *common.Server {

--- a/cmd/backend/app/root.go
+++ b/cmd/backend/app/root.go
@@ -193,7 +193,7 @@ user created with the credentials from options "username" and "password".`,
 
 		// step11: Crontab
 		// .	- CleanupOldFilesAndRedisEntries
-		InitCrontabs()
+		_ = InitCrontabs()
 
 		// step12: samba
 		samba.NewSambaManager(f)

--- a/cmd/samba/main.go
+++ b/cmd/samba/main.go
@@ -6,13 +6,24 @@ import (
 	"files/pkg/client"
 	"files/pkg/global"
 	"files/pkg/hertz/biz/dal/database"
+	"files/pkg/lifecycle"
 	"files/pkg/models"
 	"files/pkg/samba"
 	"files/pkg/watchers"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
 
 	"k8s.io/klog/v2"
 
 	"github.com/spf13/cobra"
+)
+
+const (
+	// sambaShutdownTimeout caps total teardown time after the first signal.
+	sambaShutdownTimeout = 30 * time.Second
 )
 
 var rootCmd = &cobra.Command{
@@ -37,11 +48,55 @@ var rootCmd = &cobra.Command{
 		samba.NewSambaManager(f)
 		samba.SambaService.Start()
 
-		var w = watchers.NewWatchers(context.Background(), config)
+		coord := lifecycle.New()
+		coord.Add("postgres", 5*time.Second, func(context.Context) error {
+			return database.Close()
+		})
+		coord.Add("external-fsnotify", 2*time.Second, func(context.Context) error {
+			return global.ExternalWatcherClose()
+		})
+
+		watcherCtx, watcherCancel := context.WithCancel(context.Background())
+		var w = watchers.NewWatchers(watcherCtx, config)
 		watchers.AddToWatchers[v1.ShareSamba](w, samba.SambaGVR, samba.SambaService.HandlerEvent())
 		watchers.AddToWatchers[models.User](w, models.UserGVR, samba.SambaService.UserHandlerEvent())
 
-		w.Run(1)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if runErr := w.Run(1); runErr != nil {
+				klog.Errorf("samba watcher exited with error: %v", runErr)
+			}
+		}()
+		coord.Add("k8s-watcher", 10*time.Second, func(ctx context.Context) error {
+			watcherCancel()
+			done := make(chan struct{})
+			go func() { wg.Wait(); close(done) }()
+			select {
+			case <-done:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		})
+
+		// Signal handling: first SIGTERM/SIGINT triggers ordered shutdown
+		// with a hard deadline; a second signal aborts immediately so an
+		// operator can always force-exit a stuck binary.
+		sigCh := make(chan os.Signal, 2)
+		signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+		<-sigCh
+		klog.Infof("samba: received shutdown signal, draining (timeout=%s)", sambaShutdownTimeout)
+		go func() {
+			<-sigCh
+			klog.Warning("samba: second shutdown signal received, forcing exit")
+			os.Exit(1)
+		}()
+
+		ctx, cancel := context.WithTimeout(context.Background(), sambaShutdownTimeout)
+		defer cancel()
+		coord.Run(ctx)
 	},
 }
 

--- a/pkg/drivers/posix/upload/init.go
+++ b/pkg/drivers/posix/upload/init.go
@@ -33,11 +33,14 @@ func Init(c *cron.Cron) {
 
 }
 
+// cronDeleteOldFile registers an hourly job that removes the upload-buffer
+// file once it has aged past expireTime. The caller MUST pass a non-nil
+// cron instance whose lifecycle is owned by InitCrontabs; otherwise the job
+// would run on a private scheduler that no shutdown hook can stop.
 func cronDeleteOldFile(filePath string, c *cron.Cron) {
-	needStart := false
 	if c == nil {
-		c = cron.New()
-		needStart = true
+		klog.Errorf("cronDeleteOldFile: nil cron passed for %s; refusing to spawn an orphan scheduler", filePath)
+		return
 	}
 
 	_, err := c.AddFunc("30 * * * *", func() {
@@ -48,10 +51,6 @@ func cronDeleteOldFile(filePath string, c *cron.Cron) {
 	})
 	if err != nil {
 		klog.Warningf("AddFunc DeleteOldSubfolders err:%v", err)
-	}
-
-	if needStart {
-		c.Start()
 	}
 }
 

--- a/pkg/global/external.go
+++ b/pkg/global/external.go
@@ -45,6 +45,17 @@ func InitGlobalMounted() {
 	//GlobalMounted.watchDiskUsage()
 }
 
+// ExternalWatcherClose stops the package-level fsnotify watcher used by
+// watchMounted. Closing the watcher terminates its Errors/Events channels;
+// the watcher goroutine selects on those and returns once they close.
+// Safe to call when the watcher was never initialized.
+func ExternalWatcherClose() error {
+	if externalWatcher == nil {
+		return nil
+	}
+	return externalWatcher.Close()
+}
+
 func (m *Mount) Updated() {
 	GlobalMounted.getMounted()
 }

--- a/pkg/hertz/biz/dal/database/init.go
+++ b/pkg/hertz/biz/dal/database/init.go
@@ -34,3 +34,21 @@ func Init() {
 		panic(err)
 	}
 }
+
+// Close releases the underlying *sql.DB connection pool. Safe to call when
+// Init was skipped (DB == nil) or when the GORM-managed pool is missing.
+// Only invoked from the graceful-shutdown coordinator after all request
+// handlers, cron jobs, and watchers have stopped using the pool.
+func Close() error {
+	if DB == nil {
+		return nil
+	}
+	sqlDB, err := DB.DB()
+	if err != nil {
+		return err
+	}
+	if sqlDB == nil {
+		return nil
+	}
+	return sqlDB.Close()
+}

--- a/pkg/hertz/hertz.go
+++ b/pkg/hertz/hertz.go
@@ -3,8 +3,10 @@
 package hertz
 
 import (
+	"context"
 	"files/pkg/common"
 	"files/pkg/hertz/biz/router"
+	"files/pkg/lifecycle"
 
 	"time"
 
@@ -13,9 +15,21 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// HertzServer starts the Hertz HTTP server. The listen address is derived
-// from cfg (Address/Port). A nil cfg falls back to the legacy 127.0.0.1:8080.
-func HertzServer(cfg *common.Server) {
+// hertzExitWait controls how long Hertz waits for in-flight requests to
+// finish during shutdown. The default 5s is too short for ongoing uploads
+// or rclone/seafile syncs; 20s is a balance between drain time and the
+// outer container SIGKILL window.
+const hertzExitWait = 20 * time.Second
+
+// HertzServer starts the Hertz HTTP server and blocks on Spin until a
+// shutdown signal arrives. The listen address is derived from cfg
+// (Address/Port). A nil cfg falls back to the legacy 127.0.0.1:8080.
+//
+// When coord is non-nil, every other registered shutdown hook is run as
+// part of Hertz' OnShutdown callback. This guarantees connection drain
+// happens first (Hertz manages that internally) and only then do downstream
+// subsystems (cron, watchers, db, redis, …) get torn down in reverse order.
+func HertzServer(cfg *common.Server, coord *lifecycle.Coordinator) {
 	addr := "127.0.0.1"
 	port := "8080"
 	if cfg != nil {
@@ -40,7 +54,17 @@ func HertzServer(cfg *common.Server) {
 		server.WithReadBufferSize(64*1024),
 		server.WithALPN(true),
 		server.WithIdleTimeout(200*time.Second),
+		server.WithExitWaitTime(hertzExitWait),
 	)
+
+	if coord != nil {
+		// Hertz' Engine.OnShutdown CtxCallback runs concurrently with the
+		// transport drain; it gets a context bounded by ExitWaitTime so the
+		// coordinator's per-hook timeouts also live within that envelope.
+		h.OnShutdown = append(h.OnShutdown, func(ctx context.Context) {
+			coord.Run(ctx)
+		})
+	}
 
 	h.Use(router.Options())
 	h.Use(router.Cors())
@@ -51,5 +75,5 @@ func HertzServer(cfg *common.Server) {
 
 	register(h)
 	h.Spin()
-	klog.Infof("hertz server started")
+	klog.Infof("hertz server stopped")
 }

--- a/pkg/hertz/hertz.go
+++ b/pkg/hertz/hertz.go
@@ -25,10 +25,12 @@ const hertzExitWait = 20 * time.Second
 // shutdown signal arrives. The listen address is derived from cfg
 // (Address/Port). A nil cfg falls back to the legacy 127.0.0.1:8080.
 //
-// When coord is non-nil, every other registered shutdown hook is run as
-// part of Hertz' OnShutdown callback. This guarantees connection drain
-// happens first (Hertz manages that internally) and only then do downstream
-// subsystems (cron, watchers, db, redis, …) get torn down in reverse order.
+// Hertz' built-in signal waiter catches SIGTERM/SIGINT, drains in-flight
+// connections within ExitWaitTime, and only then returns from Spin. After
+// Spin returns we invoke coord.Run (when supplied) so downstream subsystems
+// (cron, watchers, redis, db, …) are torn down strictly after the HTTP
+// transport has stopped accepting new work. This sequencing matters: it
+// keeps redis/db reachable while the last in-flight requests finish.
 func HertzServer(cfg *common.Server, coord *lifecycle.Coordinator) {
 	addr := "127.0.0.1"
 	port := "8080"
@@ -57,15 +59,6 @@ func HertzServer(cfg *common.Server, coord *lifecycle.Coordinator) {
 		server.WithExitWaitTime(hertzExitWait),
 	)
 
-	if coord != nil {
-		// Hertz' Engine.OnShutdown CtxCallback runs concurrently with the
-		// transport drain; it gets a context bounded by ExitWaitTime so the
-		// coordinator's per-hook timeouts also live within that envelope.
-		h.OnShutdown = append(h.OnShutdown, func(ctx context.Context) {
-			coord.Run(ctx)
-		})
-	}
-
 	h.Use(router.Options())
 	h.Use(router.Cors())
 	h.Use(router.TimingMiddleware())
@@ -75,5 +68,16 @@ func HertzServer(cfg *common.Server, coord *lifecycle.Coordinator) {
 
 	register(h)
 	h.Spin()
-	klog.Infof("hertz server stopped")
+	klog.Infof("hertz server stopped, running shutdown coordinator")
+
+	if coord != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+		coord.Run(ctx)
+	}
 }
+
+// shutdownTimeout caps the total time the coordinator may spend stopping
+// non-HTTP subsystems after Hertz has drained. It does not include the
+// 20s transport drain itself, which lives inside Hertz Spin.
+const shutdownTimeout = 30 * time.Second

--- a/pkg/lifecycle/shutdown.go
+++ b/pkg/lifecycle/shutdown.go
@@ -1,0 +1,99 @@
+// Package lifecycle provides a small ordered-shutdown coordinator for the
+// backend binaries. Subsystems register Stop hooks during initialization;
+// on shutdown the hooks are invoked in reverse-registration order, each
+// with its own timeout, so a stuck or slow subsystem cannot block the rest
+// of the teardown.
+package lifecycle
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+// Hook is a single named teardown step. Stop is called with a context whose
+// deadline is the smaller of the per-hook Timeout and the parent shutdown
+// deadline. A zero Timeout means "no per-hook ceiling beyond the parent
+// deadline".
+type Hook struct {
+	Name    string
+	Stop    func(ctx context.Context) error
+	Timeout time.Duration
+}
+
+// Coordinator collects shutdown hooks and runs them in reverse-registration
+// order. It is safe to register hooks concurrently with other goroutines,
+// but Run should be called exactly once from a single shutdown driver
+// goroutine.
+type Coordinator struct {
+	mu    sync.Mutex
+	hooks []Hook
+}
+
+// New returns an empty Coordinator.
+func New() *Coordinator { return &Coordinator{} }
+
+// Add registers a hook. Hooks added later run first during Run (LIFO).
+// A nil stop function is silently dropped to make conditional registration
+// (e.g. "register only when feature X is enabled") cheaper at call sites.
+func (c *Coordinator) Add(name string, timeout time.Duration, stop func(ctx context.Context) error) {
+	if stop == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.hooks = append(c.hooks, Hook{Name: name, Stop: stop, Timeout: timeout})
+}
+
+// Run executes every registered hook in reverse-registration order. The
+// parent ctx caps total shutdown time; each hook additionally honors its
+// own Timeout. Errors and panics are logged and never abort the chain so a
+// single broken subsystem cannot prevent others from cleaning up.
+func (c *Coordinator) Run(ctx context.Context) {
+	c.mu.Lock()
+	hooks := make([]Hook, len(c.hooks))
+	copy(hooks, c.hooks)
+	c.mu.Unlock()
+
+	klog.Infof("lifecycle: running %d shutdown hook(s)", len(hooks))
+	for i := len(hooks) - 1; i >= 0; i-- {
+		h := hooks[i]
+		if ctx.Err() != nil {
+			klog.Warningf("lifecycle: parent deadline reached, skipping remaining hook %q (and earlier)", h.Name)
+			return
+		}
+		runHook(ctx, h)
+	}
+	klog.Infof("lifecycle: all shutdown hooks done")
+}
+
+func runHook(parent context.Context, h Hook) {
+	hookCtx := parent
+	var cancel context.CancelFunc
+	if h.Timeout > 0 {
+		hookCtx, cancel = context.WithTimeout(parent, h.Timeout)
+		defer cancel()
+	}
+
+	start := time.Now()
+	err := safeStop(hookCtx, h.Stop)
+	elapsed := time.Since(start)
+	switch {
+	case err == nil:
+		klog.Infof("lifecycle: hook %q stopped in %s", h.Name, elapsed)
+	default:
+		klog.Errorf("lifecycle: hook %q failed after %s: %v", h.Name, elapsed, err)
+	}
+}
+
+func safeStop(ctx context.Context, stop func(context.Context) error) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic during shutdown: %v", r)
+		}
+	}()
+	return stop(ctx)
+}

--- a/pkg/lifecycle/shutdown_test.go
+++ b/pkg/lifecycle/shutdown_test.go
@@ -1,0 +1,134 @@
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestCoordinatorRunsHooksInReverseOrder(t *testing.T) {
+	c := New()
+	var order []string
+	c.Add("first", 0, func(context.Context) error {
+		order = append(order, "first")
+		return nil
+	})
+	c.Add("second", 0, func(context.Context) error {
+		order = append(order, "second")
+		return nil
+	})
+	c.Add("third", 0, func(context.Context) error {
+		order = append(order, "third")
+		return nil
+	})
+
+	c.Run(context.Background())
+
+	got := []string{}
+	got = append(got, order...)
+	want := []string{"third", "second", "first"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v hooks, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order mismatch at %d: want %v got %v", i, want, got)
+		}
+	}
+}
+
+func TestCoordinatorPerHookTimeoutDoesNotBlockOthers(t *testing.T) {
+	c := New()
+	var ranSecond atomic.Bool
+	c.Add("slow-deps", 0, func(context.Context) error {
+		ranSecond.Store(true)
+		return nil
+	})
+	c.Add("slow", 20*time.Millisecond, func(ctx context.Context) error {
+		select {
+		case <-time.After(500 * time.Millisecond):
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	})
+
+	start := time.Now()
+	c.Run(context.Background())
+	elapsed := time.Since(start)
+
+	if elapsed > 250*time.Millisecond {
+		t.Fatalf("expected per-hook timeout to bound total time, took %s", elapsed)
+	}
+	if !ranSecond.Load() {
+		t.Fatalf("expected earlier-registered hook to still run after slow hook timeout")
+	}
+}
+
+func TestCoordinatorParentDeadlineStopsChain(t *testing.T) {
+	c := New()
+	var ran atomic.Int32
+	c.Add("a", 0, func(context.Context) error {
+		ran.Add(1)
+		return nil
+	})
+	c.Add("b", 0, func(context.Context) error {
+		ran.Add(1)
+		time.Sleep(50 * time.Millisecond)
+		return nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	c.Run(ctx)
+
+	if ran.Load() == 2 {
+		t.Fatalf("expected parent deadline to skip earlier-registered hook")
+	}
+}
+
+func TestCoordinatorPanicIsIsolated(t *testing.T) {
+	c := New()
+	var ran atomic.Bool
+	c.Add("survivor", 0, func(context.Context) error {
+		ran.Store(true)
+		return nil
+	})
+	c.Add("boom", 0, func(context.Context) error {
+		panic("boom")
+	})
+
+	c.Run(context.Background())
+
+	if !ran.Load() {
+		t.Fatalf("expected survivor hook to run after panicking hook")
+	}
+}
+
+func TestCoordinatorErrorDoesNotAbortChain(t *testing.T) {
+	c := New()
+	var ran atomic.Bool
+	sentinel := errors.New("nope")
+	c.Add("survivor", 0, func(context.Context) error {
+		ran.Store(true)
+		return nil
+	})
+	c.Add("err", 0, func(context.Context) error {
+		return sentinel
+	})
+
+	c.Run(context.Background())
+	if !ran.Load() {
+		t.Fatalf("expected survivor hook to run after error hook")
+	}
+}
+
+func TestCoordinatorNilStopIgnored(t *testing.T) {
+	c := New()
+	c.Add("nil", 0, nil)
+	if len(c.hooks) != 0 {
+		t.Fatalf("expected nil stop to be dropped, got %d hooks", len(c.hooks))
+	}
+}

--- a/pkg/redisutils/redis_client.go
+++ b/pkg/redisutils/redis_client.go
@@ -33,3 +33,13 @@ func InitRedis() {
 		DB:       redisDB,                     //0,
 	})
 }
+
+// Close releases the shared Redis client. Safe to call on a nil client; the
+// graceful-shutdown coordinator invokes this last so any earlier hook can
+// still publish "I am stopping" messages or read a final snapshot.
+func Close() error {
+	if RedisClient == nil {
+		return nil
+	}
+	return RedisClient.Close()
+}

--- a/pkg/webhook/upload/notify.go
+++ b/pkg/webhook/upload/notify.go
@@ -21,6 +21,7 @@ package upload
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"files/pkg/models"
 	"io"
@@ -64,6 +65,8 @@ type newItemsBody struct {
 var (
 	queue      chan NewItem
 	startOnce  sync.Once
+	stopOnce   sync.Once
+	workerWG   sync.WaitGroup
 	httpClient = &http.Client{} // intentionally no Timeout; keep-alive enabled by default transport
 	dropped    uint64           // atomic counter; updated when the queue is full
 )
@@ -85,10 +88,36 @@ func Start() {
 	}
 	startOnce.Do(func() {
 		queue = make(chan NewItem, queueCap)
+		workerWG.Add(1)
 		go runWorker()
 		klog.Infof("%s notify enabled, queueCap=%d, maxBatchSize=%d, url=%s",
 			logPrefix, queueCap, maxBatchSiz, notifyURL())
 	})
+}
+
+// Stop drains the worker. It closes the in-memory queue (no further
+// Enqueue will be accepted), waits for the worker to flush whatever it has
+// already pulled out of the queue, and returns. ctx bounds the wait; if it
+// fires first, Stop returns ctx.Err but the worker keeps running until its
+// in-flight POST completes (single in-flight by design). Idempotent.
+func Stop(ctx context.Context) error {
+	if queue == nil {
+		return nil
+	}
+	stopOnce.Do(func() {
+		close(queue)
+	})
+	done := make(chan struct{})
+	go func() {
+		workerWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // Enqueue is non-blocking. Drops the item (with a throttled warning) when
@@ -111,9 +140,11 @@ func Enqueue(item NewItem) {
 }
 
 func runWorker() {
+	defer workerWG.Done()
 	defer func() {
 		if r := recover(); r != nil {
 			klog.Errorf("%s worker panic: %v; restarting", logPrefix, r)
+			workerWG.Add(1)
 			go runWorker()
 		}
 	}()


### PR DESCRIPTION
## Summary

Introduce graceful shutdown for the `backend` and `samba` binaries. Today both rely on `os.Exit` after Hertz' default 5s drain, leaving cron jobs, fsnotify watchers, K8s watchers, the upload-webhook worker, and redis/postgres pools to be killed mid-flight. This PR wires them through a small ordered-shutdown coordinator so a SIGTERM produces a clean teardown.

### Approach

- `pkg/lifecycle.Coordinator` — LIFO hook registry with per-hook timeouts, panic isolation, and parent-deadline awareness. Pure logic, table-driven unit tests cover order, timeouts, panics, errors, and nil handling.
- Hertz keeps owning its own signal waiter and HTTP drain (now `WithExitWaitTime(20s)` instead of the default 5s). After `Spin` returns, `HertzServer` invokes `coord.Run(ctx)` so HTTP connections drain *before* redis/postgres go away.
- Samba binary installs its own SIGTERM/SIGINT handler since it has no Hertz; a second signal forces `os.Exit(1)` so an operator can always force-exit a stuck process.
- New `Close()`/`Stop()` entry points on `redisutils`, `pkg/hertz/biz/dal/database`, `pkg/global` (fsnotify), and `pkg/webhook/upload` (worker drain via `sync.WaitGroup`).
- `InitCrontabs()` now returns the `*cron.Cron` so the coordinator can call `Stop()` and wait on the drain context.
- `cronDeleteOldFile` no longer silently spawns a private cron when called with `nil`; that orphan would have leaked past shutdown and any caller hitting that path is now a logged error.
- Removed dead `cleanupHandler` in `cmd/backend/app/root.go`.

### Shutdown order (registration → reverse execution)

```
register: postgres → redis → k8s-watcher → upload-webhook → external-fsnotify → cron
execute:  Hertz drain → cron Stop → fsnotify Close → k8s watcher cancel+wg → upload worker drain → redis Close → postgres Close
```

### Out of scope (deferred to phase 2)

Documented in the plan, not in this PR:
- Tasks pond pool / `Task.context.WithCancel(context.Background())` (needs deeper API change)
- rclone `StopJobs` on shutdown (external process, idempotency check)
- SeaRPC / named-pipe close (need to confirm searpc API)
- `pkg/integration` 15s ticker goroutine (no stop hook today)
- fsnotify watcher goroutine `wg.Join` (today close → channel-close → goroutine exits naturally; no explicit join)

## Test plan

- [x] `go test ./pkg/lifecycle/...` (table-driven coverage of order, per-hook timeout, parent deadline, panic isolation, error isolation, nil handling)
- [x] `go vet ./pkg/lifecycle/... ./pkg/global/... ./pkg/redisutils/...` (other touched packages depend on `.gitignore`d `hz` generated code; CI will run full vet after `hz update`)
- [x] `gofmt -w` + `ReadLints` on all touched files
- [ ] Manual: `docker run` then `kill -TERM`; expect ordered hook log lines and `exit 0`
- [ ] Manual: trigger long upload, send SIGTERM mid-request → request should drain within 20s rather than be cut off
- [ ] Manual: send `Ctrl-C` twice → second signal forces immediate `exit 1`
