### PR TITLE
fix(media): replace runtime panics with logged early returns

### DIFF
--- a/pkg/media/api/controllers/dynamic_hls_controller.go
+++ b/pkg/media/api/controllers/dynamic_hls_controller.go
@@ -1111,8 +1111,9 @@ func (d *DynamicHlsController) GetCurrentTranscodingIndex(playlistPath, segmentE
 
 func GetLastTranscodingFile(playlistPath string, segmentExtension string, fileSystem ioo.IFileSystem) *ioo.FileSystemMetadata {
 	folder := filepath.Dir(playlistPath)
-	if folder == "" {
-		panic(fmt.Errorf("path can't be a root directory: %s", playlistPath))
+	if folder == "" || folder == "." {
+		klog.Errorf("GetLastTranscodingFile: invalid playlist path (no parent dir): %q", playlistPath)
+		return nil
 	}
 
 	filePrefix := filepath.Base(playlistPath)

--- a/pkg/media/mediabrowser/controller/mediaencoding/encoding_helper.go
+++ b/pkg/media/mediabrowser/controller/mediaencoding/encoding_helper.go
@@ -230,10 +230,12 @@ func (e *EncodingHelper) AttachMediaSourceInfo(
 	requestedUrl string,
 ) {
 	if state == nil {
-		panic("state is nil")
+		klog.Error("AttachMediaSourceInfo: state is nil, skipping")
+		return
 	}
 	if mediaSource == nil {
-		panic("mediaSource is nil")
+		klog.Error("AttachMediaSourceInfo: mediaSource is nil, skipping")
+		return
 	}
 
 	path := mediaSource.Path


### PR DESCRIPTION
## Summary

Two media helpers `panic` on unexpected input rather than failing the request:

- `GetLastTranscodingFile` in `pkg/media/api/controllers/dynamic_hls_controller.go` panics when `filepath.Dir(playlistPath) == ""`. The only caller (`GetCurrentTranscodingIndex`) already handles a `nil` return as "no file yet", so the panic just turns a recoverable edge case into a crashed server process.
- `EncodingHelper.AttachMediaSourceInfo` in `pkg/media/mediabrowser/controller/mediaencoding/encoding_helper.go` panics on a nil `state` or `mediaSource`. It is called from the transcoding manager and streaming helpers; nil inputs are upstream bugs, but they should not take down the whole server.

## Fix

- Replace the panics with `klog.Error` plus an early return.
- Tighten the `playlistPath` guard to also reject `"."`, which is what `filepath.Dir` returns when the input has no separator (otherwise the new branch is dead).
- Caller behaviour:
  - `GetLastTranscodingFile`'s caller already does `if file == nil { return nil }`, so this slots in cleanly.
  - `AttachMediaSourceInfo`'s callers continue with the unmodified `state`. That is no worse than the crashing behaviour today and the log line carries enough context to find the upstream nil.

## Test plan

- [ ] Trigger an HLS request with a playlist path that has no directory component and confirm the server logs the warning and returns gracefully instead of panicking.
- [ ] Run the regular transcoding flow end-to-end and confirm normal playback still works (no behaviour change in the happy path).
