### PR TITLE
fix(files): GetFileNameFromPath 处理无分隔符输入避免越界 panic

### DIFF
--- a/pkg/files/fileutils.go
+++ b/pkg/files/fileutils.go
@@ -700,11 +700,19 @@ func GetFileNameFromPath(s string) (string, bool) {
 	} else if s == "" {
 		return "", true
 	}
+	// Note: the second return value is "is *not* a file" - i.e. it
+	// returns true when the input ends with "/". The historic name of
+	// this flag is preserved.
 	var isFile = strings.HasSuffix(s, "/")
 	var tmp = strings.TrimSuffix(s, "/")
 	var p = strings.LastIndex(tmp, "/")
-	var r = tmp[p:]
-	r = strings.Trim(r, "/")
+	if p < 0 {
+		// No "/" in tmp - it's already a bare basename. The previous
+		// implementation did `tmp[p:]` here, which is `tmp[-1:]` and
+		// panics on slice bounds.
+		return tmp, !isFile
+	}
+	r := strings.Trim(tmp[p:], "/")
 
 	return r, !isFile
 }


### PR DESCRIPTION
## 概要

\`pkg/files/fileutils.go\` 的 \`GetFileNameFromPath\`：

\`\`\`go
var tmp = strings.TrimSuffix(s, \"/\")
var p = strings.LastIndex(tmp, \"/\")
var r = tmp[p:]   // <-- 如果 tmp 不含 \"/\"，p == -1，tmp[-1:] 直接 panic
\`\`\`

只要传入的字符串不含 \"/\"（例如一个未规范化的单段名），就会触发 \`runtime error: slice bounds out of range [-1:]\`，请求 goroutine 当场挂掉。

## 改动

显式处理 \`p < 0\` 分支：此时输入本身就是一个 basename，直接返回。

## 验证方式

- [ ] \`GetFileNameFromPath(\"foo.txt\")\` 不再 panic，返回 \`(\"foo.txt\", true)\`。
- [ ] \`GetFileNameFromPath(\"/a/b/c\")\` 仍返回 \`(\"c\", true)\`、\`GetFileNameFromPath(\"/a/b/\")\` 返回 \`(\"b\", false)\`、\`GetFileNameFromPath(\"/\")\` 返回 \`(\"\", false)\`、\`GetFileNameFromPath(\"\")\` 返回 \`(\"\", true)\`，行为不变。


Made with [Cursor](https://cursor.com)