### PR TITLE
chore(logs): simplify and silence sensitive debug logs

### DIFF
--- a/pkg/drivers/clouds/rclone/config/config.go
+++ b/pkg/drivers/clouds/rclone/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	common2 "files/pkg/common"
 	"files/pkg/drivers/clouds/rclone/common"
@@ -59,11 +58,7 @@ func (c *config) Create(param *Config) error {
 		Parameters: c.parseCreateConfigParameters(param),
 	}
 
-	if common2.ParseBool(common2.DebugIntegration) {
-		klog.Infof("[rclone] create config: %s, param: %s", param.Type, base64.StdEncoding.EncodeToString([]byte(common2.ToJson(data))))
-	} else {
-		klog.Infof("[rclone] create config: %s", param.Type)
-	}
+	klog.Infof("[rclone] create config: %s", param.Type)
 
 	_, err := utils.Request(ctx, url, http.MethodPost, nil, []byte(common2.ToJson(data)))
 	if err != nil {

--- a/pkg/drivers/clouds/rclone/rclone.go
+++ b/pkg/drivers/clouds/rclone/rclone.go
@@ -1,7 +1,6 @@
 package rclone
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"files/pkg/common"
@@ -100,11 +99,7 @@ func (r *rclone) StartHttp(configs []*config.Config) error {
 	_ = changedConfigsJson
 
 	if changedConfigsJson != "{}" {
-		if common.ParseBool(common.DebugIntegration) {
-			klog.Infof("[startHttp] changed configs: %s", base64.StdEncoding.EncodeToString([]byte(common.ToJson(changedConfigs))))
-		} else {
-			klog.Info("[startHttp] changed configs")
-		}
+		klog.Info("[startHttp] changed configs")
 	}
 
 	if len(changedConfigs.Delete) > 0 {

--- a/pkg/integration/account.go
+++ b/pkg/integration/account.go
@@ -23,7 +23,7 @@ func (i *integration) getAccounts(owner string, authToken string) ([]*accountsRe
 	var header = make(map[string]string)
 	header[common.REQUEST_HEADER_AUTHORIZATION] = fmt.Sprintf("Bearer %s", authToken)
 
-	resp, err := common.Request(integrationUrl, http.MethodPost, header, data, common.ParseBool(common.DebugIntegration))
+	resp, err := common.Request(integrationUrl, http.MethodPost, header, data, false)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +50,7 @@ func (i *integration) getToken(owner string, accountName string, accountType str
 	header[restful.HEADER_ContentType] = restful.MIME_JSON
 	header[common.REQUEST_HEADER_AUTHORIZATION] = fmt.Sprintf("Bearer %s", authToken)
 
-	resp, err := common.Request(integrationUrl, http.MethodPost, header, data, common.ParseBool(common.DebugIntegration))
+	resp, err := common.Request(integrationUrl, http.MethodPost, header, data, false)
 
 	if err != nil {
 		return nil, err

--- a/pkg/samba/samba.go
+++ b/pkg/samba/samba.go
@@ -272,8 +272,9 @@ func (s *samba) generateConf() {
 
 	s.deleteExcludeUsers(smbUsers, smbShares)
 
-	smbShareBytes, _ := json.Marshal(smbShares)
-	klog.Infof("samba share paths: %s", string(smbShareBytes))
+	for id, p := range smbShares {
+		klog.Infof("samba share paths, id: %s, owner: %s, fileType: %s, extend: %s, path: %s, shareType: %s, name: %s, users: %d", id, p.Owner, p.FileType, p.Extend, p.Path, p.ShareType, p.Name, len(p.Members))
+	}
 
 	var shares = SambaShares{}
 	for _, item := range smbShares { // ~ map


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Tones down a few noisy/sensitive debug log statements that were previously gated behind `DebugIntegration` (or unconditionally dumped JSON). The `DebugIntegration` toggle would still emit base64-encoded payloads / full marshalled state when enabled; this change makes the logs uniformly safe and concise.

## Changes

1. `pkg/samba/samba.go` — `generateConf`
   - Removed `json.Marshal(smbShares)` + dump.
   - Replaced with a per-share structured log line:
     ```go
     for id, p := range smbShares {
         klog.Infof("samba share paths, id: %s, owner: %s, fileType: %s, extend: %s, path: %s, shareType: %s, name: %s, users: %d", id, p.Owner, p.FileType, p.Extend, p.Path, p.ShareType, p.Name, len(p.Members))
     }
     ```

2. `pkg/drivers/clouds/rclone/rclone.go` — `StartHttp`
   - Dropped the `DebugIntegration` branch that base64-encoded the full `changedConfigs` JSON.
   - Always logs `klog.Info("[startHttp] changed configs")`.
   - Removed the now-unused `encoding/base64` import.

3. `pkg/drivers/clouds/rclone/config/config.go` — `Create`
   - Dropped the `DebugIntegration` branch that base64-encoded the full create-config payload.
   - Always logs `klog.Infof("[rclone] create config: %s", param.Type)`.
   - Removed the now-unused `encoding/base64` import.

4. `pkg/integration/account.go`
   - `getAccounts` and `getToken` now pass `false` to `common.Request` instead of `common.ParseBool(common.DebugIntegration)`, preventing the underlying HTTP client from logging integration request/response payloads (which can contain tokens / secrets).

## Notes

- No behavior change beyond logging.
- No dependencies added/removed.
- Build issues observed locally are pre-existing and unrelated to these edits (the auto-generated `pkg/hertz/biz/model/api/...` packages are not present in this checkout).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66bd7037-81b3-47bd-94db-2578aed37cce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66bd7037-81b3-47bd-94db-2578aed37cce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

