### PR TITLE
fix(tasks): move() 用 t.ctx 替代 context.Background

### DIFF
--- a/pkg/tasks/task_paste_posix.go
+++ b/pkg/tasks/task_paste_posix.go
@@ -1,7 +1,6 @@
 package tasks
 
 import (
-	"context"
 	"files/pkg/common"
 	"files/pkg/files"
 	"fmt"
@@ -183,7 +182,13 @@ func (t *Task) move() error {
 
 	var args = []string{srcPath, dstPath}
 
-	if _, err = common.ExecCommand(context.Background(), mv, args); err != nil {
+	if _, err = common.ExecCommand(t.ctx, mv, args); err != nil {
+		// Match the rsync handler: if cancellation already happened,
+		// surface the bare context error so Task.Execute maps it to
+		// Canceled/Paused (TaskCancel == "context canceled").
+		if cerr := t.ctx.Err(); cerr != nil {
+			return cerr
+		}
 		return fmt.Errorf("exec mv error: %v", err)
 	}
 


### PR DESCRIPTION
## 概要

\`pkg/tasks/task_paste_posix.go\` 的 \`(*Task).move\`：

\`\`\`go
if _, err = common.ExecCommand(context.Background(), mv, args); err != nil { ... }
\`\`\`

用了 \`context.Background()\` 而不是 \`t.ctx\`。结果就是：

- \`PauseTask\` / \`CancelTask\` 通过 \`t.ctxCancel()\` 通知任务退出；
- 其它 phase（rsync 等）会响应；
- 但 mv 这一步 **完全收不到取消信号**——长 mv（跨 FS rename 退化成 copy+remove）会一直跑下去；
- 任务"已取消"和实际进程之间状态不一致。

## 改动

- \`ExecCommand(t.ctx, mv, args)\`，让 mv 子进程随任务 ctx 一起被中断。
- 取消的情况下返回 \`t.ctx.Err()\`，跟 \`rsync\` 一致——\`Task.Execute\` 中 \`TaskCancel == \"context canceled\"\` 字符串匹配能正确识别为 Canceled / Paused。
- 顺手把 \`\"context\"\` 这个不再使用的 import 去掉。

## 验证方式

- [ ] 手工：构造一个跨设备 move（rename 会失败、退化为 mv 复制+删除），在 mv 中途调 \`CancelTask\`，确认 worker 退出且任务状态为 Canceled。
- [ ] 正常 paste 流程不受影响。


Made with [Cursor](https://cursor.com)