### PR TITLE
fix(tasks): DownloadFromFiles 把任务 ctx 串到 HTTP 请求

### DIFF
--- a/pkg/tasks/task_paste_download.go
+++ b/pkg/tasks/task_paste_download.go
@@ -43,7 +43,7 @@ func (t *Task) DownloadFromFiles() error {
 	var filesServerIp = filesServer.Status.PodIP
 
 	filesServerUrl := fmt.Sprintf("http://%s/api/tree/%s/%s/%s", filesServerIp, src.FileType, src.Extend, strings.TrimPrefix(src.Path, "/"))
-	filesListsReq, err := http.NewRequest("GET", filesServerUrl, nil)
+	filesListsReq, err := http.NewRequestWithContext(t.ctx, "GET", filesServerUrl, nil)
 	if err != nil {
 		return err
 	}
@@ -158,7 +158,7 @@ func (t *Task) DownloadFromFiles() error {
 		klog.Infof("[Task] Id: %s, download file url %s, write file: %s", t.id, downloadUrl, filePath)
 
 		var downloadReq *http.Request
-		downloadReq, err = http.NewRequest("GET", downloadUrl, nil)
+		downloadReq, err = http.NewRequestWithContext(t.ctx, "GET", downloadUrl, nil)
 		if err != nil {
 			klog.Errorf("[Task] Id: %s, download new request failed, url: %s, error: %v", t.id, downloadUrl, err)
 			break


### PR DESCRIPTION
## 概要

\`pkg/tasks/task_paste_download.go\` 的两次 \`http.NewRequest\`（一次拉文件树、一次拉单个文件）都没带任何 context。任务被 Pause / Cancel 时只有读循环里调用了 \`t.isCancel()\` 检测，但：

- 慢的 dial、慢的服务端响应头阶段、连接被 hang 住 ⇒ 整个 HTTP roundtrip 仍然挂着
- 任务的 ctx 已经 cancel，但传输层没有任何信号
- 取消语义滞后，最坏情况下 worker goroutine 一直占着不放

## 改动

把两处 \`http.NewRequest(\"GET\", ...)\` 改为 \`http.NewRequestWithContext(t.ctx, \"GET\", ...)\`。\`net/http\` Transport 看到 ctx cancel 会立刻终止 dial / 读 header / 读 body，cancellation 立刻生效。

## 验证方式

- [ ] 手工：让 \`filesServerIp\` 上的端口接受连接但不返回数据（\`nc -l\`），触发 download；调用 \`CancelTask\`，确认 worker 立刻退出而不是停在 read header 上。
- [ ] 正常下载流程不受影响。


Made with [Cursor](https://cursor.com)