### PR TITLE
fix(files): Chown 不再被 Chmod 覆盖丢失错误

### DIFF
--- a/pkg/files/fileutils.go
+++ b/pkg/files/fileutils.go
@@ -301,18 +301,29 @@ func Chown(fs afero.Fs, path string, uid, gid int) error {
 		klog.Infof("Function Chown execution time: %v\n", elapsed)
 	}()
 
-	var err error = nil
-	if fs == nil {
-		err = os.Chown(path, uid, gid)
-		err = os.Chmod(path, 0775)
-	} else {
-		err = fs.Chown(path, uid, gid)
-		err = fs.Chmod(path, 0775)
+	chown := os.Chown
+	chmod := os.Chmod
+	if fs != nil {
+		chown = fs.Chown
+		chmod = fs.Chmod
 	}
-	if err != nil {
-		klog.Errorf("can't chown directory %s to user %d: %s", path, uid, err)
+
+	var errs []error
+	if err := chown(path, uid, gid); err != nil {
+		// Previously this assignment was overwritten by Chmod's result
+		// on the next line, silently dropping ownership errors.
+		errs = append(errs, fmt.Errorf("chown %s to %d:%d: %w", path, uid, gid, err))
 	}
-	return err
+	if err := chmod(path, 0775); err != nil {
+		errs = append(errs, fmt.Errorf("chmod %s to 0775: %w", path, err))
+	}
+
+	if len(errs) > 0 {
+		err := e.Join(errs...)
+		klog.Errorf("can't chown/chmod directory %s to user %d: %s", path, uid, err)
+		return err
+	}
+	return nil
 }
 
 func createAndChownDir(fs afero.Fs, path string, mode os.FileMode, uid, gid int) error {


### PR DESCRIPTION
## 概要

\`pkg/files/fileutils.go\` 的 \`Chown\` 实现有一个非常隐蔽的 bug：

\`\`\`go
var err error = nil
if fs == nil {
    err = os.Chown(path, uid, gid)   // <-- err 在这里
    err = os.Chmod(path, 0775)        // <-- 立刻被 chmod 的结果覆盖
} else {
    err = fs.Chown(path, uid, gid)
    err = fs.Chmod(path, 0775)
}
\`\`\`

只要 \`Chmod\` 成功，\`Chown\` 的失败就被静默吞掉，调用方拿到 \`nil\`，文件实际属主仍是错误的（这在容器里以 root 跑、之后切到 1000:1000 的场景中后果尤为严重）。

## 改动

- 不再复用同一个 \`err\` 变量。两次调用的错误都收集到 \`errs []error\`，最终用 \`errors.Join\` 合并返回。
- 错误消息加上路径和目标 uid:gid，便于排查。

文件已经把 \`errors\` 包以别名 \`e\` 引入，沿用同一别名 \`e.Join\`。

## 验证方式

- [ ] 单元/手工：构造一个目录，让其 owner 不可改（例如非 root 跑 \`Chown\` 到 0:0），原本会返回 nil；现在应该返回包含 \"chown ... permission denied\" 的错误。
- [ ] 正常路径下没有 chown/chmod 失败时仍返回 nil。


Made with [Cursor](https://cursor.com)