### PR TITLE
fix: stop logging credentials (share token, samba password, searpc payload, oauth tokens)

### DIFF
--- a/cmd/backend/app/root.go
+++ b/cmd/backend/app/root.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"files/pkg/client"
 	"files/pkg/common"
+	"files/pkg/common/redact"
 	"files/pkg/diskcache"
 	"files/pkg/drivers"
 	"files/pkg/drivers/clouds/rclone"
@@ -15,16 +16,15 @@ import (
 	"files/pkg/img"
 	"files/pkg/integration"
 	"files/pkg/models"
-	"files/pkg/webhook/upload"
 	"files/pkg/redisutils"
 	"files/pkg/samba"
 	"files/pkg/tasks"
 	"files/pkg/watchers"
+	"files/pkg/webhook/upload"
 	"fmt"
 	"io"
 	"net"
 	"os"
-	"regexp"
 	"strings"
 
 	"github.com/spf13/afero"
@@ -368,25 +368,11 @@ func initConfig() {
 			klog.Infof("[ENV] %s", e)
 			continue
 		}
-		klog.Infof("[ENV] %s=%s", k, redactValue(k, val))
+		klog.Infof("[ENV] %s=%s", k, redact.Value(k, val))
 	}
 
 	klog.Infof("=== VIPER SETTINGS ===")
 	for _, key := range v.AllKeys() {
-		klog.Infof("[VIPER] %s = %v", key, redactValue(key, fmt.Sprintf("%v", v.Get(key))))
+		klog.Infof("[VIPER] %s = %v", key, redact.Value(key, fmt.Sprintf("%v", v.Get(key))))
 	}
-}
-
-// sensitiveKeyPattern matches config keys whose value should be redacted in logs.
-var sensitiveKeyPattern = regexp.MustCompile(`(?i)(password|passwd|secret|token|apikey|api_key|key|cookie|cred)`)
-
-// redactValue masks values whose key looks sensitive. Empty values pass through.
-func redactValue(key, value string) string {
-	if value == "" {
-		return value
-	}
-	if sensitiveKeyPattern.MatchString(key) {
-		return "***"
-	}
-	return value
 }

--- a/pkg/common/redact/redact.go
+++ b/pkg/common/redact/redact.go
@@ -1,0 +1,31 @@
+// Package redact provides minimal helpers for masking credential-like
+// values in *startup-diagnostic* log lines that must dump a whole table
+// (env vars, viper keys). For one-off log call sites that just contain a
+// secret, the right answer is "do not log it" rather than calling these
+// helpers.
+package redact
+
+import "regexp"
+
+// sensitiveKey matches field/env names that look credential-bearing. The
+// pattern is case-insensitive and matches anywhere in the name so e.g.
+// `MY_API_KEY`, `accessToken`, `dbPassword` all hit.
+var sensitiveKey = regexp.MustCompile(`(?i)(password|passwd|secret|token|apikey|api_key|key|cookie|cred)`)
+
+// Key reports whether name looks like a credential identifier.
+func Key(name string) bool {
+	return sensitiveKey.MatchString(name)
+}
+
+// Value returns "***" when key is sensitive and value is non-empty;
+// otherwise it returns value unchanged. Empty values pass through so the
+// caller can still see "key was unset".
+func Value(key, value string) string {
+	if value == "" {
+		return value
+	}
+	if Key(key) {
+		return "***"
+	}
+	return value
+}

--- a/pkg/common/redact/redact_test.go
+++ b/pkg/common/redact/redact_test.go
@@ -1,0 +1,48 @@
+package redact
+
+import "testing"
+
+func TestKey(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"", false},
+		{"foo", false},
+		{"FB_HOST", false},
+		{"password", true},
+		{"PASSWORD", true},
+		{"db_password", true},
+		{"AccessToken", true},
+		{"MY_API_KEY", true},
+		{"apikey", true},
+		{"api_key", true},
+		{"sessionCookie", true},
+		{"credential", true},
+		{"secret_value", true},
+	}
+	for _, c := range cases {
+		if got := Key(c.name); got != c.want {
+			t.Errorf("Key(%q) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestValue(t *testing.T) {
+	cases := []struct {
+		key, value, want string
+	}{
+		{"FB_HOST", "example.com", "example.com"},
+		{"FB_PASSWORD", "hunter2", "***"},
+		{"FB_PASSWORD", "", ""},
+		{"DB_TOKEN", "abc.def.ghi", "***"},
+		{"AccessToken", "xyz", "***"},
+		{"plain", "value", "value"},
+		{"plain", "", ""},
+	}
+	for _, c := range cases {
+		if got := Value(c.key, c.value); got != c.want {
+			t.Errorf("Value(%q, %q) = %q, want %q", c.key, c.value, got, c.want)
+		}
+	}
+}

--- a/pkg/drivers/sync/seahub/searpc/named_pipe.go
+++ b/pkg/drivers/sync/seahub/searpc/named_pipe.go
@@ -49,7 +49,7 @@ func (t *NamedPipeTransport) Stop() {
 }
 
 func (t *NamedPipeTransport) Send(service, fcallStr string) (string, error) {
-	klog.Infof("Send called - service: %s, fcallStr: %s", service, fcallStr)
+	klog.V(4).Infof("searpc send: service=%s len=%d", service, len(fcallStr))
 	var respStr string
 	var err error
 

--- a/pkg/hertz/biz/handler/api/share/share_service.go
+++ b/pkg/hertz/biz/handler/api/share/share_service.go
@@ -2248,7 +2248,7 @@ func GetToken(ctx context.Context, c *app.RequestContext) {
 	result["code"] = 0
 	result["data"] = defaultToken.Token
 
-	klog.Infof("GetToken, get external shared, shareId: %s, token: %s", req.PathId, defaultToken.Token)
+	klog.V(2).Infof("GetToken, get external shared, shareId: %s", req.PathId)
 
 	c.JSON(consts.StatusOK, result)
 }

--- a/pkg/hertz/biz/router/middleware.go
+++ b/pkg/hertz/biz/router/middleware.go
@@ -504,7 +504,7 @@ func checkExternal(currentUser string, token string, sharePaths *share.SharePath
 		return defaultExpired, false, errors.New("shareToken not found")
 	}
 
-	klog.Infof("share token: %s", common.ToJson(shareToken))
+	klog.V(2).Infof("share token validated, shareId: %s, expireAt: %s", sharePaths.ID, shareToken.ExpireAt)
 
 	expired, _ := time.Parse(time.RFC3339Nano, shareToken.ExpireAt)
 	if time.Now().After(expired) {

--- a/pkg/media/utils/token.go
+++ b/pkg/media/utils/token.go
@@ -44,7 +44,7 @@ func GetAuthToken(owner string) (string, error) {
 		// fmt.Errorf("Failed to create token for user %s in namespace %s: %v", owner, namespace, err)
 		return "", fmt.Errorf("failed to create token for user %s in namespace %s: %v", owner, namespace, err)
 	}
-	klog.Infof("%+v\n", token)
+	klog.V(2).Infof("auth token issued for %s, expiresAt=%s", owner, token.Status.ExpirationTimestamp)
 
 	if !ok {
 		at = authv1.TokenRequestStatus{}
@@ -84,8 +84,7 @@ func GetToken(owner string, accountName string, accountType string, authToken st
 	if accountResp.Data == nil || accountResp.Data.RawData == nil {
 		return nil, errors.New("account response data or raw data is nil")
 	}
-	klog.Infof("accountResp.Data: %+v\n", accountResp.Data)
-	klog.Infof("accountResp.Data.RawData: %+v\n", accountResp.Data.RawData)
+	klog.V(2).Infof("account fetched: name=%s type=%s", accountResp.Data.Name, accountResp.Data.Type)
 	return accountResp.Data, nil
 }
 

--- a/pkg/samba/commands.go
+++ b/pkg/samba/commands.go
@@ -33,7 +33,7 @@ func (c *commands) Update() error {
 }
 
 func (c *commands) CreateUser(userName, password, groupName string) error {
-	klog.Infof("samba createUser, name: %s, group: %s, pwd: %s", userName, groupName, password)
+	klog.Infof("samba createUser, name: %s, group: %s", userName, groupName)
 	u, err := user.Lookup(userName)
 	if err != nil {
 		klog.Warning(err)

--- a/pkg/samba/samba.go
+++ b/pkg/samba/samba.go
@@ -320,7 +320,7 @@ func (s *samba) generateConf() {
 				for _, user := range item.Members {
 					sharePwd, err = s.getUser(user.Password)
 					if err != nil {
-						klog.Errorf("samba get user pwd error: %v, password: %s, userId: %s, userName: %s, owner: %s", err, user.Password, user.UserId, user.UserName, item.Owner)
+						klog.Errorf("samba get user pwd error: %v, userId: %s, userName: %s, owner: %s", err, user.UserId, user.UserName, item.Owner)
 						continue
 					}
 


### PR DESCRIPTION
## Summary

Stop logging plaintext credentials. Five call sites were dumping share tokens, samba user passwords, RPC payloads, K8s service-account JWTs, and OAuth refresh/access tokens directly into stdout. Each is now either deleted or downgraded to a `klog.V(N)` line that contains only non-sensitive metadata (owner, shareId, expiry, payload length).

### Approach

The user explicitly asked for "do not log them at all" rather than "mask and still log", so:

- **Token / password call sites are deleted outright** (or replaced with a `klog.V(2).Infof(...)` line that carries only ID / expiry, which is off by default in production).
- **Per-RPC searpc log is demoted to `klog.V(4)`** and only logs `service=...` and `len=...`, never the payload itself. Default `-v=0` means it is silent in production.
- **The startup-diagnostic table** (`cmd/backend/app/root.go` env + viper dump) keeps a tiny redaction helper, since the whole point of that block is to print every env/viper key for support diagnostics.

A new minimal package `pkg/common/redact` provides only what that one call site needs:

```go
func Key(name string) bool                        // does name look credential-bearing
func Value(key, value string) string              // "***" when key is sensitive, else value
```

No reflection, no JSON helpers, no first-N-chars masking — those would just encourage "mask and still log" everywhere.

### Call site map

| File:line | Before | After |
|---|---|---|
| `pkg/hertz/biz/handler/api/share/share_service.go:2251` | `klog.Infof("...token: %s", req.PathId, defaultToken.Token)` | `klog.V(2).Infof("GetToken, get external shared, shareId: %s", req.PathId)` |
| `pkg/hertz/biz/router/middleware.go:507` | `klog.Infof("share token: %s", common.ToJson(shareToken))` | `klog.V(2).Infof("share token validated, shareId: %s, expireAt: %s", ...)` |
| `pkg/samba/commands.go:36` | `... pwd: %s ...` | password field removed |
| `pkg/samba/samba.go:323` | `... password: %s ...` | password field removed |
| `pkg/drivers/sync/seahub/searpc/named_pipe.go:52` | `klog.Infof("Send called - service: %s, fcallStr: %s", ...)` | `klog.V(4).Infof("searpc send: service=%s len=%d", ...)` |
| `pkg/media/utils/token.go:47` | `klog.Infof("%+v", token)` (whole TokenRequest) | `klog.V(2).Infof("auth token issued for %s, expiresAt=%s", ...)` |
| `pkg/media/utils/token.go:87-88` | `accountResp.Data` and `RawData` (refresh/access/id token) dumped | `klog.V(2).Infof("account fetched: name=%s type=%s", ...)` |
| `cmd/backend/app/root.go:414/419` | local `redactValue` / `sensitiveKeyPattern` | `redact.Value(k, v)` from new package |

### Out of scope (single-PR discipline)

- Mount-info `%+v` logs in `pkg/global/external.go` — DiskInfo holds no credentials.
- Generic handler error-message redaction (paths, internal hostnames).
- Project-wide `klog.Infof("%+v"` audit — too large; do as a follow-up.
- Secrets-management integration (vault / k8s secret).

## Test plan

- [x] `go test ./pkg/common/redact/...` — covers `Key` (case-insensitive substrings, common patterns like `AccessToken`, `MY_API_KEY`) and `Value` (sensitive vs plain, empty-value passthrough)
- [x] `go vet ./pkg/common/redact/... ./pkg/media/utils/... ./pkg/drivers/sync/seahub/searpc/...` clean
- [x] `gofmt -w` + `ReadLints` on every touched file — clean
- [ ] Manual: hit `/api/share/get_token`, create a samba user, trigger a searpc call, fetch an OAuth account; grep produced logs for `pwd:`, `token: ey`, `fcallStr:`, `refresh_token`, `access_token` — expect zero hits at default verbosity
- [ ] Manual: restart with `-v=4` and confirm `searpc send: service=... len=...` appears

### Backwards-compat note for ops

If any monitoring greps `share token: `, `pwd: `, or `Send called - service:` from filebrowser logs, those rules will stop matching. The replacement lines use new keywords (`shareId:`, `searpc send: service=`) at lower verbosity.
