### PR TITLE
fix(tasks): repair undefined `client` reference in DownloadFromFiles

### DIFF
--- a/pkg/tasks/task_paste_download.go
+++ b/pkg/tasks/task_paste_download.go
@@ -168,7 +168,7 @@ func (t *Task) DownloadFromFiles() error {
 
 		var downloadResp *http.Response
 
-		downloadResp, err = client.Do(downloadReq)
+		downloadResp, err = streamHTTPClient.Do(downloadReq)
 		if err != nil {
 			klog.Errorf("[Task] Id: %s, download failed, url: %s, error: %v", t.id, downloadUrl, err)
 			downloadResp.Body.Close()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`pkg/tasks` currently fails to compile on `main` because of an undefined identifier `client` at `pkg/tasks/task_paste_download.go:171`.

## Root cause

Commit [e07303c](https://github.com/beclab/files/commit/e07303c) `fix(tasks): use shared streaming client for sync download paths` removed the function-local `client := &http.Client{...}` from `DownloadFromFiles` and switched its callers over to the new package-level `streamHTTPClient` declared in `pkg/tasks/httpclient.go`.

`DownloadFromFiles` has **two** `client.Do(...)` call sites:

1. The file list request (around the original line 51) — correctly migrated to `streamHTTPClient.Do(...)`.
2. The per-file download request (now line 171) — **missed**, still references the deleted `client` variable.

The result is:

```
# files/pkg/tasks
pkg/tasks/task_paste_download.go:171:23: undefined: client
```

## Fix

A one-line change: switch the second call site to `streamHTTPClient.Do(...)` to match the original intent of `e07303c`. No behavior change beyond what `e07303c` already documented (shared transport with tuned `ResponseHeaderTimeout` / `IdleConnTimeout` / `TLSHandshakeTimeout`, no overall `Client.Timeout` so multi-GB streaming downloads aren't clipped).

## Verification

`go build ./pkg/tasks/...` succeeds locally after the change.

## Risk

Minimal. The replacement client (`streamHTTPClient`) has the same lifecycle and is already used by the sibling call site in the same function on this same branch.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1828b75a-e77c-4d16-a657-429cda46df98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1828b75a-e77c-4d16-a657-429cda46df98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

