### PR TITLE
fix(share): ResetPassword 补 return 与更新失败时的错误响应

### DIFF
--- a/pkg/hertz/biz/handler/api/share/share_service.go
+++ b/pkg/hertz/biz/handler/api/share/share_service.go
@@ -2345,6 +2345,7 @@ func ResetPassword(ctx context.Context, c *app.RequestContext) {
 	if err != nil {
 		klog.Errorf("ResetPassword, querySharePath error: %v", err)
 		handler.RespError(c, fmt.Sprintf("ResetPassword Error: %v", err))
+		return
 	}
 
 	if sharePath == nil {
@@ -2356,6 +2357,7 @@ func ResetPassword(ctx context.Context, c *app.RequestContext) {
 
 	if err = database.ResetExternalSharePasswordTx(sharePath); err != nil {
 		klog.Errorf("ResetPassword, update error: %v", err)
+		handler.RespError(c, fmt.Sprintf("ResetPassword Error: %v", err))
 		return
 	}
 


### PR DESCRIPTION
## 概要

\`pkg/hertz/biz/handler/api/share/share_service.go\` 的 \`ResetPassword\` 有两处控制流问题：

1. \`QueryShareById\` 出错时调用了一次 \`RespError\` 但 **没有 \`return\`**：
   - 如果 \`sharePath\` 非 nil，后续会再写一次响应（双写）。
   - 如果 \`sharePath\` 为 nil，会再走一次 nil 检查兜底，但中间这两步逻辑上是错的。
2. \`ResetExternalSharePasswordTx\` 失败时只 \`klog.Errorf\` + 裸 \`return\`，**完全不给客户端写响应**，前端只能等到超时。

## 改动

- \`QueryShareById\` 错误分支补 \`return\`。
- \`ResetExternalSharePasswordTx\` 失败时补 \`handler.RespError(...)\` 并 \`return\`。

## 验证方式

- [ ] 手工：构造 \`QueryShareById\` 出错（例如把 path_id 改成不存在的 uuid 同时让查询报错），确认只收到一次错误响应。
- [ ] 手工：模拟 \`ResetExternalSharePasswordTx\` 失败（例如临时把 DB 写权限拿掉），确认前端能收到 \"ResetPassword Error: ...\" 而不是请求挂住。
- [ ] 正常路径调用 \`PUT /api/share/share_password/\`，确认仍返回 \`{code:0}\`。


Made with [Cursor](https://cursor.com)