### PR TITLE
fix(tasks): ClearTasks 用任务 id 删除而非指针

### DIFF
--- a/pkg/tasks/manager.go
+++ b/pkg/tasks/manager.go
@@ -309,7 +309,10 @@ func (t *taskManager) ClearTasks() {
 		if len(tasks) > 0 {
 			klog.Infof("Task remove %s tasks: %d", user, len(tasks))
 			for _, t := range tasks {
-				userPool.tasks.Delete(t)
+				// userPool.tasks stores entries keyed by task id (see
+				// Task.Execute -> LoadOrStore(t.id, t)); deleting by
+				// the *Task pointer would never match.
+				userPool.tasks.Delete(t.id)
 			}
 		}
 


### PR DESCRIPTION
## 概要

`pkg/tasks/manager.go` 的 `ClearTasks` 在收集完终态任务后，循环里调用了 `userPool.tasks.Delete(t)`，传入的是 `*Task` 指针；但任务进 `sync.Map` 时用的是 **字符串 id**（`Task.Execute` 中 `LoadOrStore(t.id, t)`）。指针 key 与字符串 key 永远不匹配，所以 `Delete` 实际上一次都没生效——已完成 / 失败 / 取消的任务无限堆积，每日 cron 的清理形同虚设。

## 改动

- `pkg/tasks/manager.go ClearTasks`：把 `userPool.tasks.Delete(t)` 改为 `userPool.tasks.Delete(t.id)`，并附上注释说明为什么 key 必须是 id。

## 验证方式

- [ ] 单元/手工：跑出几个 `Completed` / `Failed` / `Canceled` 任务，把 `createAt` 调整到 12 小时之前，触发 `ClearTasks`，确认 `userPool.tasks` 中对应 id 的条目消失。
- [ ] 走完一次正常的 paste 流程，确认进行中任务不被误删。


Made with [Cursor](https://cursor.com)