### PR TITLE
fix(files): MountPathIncluster 错误分支补 Close response body

### DIFF
--- a/pkg/files/file.go
+++ b/pkg/files/file.go
@@ -156,12 +156,16 @@ func MountPathIncluster(r *http.Request) (map[string]interface{}, error) {
 
 		respBody, err := io.ReadAll(resp.Body)
 		if err != nil {
+			// Previously this early return left resp.Body unread/unclosed,
+			// leaking the connection. Close before bailing out.
+			_ = resp.Body.Close()
 			return nil, err
 		}
 
 		var responseMap map[string]interface{}
 		err = json.Unmarshal(respBody, &responseMap)
 		if err != nil {
+			_ = resp.Body.Close()
 			return nil, err
 		}
 


### PR DESCRIPTION
## 概要

\`pkg/files/file.go\` 的 \`MountPathIncluster\` 在循环体里只在某条快乐路径上显式 \`resp.Body.Close()\`，但两处提前 \`return nil, err\`：

\`\`\`go
respBody, err := io.ReadAll(resp.Body)
if err != nil {
    return nil, err   // <-- 没 Close
}
var responseMap map[string]interface{}
err = json.Unmarshal(respBody, &responseMap)
if err != nil {
    return nil, err   // <-- 没 Close
}
\`\`\`

每次 \`ReadAll\` / \`Unmarshal\` 失败都漏一个 HTTP 连接（及其底层 fd）。重复失败下，TerminusdHTTPClient 的连接池 / 文件描述符会被耗尽。

## 改动

在两处提前返回前补 \`_ = resp.Body.Close()\`。

## 验证方式

- [ ] 手工：让 TerminusdHost 返回非 JSON 内容；多次触发挂载，确认进程的 fd 数不会随请求次数线性增长。
- [ ] 正常路径不受影响。


Made with [Cursor](https://cursor.com)