### PR TITLE
fix(share): GetExternalSharePath 修复 nil panic 与 token/path_id 越权 (IDOR)

### DIFF
--- a/pkg/hertz/biz/handler/api/share/share_service.go
+++ b/pkg/hertz/biz/handler/api/share/share_service.go
@@ -2289,7 +2289,22 @@ func GetExternalSharePath(ctx context.Context, c *app.RequestContext) {
 		return
 	}
 
-	expired, _ := time.Parse(time.RFC3339Nano, shareToken.ExpireAt)
+	// The token must be issued for *this* share. Without this check,
+	// any valid token could be paired with another share's path_id to
+	// read that share's metadata (IDOR).
+	if shareToken.PathID != req.PathId {
+		klog.Warningf("GetSharePath, token/path_id mismatch: token=%s wants path_id=%s, token belongs to path_id=%s",
+			req.Token, req.PathId, shareToken.PathID)
+		handler.RespErrorExpired(c, common.CodeTokenExpired, common.ErrorMessageTokenExpired, time.Now().Unix())
+		return
+	}
+
+	expired, err := time.Parse(time.RFC3339Nano, shareToken.ExpireAt)
+	if err != nil {
+		klog.Errorf("GetSharePath, parse token expire_at %q error: %v", shareToken.ExpireAt, err)
+		handler.RespErrorExpired(c, common.CodeTokenExpired, common.ErrorMessageTokenExpired, time.Now().Unix())
+		return
+	}
 	if time.Now().After(expired) {
 		handler.RespErrorExpired(c, common.CodeTokenExpired, common.ErrorMessageTokenExpired, expired.Unix())
 		return
@@ -2299,9 +2314,20 @@ func GetExternalSharePath(ctx context.Context, c *app.RequestContext) {
 	if err != nil {
 		klog.Errorf("GetSharePath, get path error: %v", err)
 		handler.RespErrorExpired(c, common.CodeLinkExpired, common.ErrorMessageLinkExpired, time.Now().Unix())
+		return
+	}
+	if sharePath == nil {
+		klog.Errorf("GetSharePath, path not found: %s", req.PathId)
+		handler.RespErrorExpired(c, common.CodeLinkExpired, common.ErrorMessageLinkExpired, time.Now().Unix())
+		return
 	}
 
-	expired, _ = time.Parse(time.RFC3339Nano, sharePath.ExpireTime)
+	expired, err = time.Parse(time.RFC3339Nano, sharePath.ExpireTime)
+	if err != nil {
+		klog.Errorf("GetSharePath, parse path expire_time %q error: %v", sharePath.ExpireTime, err)
+		handler.RespErrorExpired(c, common.CodeLinkExpired, common.ErrorMessageLinkExpired, time.Now().Unix())
+		return
+	}
 	if time.Now().After(expired) {
 		handler.RespErrorExpired(c, common.CodeLinkExpired, common.ErrorMessageLinkExpired, expired.Unix())
 		return


### PR DESCRIPTION
## 概要

`pkg/hertz/biz/handler/api/share/share_service.go` 的 `GetExternalSharePath` 同时存在两个问题：

### 1. 漏 \`return\` 导致 nil 解引用 panic

\`GetSharePath\` 出错时只调用了一次 \`RespErrorExpired\`，但 **没有 \`return\`**。后面紧接着的 \`time.Parse(time.RFC3339Nano, sharePath.ExpireTime)\` 会对 nil 的 \`sharePath\` 取字段，直接 panic 整个请求 goroutine。

### 2. token 与 path_id 不绑定（IDOR）

只校验了 \`shareToken\` 是否存在和过期，**没有校验 \`shareToken.PathID == req.PathId\`**。这意味着：
- 任意一个有效（未过期）的分享 token，
- 配上 **任意另一个分享的 \`path_id\`**，
- 就可以拉取那个分享的元数据（owner / 路径 / 上传限额 / 节点等）。

这是典型的 IDOR 越权读取。

## 改动

- 校验 \`shareToken.PathID == req.PathId\`，不一致按 token 过期处理并打 warning（含 token / 期望 path_id / token 实际归属 path_id）。
- \`GetSharePath\` 出错后补 \`return\`，并增加 \`sharePath == nil\` 的兜底分支。
- 把两处 \`time.Parse(...)\` 的错误从 \`_\` 改成显式判断：解析失败按相应过期错误处理（避免被静默归零成 \"零时间一定 < now\" 后误放行/误拒）。

## 验证方式

- [ ] 手工：用 token A 配 share path B 的 \`path_id\` 调 \`/api/share/get_share/?token=...&path_id=...\`，确认现在返回 \"token expired\" 而非 share B 的元数据。
- [ ] 手工：把 \`share_paths\` 表里某条 \`expire_time\` 改成非法字符串，调用同接口，确认返回 \"link expired\" 而不是 panic。
- [ ] 跑通正常的合法 token + 正确 path_id 调用，确认元数据照常返回。


Made with [Cursor](https://cursor.com)