### PR TITLE
fix: multiple bug fixes for file operations, sharing, and upload

### DIFF
--- a/pkg/common/errors.go
+++ b/pkg/common/errors.go
@@ -25,6 +25,33 @@ var (
 	ErrFileSizeExceeds4GB   = errors.New("file size exceeds 4GB")
 )
 
+// SanitizeFsError returns an error whose message no longer contains the
+// possibly very long source/destination paths that os.Rename / os.Open and
+// other filesystem syscalls embed in *os.LinkError, *os.PathError and
+// *os.SyscallError. The underlying syscall message (e.g. "file name too long")
+// is preserved, so callers can still understand what went wrong.
+//
+// If err is nil or none of the wrappers above apply, the original error is
+// returned unchanged.
+func SanitizeFsError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var linkErr *os.LinkError
+	if errors.As(err, &linkErr) && linkErr.Err != nil {
+		return errors.New(linkErr.Err.Error())
+	}
+	var pathErr *os.PathError
+	if errors.As(err, &pathErr) && pathErr.Err != nil {
+		return errors.New(pathErr.Err.Error())
+	}
+	var syscallErr *os.SyscallError
+	if errors.As(err, &syscallErr) && syscallErr.Err != nil {
+		return errors.New(syscallErr.Err.Error())
+	}
+	return err
+}
+
 func ErrToStatus(err error) int {
 	switch {
 	case err == nil:

--- a/pkg/drivers/posix/posix/posix.go
+++ b/pkg/drivers/posix/posix/posix.go
@@ -475,7 +475,7 @@ func (s *PosixStorage) Rename(contextArgs *models.HttpContextArgs) ([]byte, erro
 	klog.Infof("Posix rename, src: %s, dst: %s", rSrcPath, rDstPath)
 
 	if err = afs.Rename(rSrcPath, rDstPath); err != nil {
-		return nil, err
+		return nil, common.SanitizeFsError(err)
 	}
 
 	return nil, nil

--- a/pkg/drivers/posix/upload/fileinfos.go
+++ b/pkg/drivers/posix/upload/fileinfos.go
@@ -81,9 +81,9 @@ func (m *FileInfoMgr) DeleteOldInfos() {
 			id := key.(string)
 			klog.Infof("id %s expire del in map", id)
 			InfoSyncMap.Delete(key)
-			if uploadsFile, ok := UploadsFiles.LoadAndDelete(id); ok {
-				f := uploadsFile.(string)
-				RemoveTempFileAndInfoFile(filepath.Base(f), filepath.Dir(f))
+			if uploadsFile, ok := UploadsFiles[id]; ok {
+				delete(UploadsFiles, id)
+				RemoveTempFileAndInfoFile(filepath.Base(uploadsFile), filepath.Dir(uploadsFile))
 			}
 		}
 		return true
@@ -114,7 +114,7 @@ func (m *FileInfoMgr) UpdateInfo(id string, info FileInfo) {
 
 func (m *FileInfoMgr) DelFileInfo(id, tmpName, uploadsDir string) {
 	InfoSyncMap.Delete(id)
-	UploadsFiles.Delete(id)
+	delete(UploadsFiles, id)
 	RemoveTempFileAndInfoFile(tmpName, uploadsDir)
 }
 

--- a/pkg/drivers/posix/upload/handlefunc.go
+++ b/pkg/drivers/posix/upload/handlefunc.go
@@ -109,7 +109,7 @@ func HandleUploadedBytes(fileParam *models.FileParam, fileName string, fileIdent
 	// todo add identy
 	innerIdentifier := MakeUid(fullPath) // real upload file temp name
 	tmpName := innerIdentifier
-	UploadsFiles.Store(innerIdentifier, filepath.Join(uploadTempPath, tmpName))
+	UploadsFiles[innerIdentifier] = filepath.Join(uploadTempPath, tmpName)
 
 	exist, info := FileInfoManager.ExistFileInfo(innerIdentifier)
 
@@ -216,7 +216,7 @@ func HandleUploadChunks(fileParam *models.FileParam, uploadId string, resumableI
 	fullPath := filepath.Join(uploadPath, resumableInfo.ResumableRelativePath)
 	innerIdentifier := MakeUid(fullPath) // todo add resumableInfo.ResumableIdenty
 	tmpName := innerIdentifier
-	UploadsFiles.Store(innerIdentifier, filepath.Join(uploadTempPath, tmpName))
+	UploadsFiles[innerIdentifier] = filepath.Join(uploadTempPath, tmpName)
 
 	klog.Infof("[upload] uploadId: %s, fullPath: %s", uploadId, fullPath)
 

--- a/pkg/drivers/posix/upload/init.go
+++ b/pkg/drivers/posix/upload/init.go
@@ -24,10 +24,9 @@ func Init(c *cron.Cron) {
 	FileInfoManager = NewFileInfoMgr()
 	FileInfoManager.Init(c)
 
-	UploadsFiles.Range(func(_, value any) bool {
-		cronDeleteOldFile(value.(string), c)
-		return true
-	})
+	for _, uploadsFile := range UploadsFiles {
+		cronDeleteOldFile(uploadsFile, c)
+	}
 
 	getEnvInfo()
 

--- a/pkg/drivers/posix/upload/operations.go
+++ b/pkg/drivers/posix/upload/operations.go
@@ -16,7 +16,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/spf13/afero"
@@ -31,7 +30,7 @@ const (
 	ExternalPathPrefix = common.EXTERNAL_PREFIX
 )
 
-var UploadsFiles sync.Map
+var UploadsFiles map[string]string = map[string]string{}
 
 func CheckType(filetype string) bool {
 	if allowAllFileType {

--- a/pkg/files/fileutils.go
+++ b/pkg/files/fileutils.go
@@ -352,6 +352,9 @@ func MkdirAllWithChown(fs afero.Fs, path string, mode os.FileMode, forced bool, 
 			continue
 		}
 		vol = filepath.Join(vol, part)
+		if !strings.HasPrefix(vol, "/") {
+			vol = "/" + vol
+		}
 
 		if fs == nil {
 			info, err = os.Stat(vol)

--- a/pkg/hertz/biz/dal/init.go
+++ b/pkg/hertz/biz/dal/init.go
@@ -44,4 +44,42 @@ func Init() {
 	migration(&share.ShareMember{}, "share_members", rebuild)
 	migration(&share.ShareSmbUser{}, "share_smb_users", rebuild)
 	migration(&share.ShareSmbMember{}, "share_smb_members", rebuild)
+
+	cleanupOwnerAsShareMember()
+}
+
+// cleanupOwnerAsShareMember removes any share_members rows whose
+// share_member equals the owner of their share_paths row. Such rows are
+// phantom data caused by an old bug in UpdateSharePathMembers: when a
+// non-owner admin (e.g. a sub-account granted admin) edited a share's
+// members, the FE-submitted list often still carried the path's owner
+// (used purely for display), and the handler would insert that owner
+// into share_members. The phantom row makes the share appear twice in
+// the owner's ListSharePath response — once as sharedByMe, once as
+// sharedToMe via the share_members join.
+//
+// This cleanup is idempotent: on a clean DB it deletes 0 rows. The
+// source of the bug is also fixed in the handler so no new phantom
+// rows will be produced after upgrade; this exists to remediate
+// historical data in place during a normal restart.
+func cleanupOwnerAsShareMember() {
+	// Sub-query: for each share_members row, "does a share_paths row
+	// exist with the same id (= path_id) and owner == share_member?"
+	exists := database.DB.Table("share_paths").
+		Select("1").
+		Where("share_paths.id = share_members.path_id").
+		Where("share_paths.owner = share_members.share_member")
+
+	res := database.DB.
+		Where("EXISTS (?)", exists).
+		Delete(&share.ShareMember{})
+	if res.Error != nil {
+		klog.Errorf("[share-cleanup] phantom share_members cleanup failed: %v", res.Error)
+		return
+	}
+	if res.RowsAffected > 0 {
+		klog.Warningf("[share-cleanup] removed %d phantom share_members row(s) where share_member == sharePath.Owner", res.RowsAffected)
+	} else {
+		klog.Infof("[share-cleanup] no phantom share_members rows found")
+	}
 }

--- a/pkg/hertz/biz/handler/api/share/share_service.go
+++ b/pkg/hertz/biz/handler/api/share/share_service.go
@@ -598,9 +598,18 @@ func UpdateSharePathMembers(ctx context.Context, c *app.RequestContext) {
 
 	memberInfoMap := make(map[string]*share.AddOrUpdateShareMemberInfo)
 	for _, memberInfo := range req.ShareMembers {
-		if memberInfo.ShareMember != owner {
-			memberInfoMap[memberInfo.ShareMember] = memberInfo
+		// The share's owner can never be a member of their own share,
+		// and the caller (e.g. a sub-account admin) shouldn't add
+		// themselves either. The FE often re-submits the rendered
+		// member list which may include the owner for display; if we
+		// accept that blindly we end up inserting a phantom
+		// (path_id, owner) row into share_members, which then makes
+		// the share appear twice in the owner's ListSharePath
+		// (once via sharedByMe, once via the sharedToMe join).
+		if memberInfo.ShareMember == owner || memberInfo.ShareMember == sharePath.Owner {
+			continue
 		}
+		memberInfoMap[memberInfo.ShareMember] = memberInfo
 	}
 
 	memberQueryParams := &database.QueryParams{}
@@ -627,9 +636,16 @@ func UpdateSharePathMembers(ctx context.Context, c *app.RequestContext) {
 
 	for _, member := range shareMembers {
 		if _, exists := memberInfoMap[member.ShareMember]; exists {
-		} else {
-			deleteShareMembers = append(deleteShareMembers, member)
+			continue
 		}
+		// Protect the caller themselves: when a non-owner admin (e.g. a sub-account
+		// granted admin) edits members, the FE-submitted ShareMembers usually does
+		// not include the caller, so we must not remove the caller from members.
+		if member.ShareMember == owner {
+			existedShareMembers = append(existedShareMembers, member)
+			continue
+		}
+		deleteShareMembers = append(deleteShareMembers, member)
 	}
 
 	now := time.Now().UTC().Format(time.RFC3339Nano)

--- a/pkg/hertz/biz/handler/utils.go
+++ b/pkg/hertz/biz/handler/utils.go
@@ -27,6 +27,11 @@ func RespBadRequest(c *app.RequestContext, msg string) {
 	c.Abort()
 }
 
+func RespForbidden(c *app.RequestContext, msg string) {
+	c.JSON(http.StatusForbidden, utils.H{"code": 1, "message": msg})
+	c.Abort()
+}
+
 func RespStatusInternalServerError(c *app.RequestContext, msg string) {
 	c.JSON(http.StatusInternalServerError, utils.H{"code": 1, "message": msg})
 	c.Abort()

--- a/pkg/hertz/biz/router/middleware.go
+++ b/pkg/hertz/biz/router/middleware.go
@@ -618,7 +618,7 @@ func proxySharePaste(c *app.RequestContext, owner string, action string, src, ds
 
 			// check permission
 			if member.Permission < 1 {
-				handler.RespError(c, common.ErrorMessagePermissionDenied)
+				handler.RespForbidden(c, common.ErrorMessagePermissionDenied)
 				return
 			}
 		}
@@ -673,7 +673,7 @@ func proxySharePaste(c *app.RequestContext, owner string, action string, src, ds
 
 			// check permission, view, edit, admin
 			if owner != shared.Owner && member.Permission < 2 {
-				handler.RespError(c, common.ErrorMessagePermissionDenied)
+				handler.RespForbidden(c, common.ErrorMessagePermissionDenied)
 				return
 			}
 		}

--- a/pkg/hertz/hertz.go
+++ b/pkg/hertz/hertz.go
@@ -49,8 +49,12 @@ func HertzServer(cfg *common.Server, coord *lifecycle.Coordinator) {
 		server.WithHostPorts(hostPort),
 		server.WithMaxRequestBodySize(20<<20),
 		server.WithTransport(standard.NewTransporter),
-		server.WithReadTimeout(5*time.Minute),
-		server.WithWriteTimeout(5*time.Minute),
+		// 30min covers the worst-case finalize for very large uploads
+		// (e.g. tens of GB cross-PVC io.Copy). Must stay >= the
+		// matching nginx proxy_read_timeout / proxy_send_timeout /
+		// send_timeout / client_body_timeout for the /upload location.
+		server.WithReadTimeout(30*time.Minute),
+		server.WithWriteTimeout(30*time.Minute),
 		server.WithKeepAliveTimeout(3*time.Minute),
 		server.WithStreamBody(true),
 		server.WithReadBufferSize(64*1024),

--- a/pkg/hertz/idl/resources.thrift
+++ b/pkg/hertz/idl/resources.thrift
@@ -19,7 +19,7 @@ struct PatchResourcesResp {
 }
 
 struct PutResourcesReq {
-    1: required binary Body (api.raw_body="raw_body");
+    1: binary Body (api.raw_body="raw_body");
 }
 
 struct PutResourcesResp {

--- a/pkg/tasks/task_paste_sync.go
+++ b/pkg/tasks/task_paste_sync.go
@@ -858,6 +858,22 @@ func (t *Task) UploadFileToSync(src, dst *models.FileParam) error {
 	prefix, filename := filepath.Split(dst.Path)
 	prefix = strings.TrimPrefix(prefix, "/")
 
+	// Empty files cannot be created via seafhttp's chunked upload protocol
+	// (the resumable.js handler on the server side never gets invoked for a
+	// 0-byte payload, so the upload silently no-ops). Use the seafile RPC
+	// directly so the file ends up on the sync side under its raw name.
+	if diskSize == 0 {
+		parentDir := "/" + strings.TrimSuffix(prefix, "/")
+		username := dst.Owner + "@auth.local"
+		if _, err := seaserv.GlobalSeafileAPI.PostEmptyFile(dst.Extend, parentDir, filename, username); err != nil {
+			klog.Errorf("[Task] Id: %s, post empty file %s failed: %v", t.id, dst.Path, err)
+			return err
+		}
+		t.updateProgress(left, 0)
+		t.updateProgress(right, 0)
+		return nil
+	}
+
 	extension := path.Ext(filename)
 	mimeType := "application/octet-stream"
 	if extension != "" {


### PR DESCRIPTION
## Summary

This PR bundles several bug fixes across different subsystems:

### 1. Edit-to-empty bug (task_paste_sync)
- Empty (0-byte) files cannot be created via seafhttp's chunked upload protocol — the resumable.js handler never gets invoked for a zero-byte payload. Added a fast path that uses `PostEmptyFile` RPC directly for 0-byte files during paste-sync.

### 2. Rename filename-too-long error message (posix, errors)
- When `os.Rename` fails with "file name too long", the raw `*os.LinkError` embeds the full source and destination paths, producing an enormous and unhelpful error message returned to the client. Added `SanitizeFsError()` to strip paths from `*os.LinkError` / `*os.PathError` / `*os.SyscallError`, preserving only the underlying syscall message.

### 3. Empty paste-to-sync bug (task_paste_sync)
- Same root cause as #1 — covered by the `PostEmptyFile` fast path.

### 4. Share read-only paste: 400 → 403 (middleware, utils)
- Pasting into a shared folder where the caller only has read permission returned HTTP 400 (`file param error`). Changed to HTTP 403 with `RespForbidden` for both source-read-only and destination-write-only permission failures.

### 5. Share chain broken & duplicate entries (share_service, dal/init)
- **Chain broken**: When a non-owner admin (sub-account) edited share members, the handler would remove the caller from the member list if they were not explicitly re-submitted by the frontend. Added a guard to protect the caller from self-deletion.
- **Duplicate entries**: The frontend re-submits the rendered member list which includes the path owner for display. The handler blindly inserted that, creating a phantom `(path_id, owner)` row in `share_members`, making the share appear twice in the owner's list. Now filters out both the owner and `sharePath.Owner` from the incoming member list. Added `cleanupOwnerAsShareMember()` in `dal/init.go` to remove historical phantom rows on startup.

### 6. Large file upload timeout protection (hertz)
- Increased Hertz `ReadTimeout` and `WriteTimeout` from 5 min to 30 min to cover worst-case finalization of very large uploads (tens of GB cross-PVC `io.Copy`).

### Other
- Fixed `MkdirAllWithChown` path normalization: ensured `vol` always starts with `/` after `filepath.Join`.
- Fixed `PutResourcesReq.Body` thrift field: removed unnecessary `required` annotation.
- Reverted `UploadsFiles` from `sync.Map` back to `map[string]string` to fix a concurrency regression that caused upload resume to silently truncate temp files.

## Test plan

- [ ] Upload a 0-byte file and verify it syncs correctly
- [ ] Rename a file with a very long name and verify the error message is clean
- [ ] Paste into a read-only shared folder and verify HTTP 403 is returned
- [ ] As a sub-account admin, edit share members and verify the caller is not removed
- [ ] Verify the path owner does not appear as a duplicate in the share list
- [ ] Upload a large file (>1 GB) and verify it completes without timeout
- [ ] Refresh page mid-upload, re-select the same file, and verify resume works correctly


Made with [Cursor](https://cursor.com)