### PR TITLE
fix(tasks): DownloadFromFiles 在 Do 失败时不再对 nil resp.Body 调 Close

### DIFF
--- a/pkg/tasks/task_paste_download.go
+++ b/pkg/tasks/task_paste_download.go
@@ -171,7 +171,9 @@ func (t *Task) DownloadFromFiles() error {
 		downloadResp, err = streamHTTPClient.Do(downloadReq)
 		if err != nil {
 			klog.Errorf("[Task] Id: %s, download failed, url: %s, error: %v", t.id, downloadUrl, err)
-			downloadResp.Body.Close()
+			// On Do error the response is typically nil; touching
+			// downloadResp.Body would panic. Just break - there is
+			// nothing to close.
 			break
 		}
 


### PR DESCRIPTION
## 概要

\`pkg/tasks/task_paste_download.go\` 在下载循环里：

\`\`\`go
downloadResp, err = streamHTTPClient.Do(downloadReq)
if err != nil {
    klog.Errorf(\"[Task] Id: %s, download failed, url: %s, error: %v\", t.id, downloadUrl, err)
    downloadResp.Body.Close()   // <-- 这里
    break
}
\`\`\`

按 Go 的 \`net/http\` 文档，当 \`Do\` 返回非 nil error 时，**Response 通常是 nil**。这一行 \`downloadResp.Body.Close()\` 会触发 nil 指针解引用，把任务 worker goroutine 直接 panic 掉——只要下载端点拒绝或超时就触发。

## 改动

去掉这次 \`Body.Close()\`：Do 出错时本来就没有可关闭的 body。

## 验证方式

- [ ] 手工：把 \`filesServerIp\` 改成不可达端口，触发 download phase；任务应当走 Failed 而不是 panic。
- [ ] 正常下载流程不受影响。


Made with [Cursor](https://cursor.com)