### PR TITLE
fix(samba): pin alpine base to 3.21 to avoid musl `renameat2` mismatch

### DIFF
--- a/Dockerfile.samba
+++ b/Dockerfile.samba
@@ -42,9 +42,22 @@ RUN CGO_ENABLED=0 go build -ldflags "-w -s" -o samba_share cmd/samba/main.go
 # FROM gcr.io/distroless/base:nonroot
 # FROM gcr.io/distroless/base:debug
 
-FROM alpine:edge
+# Pinned to a stable Alpine release instead of `edge`.
+#
+# `alpine:edge` is a rolling branch where `samba` and `musl` can drift out of
+# sync. As of 2026-04 the edge `samba` package was linked against `renameat2`
+# (a libc wrapper added only in musl 1.2.6, released 2026-03-20), while the
+# edge image still ships `musl-1.2.5-r21`. This caused samba binaries (smbd,
+# smbclient, ...) to fail to load `libsmbd-base-private-samba.so` with
+# `Error relocating ...: renameat2: symbol not found`, breaking the SMB
+# service on container startup.
+#
+# Stable Alpine releases test `musl` and `samba` together, so this whole
+# class of "new package + old libc" symbol mismatches is avoided.
+FROM alpine:3.21
 
 RUN set -eu && \
+  apk --no-cache upgrade && \
   apk --no-cache add \
   tini \
   bash \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Background

The `samba-server` container fails to start with:

```
Error relocating /usr/lib/samba/libsmbd-base-private-samba.so: renameat2: symbol not found
```

This is a hard failure from the musl dynamic linker during `.so` relocation, so any samba binary (`smbd`, `nmbd`, `smbclient`, ...) exits immediately on startup, the SMB service never comes up, and the healthcheck stays failing.

## Root cause

`Dockerfile.samba` used `FROM alpine:edge` for the runtime image. `alpine:edge` is the rolling/development branch of Alpine, where individual packages can briefly drift out of sync. As of 2026-04 we hit exactly such a window:

- `samba` on edge has been rebuilt against `renameat2`, a libc wrapper added in **musl 1.2.6** (released **2026-03-20**, see [musl release notes](https://musl.libc.org/releases.html)).
- The `alpine:edge` image still ships **`musl-1.2.5-r21`**, which does not export `renameat2`.

Verified on the failing image:

```
$ apk info -W /lib/ld-musl-*.so.1
/lib/ld-musl-x86_64.so.1 is owned by musl-1.2.5-r21
```

Result: every samba binary tries to load `libsmbd-base-private-samba.so`, the dynamic linker can't resolve `renameat2`, the binary exits non-zero, and `smbd` never starts.

## Fix

- Switch the runtime base from `alpine:edge` to a pinned stable tag (`alpine:3.21`). Stable releases ship musl and samba that have been tested together, eliminating the entire class of "new package + old libc" symbol-mismatch issues.
- Add `apk --no-cache upgrade` before installing samba so any cached base-layer packages are brought up to the latest revision in the stable repo before samba is pulled in.
- Add a comment in the Dockerfile explaining why `alpine:edge` should not be used here, so the change isn't undone later.

## Why not just wait for edge to update musl

Even once edge's musl gets bumped to 1.2.6, the same class of problem will recur the next time samba (or any other package) starts using a newly-added libc wrapper before the corresponding musl release lands in edge. Pinning to a stable Alpine tag is the durable fix.

## Test plan

- Build the image: `docker build -f Dockerfile.samba -t samba-server:test .`
- Inside the resulting image, confirm musl is at least 1.2.5 and samba binaries load:

  ```bash
  apk info -W /lib/ld-musl-*.so.1
  smbd --version
  smbclient --version
  ```

  None of these should report `renameat2: symbol not found`.
- Deploy to the cluster and confirm the `samba-server` pod no longer terminates with exit code 255 and the SMB service comes up on port 445.

## Notes / follow-ups (not in this PR)

- `Dockerfile.media`, `Dockerfile.rclone`, `Dockerfile.seahub` should be reviewed for the same `alpine:edge` pattern in a separate change.
- The existing `HEALTHCHECK` line uses `--configfile=/etc/samba/samba.conf`, but the file copied in is `/etc/samba/smb.conf`. That looks like a pre-existing typo and is not related to this crash; it can be fixed separately.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-161cfcf7-3df1-46e5-9352-ecc466f5d336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-161cfcf7-3df1-46e5-9352-ecc466f5d336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

