### PR TITLE
chore(logs): drop auth tokens and Seafile upload uids from logs

### DIFF
--- a/pkg/hertz/biz/handler/upload/upload_service.go
+++ b/pkg/hertz/biz/handler/upload/upload_service.go
@@ -327,12 +327,12 @@ func SyncUploadChunksMethod(ctx context.Context, c *app.RequestContext) {
 	var originalUid = uid
 	if v, ok := seahub.GetAccessToken(uid); ok && v != "" {
 		uid = v
-		klog.Infof("[upload] Sync uploadChunks, uid: %s, originalUid: %s", uid, originalUid)
+		klog.V(4).Infof("[upload] Sync uploadChunks, using cached access token (path=%s, owner=%s)", requestPath, owner)
 	}
 
 	var executeRequest = func(uid string) (*http.Response, error) {
 		reqUrl := fmt.Sprintf("http://seafile:8082/%s/%s?ret-json=1", uploadType, uid)
-		klog.Infof("Sync uploadChunks, path: %s, owner: %s, uploadPath: %s, url: %s", requestPath, owner, uploadPath, reqUrl)
+		klog.Infof("Sync uploadChunks, path: %s, owner: %s, uploadPath: %s", requestPath, owner, uploadPath)
 
 		req, _ := http.NewRequest(http.MethodPost, reqUrl, bytes.NewReader(c.Request.Body()))
 
@@ -373,14 +373,14 @@ func SyncUploadChunksMethod(ctx context.Context, c *app.RequestContext) {
 			newUid, refreshErr := seahub.GetUploadLink(fileParam, "web", false, true)
 			if refreshErr == nil {
 				seahub.SetAccessToken(originalUid, newUid)
-				klog.Infof("[upload] Sync uploadChunks, update access token: %s -> %s", originalUid, newUid)
+				klog.V(4).Infof("[upload] Sync uploadChunks, refreshed access token (owner=%s, path=%s)", owner, requestPath)
 
 				resp, err = executeRequest(newUid)
 				if resp != nil {
 					defer resp.Body.Close()
 				}
 				if err == nil && resp.StatusCode == http.StatusOK {
-					klog.Infof("Retry success with new UID: %s", newUid)
+					klog.Infof("Sync uploadChunks: retry succeeded after token refresh (owner=%s, path=%s)", owner, requestPath)
 				}
 				if err != nil {
 					seahub.DeleteAccessToken(originalUid)

--- a/pkg/media/api/controllers/dynamic_hls_controller.go
+++ b/pkg/media/api/controllers/dynamic_hls_controller.go
@@ -376,10 +376,9 @@ func (d *DynamicHlsController) pathCommon(playPath, bflName string) (string, err
 	} else if fileParam.FileType == common.AwsS3 {
 		authToken, err := utils.GetAuthToken(bflName)
 		if err != nil {
-			klog.Infoln(err)
+			klog.Errorf("GetAuthToken failed for user=%s: %v", bflName, err)
 			return "", err
 		}
-		klog.Infoln(authToken)
 		accountResp, err := utils.GetToken(bflName, fileParam.Extend, fileParam.FileType, authToken)
 		if err != nil {
 			return "", err

--- a/pkg/media/api/helpers/streaming_helpers.go
+++ b/pkg/media/api/helpers/streaming_helpers.go
@@ -164,10 +164,9 @@ func GetStreamingState(
 		bflName := httpContext.Request.Header.Get(common.REQUEST_HEADER_OWNER)
 		authToken, err := utils.GetAuthToken(bflName)
 		if err != nil {
-			klog.Error(err)
+			klog.Errorf("[media] GetAuthToken failed for user=%s: %v", bflName, err)
 			return nil, err
 		}
-		klog.Infof("[media] protocol, authToken: %s", authToken)
 		fileParam, err := models.CreateFileParam(bflName, httpContext.Query("PlayPath"))
 		if err != nil {
 			klog.Infof("[media] GetStreamingState, parse url error: %v\n", err)


### PR DESCRIPTION
## Summary

Three log call sites still printed raw credentials at INFO level:

- `pkg/media/api/controllers/dynamic_hls_controller.go` logged the S3 auth token returned from `utils.GetAuthToken` via `klog.Infoln(authToken)`.
- `pkg/media/api/helpers/streaming_helpers.go` logged the same auth token with the prefix `[media] protocol, authToken: ...`.
- `pkg/hertz/biz/handler/upload/upload_service.go` logged Seafile upload uids (per-upload write tokens) on every chunk and on the token-refresh paths, including embedding them inside the proxied URL.

This continues the work started by the recent log-redaction PRs and brings the only remaining INFO-level token leaks I could find under control.

## Approach

Tokens are dropped from the logs entirely - **not** masked, not hashed.

- Where the call site only emitted the token as diagnostic noise, the line or field is removed.
- Where a "we hit the token cache" / "we refreshed the token" signal is genuinely useful for debugging, the line is kept at `V(4)` and logs only `owner` / `path` - never any token material.
- Error sites that previously logged a bare `err` (sometimes interleaved with a token print) now log `<context>: <err>` so the operator can tell which user / API call failed without the secret.

## Test plan

- [ ] Trigger an S3 HLS playback and confirm logs no longer contain the auth token in any form.
- [ ] Trigger a Seafile chunked upload that exercises the token-refresh path and confirm logs only show owner / path, never the uid.
- [ ] Run with `-v=4` and confirm the V(4) cache-hit / refresh debug lines still appear (without tokens).
