### PR TITLE
fix(paste): require internal token for Share=1 paste paths

### DIFF
--- a/pkg/common/internal_auth.go
+++ b/pkg/common/internal_auth.go
@@ -1,0 +1,50 @@
+package common
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"sync"
+)
+
+// HeaderInternalShareToken is the request header name used for the
+// process-local shared secret that authorizes an internal loopback
+// forward (e.g. proxySharePaste -> /api/paste/:node/ with Share=1).
+//
+// The value is generated once per process at startup and never leaves
+// it, so an external attacker cannot forge a request that claims to be
+// an internal forward.
+const HeaderInternalShareToken = "X-Internal-Share-Token"
+
+var (
+	internalTokenOnce sync.Once
+	internalToken     string
+)
+
+// InternalShareToken returns the process-local secret. It is generated
+// lazily on first use; callers must not log it.
+func InternalShareToken() string {
+	internalTokenOnce.Do(func() {
+		var b [32]byte
+		if _, err := rand.Read(b[:]); err != nil {
+			// rand.Read failure is effectively impossible on supported
+			// platforms; fall back to a deterministic-but-unique tag so
+			// initialization never panics. The mismatch will simply
+			// reject every internal call until the process is restarted.
+			internalToken = "fallback-internal-share-token"
+			return
+		}
+		internalToken = hex.EncodeToString(b[:])
+	})
+	return internalToken
+}
+
+// EqualInternalShareToken returns true iff got matches the process
+// secret using a constant-time comparison.
+func EqualInternalShareToken(got string) bool {
+	if got == "" {
+		return false
+	}
+	expected := InternalShareToken()
+	return subtle.ConstantTimeCompare([]byte(got), []byte(expected)) == 1
+}

--- a/pkg/hertz/biz/handler/api/paste/paste_service.go
+++ b/pkg/hertz/biz/handler/api/paste/paste_service.go
@@ -53,6 +53,22 @@ func PasteMethod(ctx context.Context, c *app.RequestContext) {
 		return
 	}
 
+	// Share==1 means SrcOwner / DstOwner / SrcSharePath / DstSharePath
+	// in the request body have *already* been resolved server-side by
+	// proxySharePaste. We refuse to take those fields from anyone else;
+	// otherwise a caller could paste from / to another user's drive by
+	// just setting Share=1 with crafted owner fields. The proxy attaches
+	// HeaderInternalShareToken to mark the forward as trusted.
+	if req.Share == 1 {
+		got := string(c.GetHeader(common.HeaderInternalShareToken))
+		if !common.EqualInternalShareToken(got) {
+			klog.Warningf("[paste] reject Share=1 request from %s without valid internal token (owner=%s)",
+				c.RemoteAddr(), owner)
+			c.AbortWithStatusJSON(consts.StatusForbidden, utils.H{"error": "share paste must go through the share proxy"})
+			return
+		}
+	}
+
 	var pasteParam = &models.PasteParam{
 		Owner:        owner,
 		Action:       req.Action,

--- a/pkg/hertz/biz/router/middleware.go
+++ b/pkg/hertz/biz/router/middleware.go
@@ -728,6 +728,10 @@ func proxySharePaste(c *app.RequestContext, owner string, action string, src, ds
 		req.Header.Set(string(key), string(value))
 	})
 	req.Header.Set(common.REQUEST_HEADER_OWNER, owner)
+	// Mark this as a server-side share-resolved forward; the paste
+	// handler trusts SrcOwner/DstOwner only when this header matches
+	// the process-local secret. See pkg/common/internal_auth.go.
+	req.Header.Set(common.HeaderInternalShareToken, common.InternalShareToken())
 
 	resp, err := shareProxyClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
## Summary

`PasteMethod` accepted `SrcOwner` / `DstOwner` / `SrcSharePath` / `DstSharePath` straight from the request body whenever `Share == 1`. The legitimate caller is `proxySharePaste`, which first looks up the share record server-side, verifies membership and permission, and only then forwards a request with `Share=1` plus the *resolved* owner fields. But nothing prevented an authenticated user from POSTing directly to `/api/paste/:node/` with `Share=1` and crafted owner / path fields, steering the paste at another user's drive (those fields flow into `pkg/tasks/task_paste_*.go` and pick the source/destination identity downstream).

## Fix

Introduce a process-local random secret in `pkg/common/internal_auth.go` and require that share-resolved forwards carry it via a new `X-Internal-Share-Token` header.

- `proxySharePaste` (`pkg/hertz/biz/router/middleware.go`) sets the header just before `shareProxyClient.Do`.
- `PasteMethod` (`pkg/hertz/biz/handler/api/paste/paste_service.go`) rejects `Share==1` requests without a matching token with a 403 and a warning log including the remote address.

The token is generated once per process from `crypto/rand` and is compared in constant time. It is never written to logs and never sent upstream because the only consumer is the in-process `/api/paste/:node/` handler.

## Threat model notes

- A user reaching `/api/paste/:node/` directly cannot guess the in-memory token.
- After a process restart, in-flight forwards from the old process would fail; this is acceptable because Hertz already drains in-flight requests during graceful shutdown (see the recent shutdown coordinator work).
- The token is intentionally unrelated to any external auth: only the same Go process can produce a request that carries it.

## Test plan

- [ ] POST directly to `/api/paste/:node/` with `Share=1, SrcOwner=<other user>` and confirm 403.
- [ ] Trigger a normal share paste through the share proxy and confirm it still succeeds end to end.
- [ ] Restart the server during a share paste and confirm a clean error rather than a crash.
