### PR TITLE
fix(files): detectSubtitles 用 path.Dir 取父目录而非 TrimRight 字符集

### DIFF
--- a/pkg/files/file.go
+++ b/pkg/files/file.go
@@ -474,7 +474,14 @@ func (i *FileInfo) detectSubtitles() {
 	_, ext := common.SplitNameExt(i.Path)
 
 	// detect multiple languages. Base*.vtt
-	parentDir := strings.TrimRight(i.Path, i.Name)
+	//
+	// NOTE: previously this used `strings.TrimRight(i.Path, i.Name)`,
+	// which treats i.Name as a *cutset of runes* rather than a suffix
+	// to strip. For "/foo/bar/baz.mp4" with Name="baz.mp4" it stripped
+	// every trailing 'b','a','z','.','m','p','4' rune, producing
+	// "/foo/" or worse - subtitle detection silently broke for almost
+	// all real filenames. path.Dir gives us the actual parent.
+	parentDir := path.Dir(i.Path)
 	dir, err := afero.ReadDir(i.Fs, parentDir)
 	if err == nil {
 		base := strings.TrimSuffix(i.Name, ext)


### PR DESCRIPTION
## 概要

\`pkg/files/file.go\` 的 \`detectSubtitles\` 用：

\`\`\`go
parentDir := strings.TrimRight(i.Path, i.Name)
\`\`\`

\`strings.TrimRight\` 的第二个参数是 **字符集**（cutset of runes），不是字符串后缀。对一个 video 文件 \`/foo/bar/baz.mp4\`、\`Name = \"baz.mp4\"\`：

- 字符集 = \`{'b','a','z','.','m','p','4'}\`
- 从右往左剥所有命中字符集的 rune
- 结果可能是 \`\"/foo/\"\`，或者对其它文件名是更糟糕的串

随后的 \`afero.ReadDir(i.Fs, parentDir)\` 要么读到错误的目录、要么直接报错——**几乎所有真实视频文件都拿不到字幕检测结果**。

## 改动

用 \`path.Dir(i.Path)\` 取真正的父目录，并加注释说明历史 bug。

## 验证方式

- [ ] 在某个目录下放 \`movie.mp4\` + \`movie.en.vtt\`，访问 \`movie.mp4\` 的 file info，确认 \`Subtitles\` 字段包含 \`movie.en.vtt\` 的路径。
- [ ] 视频文件名包含父目录名中的字符（如 \`/abc/abcdef.mp4\`）时，字幕检测仍然落在 \`/abc\`，而非被乱剥成奇怪的路径。


Made with [Cursor](https://cursor.com)