### PR TITLE
fix(drivers/clouds): drop close(ch) to avoid send-on-closed panic

### DIFF
--- a/pkg/drivers/clouds/download.go
+++ b/pkg/drivers/clouds/download.go
@@ -54,8 +54,11 @@ func (d *Download) download() error {
 		err   error
 	}
 
+	// Buffered so the goroutine never blocks on send, even if we already
+	// returned via <-d.ctx.Done() and no one is reading. Do NOT close(ch)
+	// here: closing while the goroutine is still about to send would panic
+	// the entire process. Letting GC reclaim the channel is safe.
 	ch := make(chan asyncResult, 1)
-	defer close(ch)
 	go func() {
 		res, err := d.service.DownloadAsync(d.fileParam, d.fileTargetPath, d.fileName)
 		ch <- asyncResult{jobId: res, err: err}


### PR DESCRIPTION
## Summary

`Download.download` runs the cloud `DownloadAsync` call in a goroutine and races the result against `ctx.Done()`:

```go
ch := make(chan asyncResult, 1)
defer close(ch)
go func() {
    res, err := d.service.DownloadAsync(...)
    ch <- asyncResult{jobId: res, err: err}
}()

select {
case <-d.ctx.Done():
    return d.ctx.Err()
case resp = <-ch:
}
```

If the ``ctx.Done()`` branch fires first, the function returns and the
``defer close(ch)`` runs **before** the producer goroutine sends. The
subsequent ``ch <- ...`` then sends on a closed channel and panics the
whole server.

The fix is to drop the ``defer close(ch)``. The channel is buffered (1)
and the goroutine sends exactly once, so:

- The goroutine never blocks on send (buffer is empty).
- No one ever ranges over the channel.
- GC reclaims the channel once both sides drop their references.

## Test plan

- [ ] Cancel an in-flight cloud download (large file, S3) and confirm the process keeps running instead of crashing.
- [ ] Confirm the happy path (no cancel) still completes and returns the job id.

🤖 Generated with [Cursor](https://cursor.com)