### PR TITLE
fix(preview): 局部化 Store/Chown 的 error，避免被互相覆盖

### DIFF
--- a/pkg/preview/preview.go
+++ b/pkg/preview/preview.go
@@ -103,13 +103,19 @@ func CreatePreview(owner string, key string,
 		return nil, err
 	}
 
-	// store
-	if err = fileCache.Store(context.TODO(), owner, key, common.CacheThumb, buf.Bytes()); err != nil {
-		klog.Errorf("preview store failed, user: %s, error: %v", owner, err)
+	// Cache the rendered preview. Failures here are intentionally
+	// non-fatal: we still have the bytes in `buf` and can serve them
+	// to the caller, the next request will just have to render again.
+	// Use a separate variable so a later call does not overwrite this
+	// error reference (the previous code shared `err` across Store /
+	// Chown / return, making it easy to lose information silently in
+	// future edits).
+	if cerr := fileCache.Store(context.TODO(), owner, key, common.CacheThumb, buf.Bytes()); cerr != nil {
+		klog.Errorf("preview store failed, user: %s, key: %s, error: %v", owner, key, cerr)
 	}
 
-	if err = files.Chown(bufferFile.Fs, bufferFile.Path, 1000, 1000); err != nil {
-		klog.Errorf("can't chown file %s to user %d: %s", bufferFile.Path, 1000, err)
+	if cerr := files.Chown(bufferFile.Fs, bufferFile.Path, 1000, 1000); cerr != nil {
+		klog.Errorf("can't chown file %s to user %d: %s", bufferFile.Path, 1000, cerr)
 	}
 
 	return buf.Bytes(), nil


### PR DESCRIPTION
## 概要

\`pkg/preview/preview.go\` 在 resize 后做两件事：写缓存 (\`fileCache.Store\`) 和 chown buffer 文件，最后返回 \`buf.Bytes(), nil\`。

原代码两次副作用都把错误写到 **同一个外层 \`err\` 变量**：

\`\`\`go
if err = fileCache.Store(...); err != nil { klog.Errorf(...) }   // 写入 err
if err = files.Chown(...);    err != nil { klog.Errorf(...) }   // 覆盖 err
return buf.Bytes(), nil
\`\`\`

今天恰好返回 \`nil\` 表示"best-effort cache"——这没问题。但 \`err\` 共享让意图变得脆弱：以后任何人想"如果 store 失败就返回错误"或"在 chown 之后再判一次 err"，都会因为变量复用，**默默丢掉其中一个分支的错误信息**。

## 改动

- 把 Store 和 Chown 的错误改成局部变量 \`cerr\`，互不影响。
- 日志加上更多上下文（owner、key、path）便于排查。
- 函数仍返回 \`buf.Bytes(), nil\`：缓存失败不影响这次响应。注释里写明这是 \"best effort\" 契约。

## 验证方式

- [ ] 单元/手工：让 Store 报错、Chown 也报错，确认两条 \`klog.Errorf\` 都被打出来；调用方仍能拿到预览字节。
- [ ] 正常路径不受影响。


Made with [Cursor](https://cursor.com)