### PR TITLE
fix(files): Listing 去掉未使用的 sync.Mutex 并改指针接收（修 copylocks）

### DIFF
--- a/pkg/files/listing.go
+++ b/pkg/files/listing.go
@@ -3,12 +3,17 @@ package files
 import (
 	"sort"
 	"strings"
-	"sync"
 
 	"github.com/maruel/natural"
 )
 
 // Listing is a collection of files.
+//
+// NOTE: Listing previously embedded sync.Mutex but no caller in the
+// repo ever locked it. Combined with `ApplySort` being declared on a
+// value receiver, this triggered `go vet copylocks` warnings every
+// time a Listing value was copied (e.g. through `byName(l)` below).
+// The mutex has been removed because it was never load-bearing.
 type Listing struct {
 	Items         []*FileInfo `json:"items"`
 	NumDirs       int         `json:"numDirs"`
@@ -17,20 +22,22 @@ type Listing struct {
 	Sorting       Sorting     `json:"sorting"`
 	Size          int64       `json:"size"`
 	FileSize      int64       `json:"fileSize"`
-	sync.Mutex
 }
 
 // ApplySort applies the sort order using .Order and .Sort
-func (l Listing) ApplySort() {
+func (l *Listing) ApplySort() {
+	if l == nil {
+		return
+	}
 	// Check '.Order' to know how to sort
 	if !l.Sorting.Asc {
 		switch l.Sorting.By {
 		case "name":
-			sort.Sort(sort.Reverse(byName(l)))
+			sort.Sort(sort.Reverse(byName(*l)))
 		case "size":
-			sort.Sort(sort.Reverse(bySize(l)))
+			sort.Sort(sort.Reverse(bySize(*l)))
 		case "modified":
-			sort.Sort(sort.Reverse(byModified(l)))
+			sort.Sort(sort.Reverse(byModified(*l)))
 		default:
 			// If not one of the above, do nothing
 			return
@@ -38,13 +45,13 @@ func (l Listing) ApplySort() {
 	} else { // If we had more Orderings we could add them here
 		switch l.Sorting.By {
 		case "name":
-			sort.Sort(byName(l))
+			sort.Sort(byName(*l))
 		case "size":
-			sort.Sort(bySize(l))
+			sort.Sort(bySize(*l))
 		case "modified":
-			sort.Sort(byModified(l))
+			sort.Sort(byModified(*l))
 		default:
-			sort.Sort(byName(l))
+			sort.Sort(byName(*l))
 			return
 		}
 	}


### PR DESCRIPTION
## 概要

\`pkg/files/listing.go\` 的 \`Listing\` 内嵌了 \`sync.Mutex\`，但仓库里 **没有任何地方调用 Lock/Unlock**。同时 \`ApplySort\` 使用值接收（\`func (l Listing) ApplySort()\`），每次调用都复制整个 \`Listing\`，包括内嵌的 Mutex——\`go vet copylocks\` 直接报警告。

复制带 Mutex 的 struct 在 Go 里语义上是错的：复制后两个 Mutex 实例完全独立、谁锁谁解锁都不再保护原 struct。

## 改动

- 去掉 \`Listing\` 上的 \`sync.Mutex\` 嵌入：从来没用到，加它就是埋坑。
- 把 \`ApplySort\` 改成指针接收 \`func (l *Listing) ApplySort()\`，加 \`if l == nil { return }\` 兜底。
- \`byName(l)\`/\`bySize(l)\`/\`byModified(l)\` 这种类型转换处改为 \`byName(*l)\` 等：转换的是 Listing 值，但 Items 是 slice header，元素 swap 仍然落到原数组上，外部行为不变。
- 移除 \`sync\` import。

## 验证方式

- [ ] \`go vet ./pkg/files/\` 不再报 \`assignment copies lock value\`。
- [ ] \`go build ./pkg/files/ ./pkg/drivers/posix/... ./pkg/drivers/sync/...\` 通过。
- [ ] 手工：触发文件列表排序（按 name/size/modified，asc/desc 各试一次），结果与之前一致。


Made with [Cursor](https://cursor.com)