### PR TITLE
chore(dal): silence GORM logger

### DIFF
--- a/pkg/hertz/biz/dal/database/init.go
+++ b/pkg/hertz/biz/dal/database/init.go
@@ -28,7 +28,7 @@ func Init() {
 	DB, err = gorm.Open(postgres.Open(dsn), &gorm.Config{
 		SkipDefaultTransaction: true,
 		PrepareStmt:            true,
-		Logger:                 logger.Default.LogMode(logger.Info),
+		Logger:                 logger.Default.LogMode(logger.Silent),
 	})
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Switch the GORM logger `LogMode` from `Info` to `Silent` in `pkg/hertz/biz/dal/database/init.go`.

## Motivation

At `LogMode(Info)`, GORM emits every SQL statement (and any slow-query / "record not found" warnings) to stdout. For tables such as `share_smb_users`, the rendered SQL includes parameter values for sensitive columns like `password` (currently base64-encoded plaintext), which then end up in container logs and any centralized logging pipeline.

This is the same class of issue we just addressed in `samba.go` (replacing the full-`json.Marshal` log line with a field-whitelist log) and aligns with the broader effort to keep credential material out of INFO-level logs.

## Behavior

Before:

```go
Logger: logger.Default.LogMode(logger.Info),
```

After:

```go
Logger: logger.Default.LogMode(logger.Silent),
```

Effects:

- No SQL statements / parameters are written to stdout by GORM.
- No slow-query warnings or `ErrRecordNotFound` notices are written by GORM.
- Actual query errors are still returned through `(...).Error` to the caller and continue to be surfaced via existing `klog.Errorf` wrappers throughout the codebase, so diagnosability for genuine failures is unchanged.

If verbose SQL tracing is ever needed for debugging, it can be re-enabled locally by switching back to `LogMode(Info)` (or driven by an env var if we want to make it runtime-toggleable later).

## Risk

Minimal. Single one-line change in DAL initialization. No schema, API, or wire-format change. `go build ./pkg/hertz/biz/dal/...` succeeds locally.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1828b75a-e77c-4d16-a657-429cda46df98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1828b75a-e77c-4d16-a657-429cda46df98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

