### PR TITLE
fix(tasks): rsync 失败不再被静默吞掉

### DIFF
--- a/pkg/tasks/task_paste_posix.go
+++ b/pkg/tasks/task_paste_posix.go
@@ -143,7 +143,15 @@ func (t *Task) rsync() error {
 	_, err = common.ExecRsync(t.ctx, rsync, args, t.updateProgressRsync)
 	if err != nil {
 		klog.Errorf("exec rsync error: %v", err)
-		return nil
+		// If the task was canceled, return the bare context error so
+		// Task.Execute matches it against TaskCancel == "context canceled"
+		// and transitions to Canceled/Paused. Otherwise surface the
+		// failure (returning nil here previously made a failed rsync
+		// look successful - silent data loss).
+		if cerr := t.ctx.Err(); cerr != nil {
+			return cerr
+		}
+		return fmt.Errorf("rsync %s -> %s: %v", srcPath, dstPath, err)
 	}
 	if strings.HasSuffix(dstPath, "/") {
 		err = files.ChownRecursive(dstPath, 1000, 1000)


### PR DESCRIPTION
## 概要

\`pkg/tasks/task_paste_posix.go\` 的 \`(*Task).rsync\` 在 \`ExecRsync\` 出错时只 \`klog.Errorf\` 一下，然后 \`return nil\`。这意味着：

- rsync 实际失败（部分文件没复制、目标盘满、权限错误等），但 phase 函数返回 nil；
- \`Task.Execute\` 把任务标成 **\`Completed\`**；
- 上层 UI 看到"成功"，紧接着的删除源文件 / 后续 phase 就可能执行——典型的静默数据丢失。

## 改动

把 rsync 的错误正常返回。同时为了不破坏取消语义：

- 如果 \`t.ctx\` 已被取消（\`t.ctx.Err() != nil\`），返回 **裸 ctx 错误**。\`Task.Execute\` 中存在 \`if errmsg == TaskCancel\` 分支（\`TaskCancel = \"context canceled\"\`，见 \`pkg/tasks/manager.go:35\`），返回 \`context.Canceled\` 时 \`Error()\` 字符串就是 \"context canceled\"，能被正确识别为 Canceled/Paused。
- 否则用 \`fmt.Errorf(\"rsync %s -> %s: %v\", ...)\` 包装并返回，由 \`Execute\` 走 Failed 分支（消息会被记入 \`task.message\`）。

## 验证方式

- [ ] 手工：让目标路径不可写（比如目录权限），触发 paste，确认任务最终是 \`Failed\` 而非 \`Completed\`，错误信息中含 srcPath/dstPath。
- [ ] 手工：在 rsync 进行中调用 \`PauseTask\`/\`CancelTask\`，确认任务被识别为 \`Paused\`/\`Canceled\` 而不是 \`Failed\`。
- [ ] 正常 paste 流程能够 \`Completed\`，不打印 rsync error。


Made with [Cursor](https://cursor.com)