### PR TITLE
fix(clouds): rclone "job not found" 不再被当成下载成功

### DIFF
--- a/pkg/drivers/clouds/download.go
+++ b/pkg/drivers/clouds/download.go
@@ -98,8 +98,13 @@ func (d *Download) download() error {
 			return nil
 		}
 
+		// "job not found" used to fall through as success, masking
+		// real failures (rclone evicted the job, the daemon was
+		// restarted, jobid leaked across processes, ...). Treat it
+		// as a hard error so the caller can decide to retry instead
+		// of believing an unfinished download succeeded.
 		if res.Error == "job not found" {
-			return nil
+			return errors.New("rclone job not found (id=" + common.ToJson(resp.jobId) + "); download did not finish")
 		}
 
 		if !res.Success && !res.Finished {


### PR DESCRIPTION
## 概要

\`pkg/drivers/clouds/download.go\` 在轮询 \`QueryJob\` 的循环里有：

\`\`\`go
if res.Error == \"job not found\" {
    return nil   // <-- 当成成功
}
\`\`\`

返回 nil 等于告诉上层"下载完成"。但 rclone 报 \"job not found\" 实际意思是 **rclone 丢了这个 job**（daemon 重启、job 被淘汰、jobid 跨进程串了等），**文件并没有真正落盘**。上层任务会接着做 chown、改名到最终路径、删 temp / 源——这是一条静默数据丢失链路。

## 改动

把这个分支改为返回错误（包含 jobId 便于排查）：

\`\`\`go
return errors.New(\"rclone job not found (id=...); download did not finish\")
\`\`\`

调用方（paste 任务）已经会把下载错误归为 Failed，是否重试由上层决定。

## 验证方式

- [ ] 手工：下载过程中 \`docker restart rclone\`（让 jobid 失效），确认任务现在是 \`Failed\`、错误信息含 \"job not found\" 字样，而不是 \`Completed\`。
- [ ] 正常下载流程不受影响。


Made with [Cursor](https://cursor.com)