### PR TITLE
fix(tasks): 用 sync.RWMutex 保护 Task 状态字段，消除 worker/HTTP 间 race

### DIFF
--- a/pkg/tasks/manager.go
+++ b/pkg/tasks/manager.go
@@ -102,18 +102,22 @@ func (t *taskManager) ResumeTask(owner, taskId string) error {
 
 	var task = val.(*Task)
 
-	if task.state != common.Paused {
-		return fmt.Errorf("task is not paused")
-	}
-
 	var ctx, cancel = context.WithCancel(context.Background())
 
+	task.mu.Lock()
+	if task.state != common.Paused {
+		task.mu.Unlock()
+		cancel()
+		return fmt.Errorf("task is not paused")
+	}
 	task.ctx = ctx
 	task.ctxCancel = cancel
 	task.suspend = false
 	task.state = common.Pending
+	funcs := task.funcs
+	task.mu.Unlock()
 
-	return task.Execute(task.funcs...)
+	return task.Execute(funcs...)
 }
 
 // pause
@@ -128,12 +132,15 @@ func (t *taskManager) PauseTask(owner, taskId string) error {
 
 	var task = val.(*Task)
 
+	task.mu.Lock()
 	if task.state != common.Pending && task.state != common.Running {
+		task.mu.Unlock()
 		return fmt.Errorf("task is not pending or running")
 	}
-
 	task.suspend = true
 	task.wasPaused = true
+	task.mu.Unlock()
+
 	go task.Cancel()
 
 	return nil
@@ -159,7 +166,9 @@ func (t *taskManager) CancelTask(owner, taskId string, all string) {
 	}
 
 	task := val.(*Task)
+	task.mu.Lock()
 	task.suspend = false
+	task.mu.Unlock()
 	go task.Cancel()
 }
 
@@ -177,6 +186,7 @@ func (t *taskManager) GetTask(owner string, taskId string, status string) []*Tas
 	}
 
 	task := val.(*Task)
+	snap := task.snapshot()
 
 	var src = task.param.Src
 	var dst = task.param.Dst
@@ -207,14 +217,14 @@ func (t *taskManager) GetTask(owner string, taskId string, status string) []*Tas
 		Dst:           dstUri,
 		DstPath:       dstFileName,
 		Src:           srcUri,
-		CurrentPhase:  task.currentPhase,
-		TotalPhases:   task.totalPhases,
-		Progress:      task.progress,
-		Transferred:   task.transfer,
-		TotalFileSize: task.totalSize,
-		TidyDirs:      task.tidyDirs,
-		Status:        task.state,
-		ErrorMessage:  task.message,
+		CurrentPhase:  snap.CurrentPhase,
+		TotalPhases:   snap.TotalPhases,
+		Progress:      snap.Progress,
+		Transferred:   snap.Transfer,
+		TotalFileSize: snap.TotalSize,
+		TidyDirs:      snap.TidyDirs,
+		Status:        snap.State,
+		ErrorMessage:  snap.Message,
 		PauseAble:     pauseAble,
 	}
 
@@ -226,26 +236,34 @@ func (t *taskManager) GetTask(owner string, taskId string, status string) []*Tas
 func (t *taskManager) GetTasksByStatus(owner, status string) []*TaskInfo {
 	userPool := t.getOrCreateUserPool(owner)
 
-	var tasks []*Task
+	type taskWithSnap struct {
+		task *Task
+		snap taskSnapshot
+	}
+
+	var tasks []taskWithSnap
 	var result []*TaskInfo
 	userPool.tasks.Range(func(key, value any) bool {
 		task := value.(*Task)
-		if strings.Contains(status, task.state) {
-			tasks = append(tasks, task)
+		snap := task.snapshot()
+		if strings.Contains(status, snap.State) {
+			tasks = append(tasks, taskWithSnap{task: task, snap: snap})
 		}
 
 		return true
 	})
 
-	if tasks == nil || len(tasks) == 0 {
+	if len(tasks) == 0 {
 		return result
 	}
 
 	sort.Slice(tasks, func(i, j int) bool {
-		return tasks[i].createAt.Before(tasks[j].createAt) // asc
+		return tasks[i].task.createAt.Before(tasks[j].task.createAt) // asc
 	})
 
-	for _, task := range tasks {
+	for _, ts := range tasks {
+		task := ts.task
+		snap := ts.snap
 		var src = task.param.Src
 		var dst = task.param.Dst
 
@@ -270,14 +288,14 @@ func (t *taskManager) GetTasksByStatus(owner, status string) []*TaskInfo {
 			Dst:           dstUri,
 			DstPath:       dstFileName,
 			Src:           srcUri,
-			CurrentPhase:  task.currentPhase,
-			TotalPhases:   task.totalPhases,
-			Progress:      task.progress,
-			Transferred:   task.transfer,
-			TotalFileSize: task.totalSize,
-			TidyDirs:      task.tidyDirs,
-			Status:        task.state,
-			ErrorMessage:  task.message,
+			CurrentPhase:  snap.CurrentPhase,
+			TotalPhases:   snap.TotalPhases,
+			Progress:      snap.Progress,
+			Transferred:   snap.Transfer,
+			TotalFileSize: snap.TotalSize,
+			TidyDirs:      snap.TidyDirs,
+			Status:        snap.State,
+			ErrorMessage:  snap.Message,
 		}
 
 		result = append(result, res)
@@ -297,7 +315,7 @@ func (t *taskManager) ClearTasks() {
 
 			task := taskValue.(*Task)
 
-			if common.ListContains([]string{common.Completed, common.Failed, common.Canceled}, task.state) {
+			if common.ListContains([]string{common.Completed, common.Failed, common.Canceled}, task.getState()) {
 				if task.createAt.Before(time.Now().Add(-12 * time.Hour)) {
 					tasks = append(tasks, task)
 				}

--- a/pkg/tasks/task.go
+++ b/pkg/tasks/task.go
@@ -9,6 +9,7 @@ import (
 	"files/pkg/models"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -34,8 +35,30 @@ type TaskInfo struct {
 }
 
 type Task struct {
-	id      string
-	param   *models.PasteParam
+	// Immutable after creation - safe to read without the lock.
+	id       string
+	param    *models.PasteParam
+	isFile   bool
+	isShare  bool
+	createAt time.Time
+	manager  *taskManager
+
+	// ctx/ctxCancel are reset in ResumeTask; that swap is also done
+	// under mu, but the worker only ever reads the latest pointer
+	// once at the start of a phase.
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+
+	// funcs is set during Execute under mu and never mutated again.
+	funcs []func() error
+
+	// mu guards every mutable field below. Without this, the worker
+	// goroutine in Execute and the HTTP handler goroutines (GetTask,
+	// GetTasksByStatus, PauseTask, CancelTask, ResumeTask) raced on
+	// every status / progress field, with classic data-race symptoms
+	// (-race fails, flaky API responses, partial reads).
+	mu sync.RWMutex
+
 	state   string
 	message string
 
@@ -45,7 +68,6 @@ type Task struct {
 	transfer     int64
 	totalSize    int64
 	tidyDirs     bool
-	isFile       bool
 
 	running bool
 	suspend bool
@@ -56,18 +78,10 @@ type Task struct {
 	pausedPhase     int
 	pausedSyncMkdir bool
 
-	ctx       context.Context
-	ctxCancel context.CancelFunc
-
-	createAt time.Time
-	execAt   time.Time
-	endAt    time.Time
-
-	funcs   []func() error
-	manager *taskManager
+	execAt time.Time
+	endAt  time.Time
 
 	details []string
-	isShare bool
 }
 
 func (t *Task) Id() string {
@@ -75,7 +89,51 @@ func (t *Task) Id() string {
 }
 
 func (t *Task) SetTotalSize(size int64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	t.totalSize = size
+}
+
+// taskSnapshot is an immutable snapshot of the mutable Task fields
+// taken under t.mu.RLock(). HTTP handlers should always project
+// through it instead of reading t.* directly.
+type taskSnapshot struct {
+	State        string
+	Message      string
+	CurrentPhase int
+	TotalPhases  int
+	Progress     int
+	Transfer     int64
+	TotalSize    int64
+	TidyDirs     bool
+	Running      bool
+	Suspend      bool
+	WasPaused    bool
+}
+
+func (t *Task) snapshot() taskSnapshot {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return taskSnapshot{
+		State:        t.state,
+		Message:      t.message,
+		CurrentPhase: t.currentPhase,
+		TotalPhases:  t.totalPhases,
+		Progress:     t.progress,
+		Transfer:     t.transfer,
+		TotalSize:    t.totalSize,
+		TidyDirs:     t.tidyDirs,
+		Running:      t.running,
+		Suspend:      t.suspend,
+		WasPaused:    t.wasPaused,
+	}
+}
+
+// getState returns just the current state string.
+func (t *Task) getState() string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.state
 }
 
 // ~ Cancel
@@ -83,31 +141,42 @@ func (t *Task) Cancel() {
 	t.ctxCancel()
 
 	for {
-		if t.running {
-			time.Sleep(100 * time.Millisecond)
-			continue
+		t.mu.RLock()
+		stillRunning := t.running
+		t.mu.RUnlock()
+		if !stillRunning {
+			break
 		}
-		break
+		time.Sleep(100 * time.Millisecond)
 	}
 
+	t.mu.Lock()
 	if !t.suspend {
 		t.state = common.Canceled
 	} else {
 		t.state = common.Paused
 	}
+	finalState := t.state
+	pausedParam := t.pausedParam
+	suspend := t.suspend
+	wasPaused := t.wasPaused
+	currentPhase := t.currentPhase
+	totalPhases := t.totalPhases
+	t.mu.Unlock()
 
-	klog.Infof("[Task] Id: %s, Cancel Final, state: %s, running: %v, suspend: %v, wasPaused: %v, phase: %d/%d, pause: %s, temp: %s", t.id, t.state, t.running, t.suspend, t.wasPaused, t.currentPhase, t.totalPhases, common.ToJson(t.pausedParam), common.ToJson(t.param.Temp))
+	klog.Infof("[Task] Id: %s, Cancel Final, state: %s, suspend: %v, wasPaused: %v, phase: %d/%d, pause: %s, temp: %s",
+		t.id, finalState, suspend, wasPaused, currentPhase, totalPhases, common.ToJson(pausedParam), common.ToJson(t.param.Temp))
 
-	if t.state == common.Canceled {
-		klog.Infof("[Task] Id: %s, Cancel Final, pause result: %s, temp result: %s", t.id, common.ToJson(t.pausedParam), common.ToJson(t.param.Temp))
+	if finalState == common.Canceled {
+		klog.Infof("[Task] Id: %s, Cancel Final, pause result: %s, temp result: %s", t.id, common.ToJson(pausedParam), common.ToJson(t.param.Temp))
 
-		if t.pausedParam != nil {
-			if t.pausedParam.FileType != common.Sync {
-				if e := rclone.Command.Clear(t.pausedParam); e != nil {
+		if pausedParam != nil {
+			if pausedParam.FileType != common.Sync {
+				if e := rclone.Command.Clear(pausedParam); e != nil {
 					klog.Errorf("[Task] Id: %s, Cancel Final, delete pause result error: %v", t.id, e)
 				}
 			} else {
-				if e := seahub.HandleDelete(t.pausedParam); e != nil {
+				if e := seahub.HandleDelete(pausedParam); e != nil {
 					klog.Errorf("[Task] Id: %s, Cancel Final, delete seahub pause result error: %v", t.id, e)
 				}
 			}
@@ -130,74 +199,98 @@ func (t *Task) Execute(fs ...func() error) error {
 	_, loaded := userPool.tasks.LoadOrStore(t.id, t)
 	_ = loaded
 
+	t.mu.Lock()
 	if t.funcs == nil {
 		t.funcs = append(t.funcs, fs...)
 	}
+	currentFuncs := t.funcs
+	t.mu.Unlock()
 
 	_, ok := userPool.pool.TrySubmit(func() { // ~ enter
 		var err error
 
 		defer func() {
-			klog.Infof("[Task] Id: %s defer! status: %s, progress: %d, size: %d, transfer: %d, elapse: %d, error: %v",
-				t.id, t.state, t.progress, t.totalSize, t.transfer, time.Since(t.execAt), err)
-
+			t.mu.Lock()
 			t.endAt = time.Now()
 			t.running = false
+			state := t.state
+			progress := t.progress
+			transfer := t.transfer
+			totalSize := t.totalSize
+			elapsed := time.Since(t.execAt)
+			t.mu.Unlock()
+
+			klog.Infof("[Task] Id: %s defer! status: %s, progress: %d, size: %d, transfer: %d, elapse: %d, error: %v",
+				t.id, state, progress, totalSize, transfer, elapsed, err)
 		}()
 
-		if common.ListContains([]string{common.Canceled, common.Paused, common.Failed, common.Running, common.Completed}, t.state) {
+		if common.ListContains([]string{common.Canceled, common.Paused, common.Failed, common.Running, common.Completed}, t.getState()) {
 			return
 		}
 
+		t.mu.Lock()
 		t.totalPhases = len(fs)
 		t.execAt = time.Now()
 		t.state = common.Running
 		t.running = true
 		t.details = nil
+		t.mu.Unlock()
 
-		for phase, f := range t.funcs {
+		for phase, f := range currentFuncs {
+			t.mu.Lock()
 			t.currentPhase = phase + 1
-			// If f() is not the final stage, such as downloadFromCloud, and uploadToSync will be executed afterwards, the src and dst need to be reset. After entering the next phase, src and dst will be extracted again.
-			klog.Infof("[Task] Id: %s, exec phase: %d/%d", t.id, t.currentPhase, t.totalPhases)
+			currentPhase := t.currentPhase
+			totalPhases := t.totalPhases
+			t.mu.Unlock()
+
+			klog.Infof("[Task] Id: %s, exec phase: %d/%d", t.id, currentPhase, totalPhases)
 			err = f()
 
 			if err != nil {
-				klog.Errorf("[Task] Id: %s, exec failed, suspend: %v, error: %s", t.id, t.suspend, err.Error())
+				suspend := func() bool { t.mu.RLock(); defer t.mu.RUnlock(); return t.suspend }()
+				klog.Errorf("[Task] Id: %s, exec failed, suspend: %v, error: %s", t.id, suspend, err.Error())
 
 				var errmsg = common.RemoveBlank(err.Error())
-				t.details = append(t.details, errmsg)
 
 				if errmsg == TaskCancel {
+					t.mu.Lock()
+					t.details = append(t.details, errmsg)
 					if t.suspend {
 						t.state = common.Paused
+						t.mu.Unlock()
 						return
 					}
-
 					t.state = common.Canceled
+					t.mu.Unlock()
 				} else {
+					t.mu.Lock()
+					t.details = append(t.details, errmsg)
 					t.message = errmsg
 					t.state = common.Failed
+					tempParam := t.param.Temp
+					pausedParam := t.pausedParam
+					t.mu.Unlock()
 
-					klog.Errorf("[Task] Id: %s, exec failed, temp result: %s, pause result: %s", t.id, common.ToJson(t.param.Temp), common.ToJson(t.pausedParam))
+					klog.Errorf("[Task] Id: %s, exec failed, temp result: %s, pause result: %s", t.id, common.ToJson(tempParam), common.ToJson(pausedParam))
 
-					if t.param.Temp != nil {
-						if e := rclone.Command.Clear(t.param.Temp); e != nil {
+					if tempParam != nil {
+						if e := rclone.Command.Clear(tempParam); e != nil {
 							klog.Errorf("[Task] Id: %s, exec failed, delete temp result error: %v", t.id, e)
 						}
 
-						if strings.Contains(t.param.Temp.Path, t.id) {
-							if e := rclone.Command.ClearTaskCaches(t.param.Temp, t.id); e != nil {
+						if strings.Contains(tempParam.Path, t.id) {
+							if e := rclone.Command.ClearTaskCaches(tempParam, t.id); e != nil {
 								klog.Errorf("[Task] Id: %s, exec failed, delete task cached result error: %v", t.id, e)
 							}
 						}
 					}
-					if t.pausedParam != nil {
-						if e := rclone.Command.Clear(t.pausedParam); e != nil {
+					if pausedParam != nil {
+						if e := rclone.Command.Clear(pausedParam); e != nil {
 							klog.Errorf("[Task] Id: %s, exec failed, delete pause result error: %v", t.id, e)
 						}
 
-						if strings.Contains(t.pausedParam.Path, t.id) {
-							if e := rclone.Command.ClearTaskCaches(t.pausedParam, t.id); e != nil {
+						if strings.Contains(pausedParam.Path, t.id) {
+							if e := rclone.Command.ClearTaskCaches(pausedParam, t.id); e != nil {
 								klog.Errorf("[Task] Id: %s, exec failed, delete task cached result error: %v", t.id, e)
 							}
 						}
@@ -209,9 +302,11 @@ func (t *Task) Execute(fs ...func() error) error {
 			}
 		}
 
+		t.mu.Lock()
 		t.state = common.Completed
 		t.progress = 100
 		t.details = append(t.details, "successed")
+		t.mu.Unlock()
 
 		// if t.param.Action == common.ActionMove && !t.isShare {
 		// 	share.UpdateMovedSharePaths(t.param.Owner, t.param.Src, t.param.Dst)
@@ -228,32 +323,44 @@ func (t *Task) Execute(fs ...func() error) error {
 }
 
 func (t *Task) updateProgress(progress int, transfer int64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	t.progress = progress
 	t.transfer += transfer
 	t.details = append(t.details, fmt.Sprintf("rsync files progress: %d, transfer: %d", progress, transfer))
 }
 
 func (t *Task) updateProgressRsync(progress int, transfer int64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	t.progress = progress
 	t.transfer = transfer
 	t.details = append(t.details, fmt.Sprintf("rsync files progress: %d, transfer: %d", progress, transfer))
 }
 
 func (t *Task) resetProgressZero() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	t.progress = 0
 	t.transfer = 0
 	t.details = append(t.details, fmt.Sprintf("rsync files progress: 0, transfer: 0"))
 }
 
 func (t *Task) updateTotalSize(totalSize int64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	t.totalSize = totalSize
 }
 
 func (t *Task) GetProgress() (string, int, int64, int64) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
 	return t.state, t.progress, t.transfer, t.totalSize
 }
 
 func (t *Task) isLastPhase() bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
 	return t.currentPhase == t.totalPhases
 }
 


### PR DESCRIPTION
## 概要

\`Task\` 结构体的 \`state\`、\`message\`、\`currentPhase\`、\`totalPhases\`、\`progress\`、\`transfer\`、\`totalSize\`、\`tidyDirs\`、\`running\`、\`suspend\`、\`wasPaused\`、\`details\`、\`execAt\`、\`endAt\` 等字段：

- **写**：由 \`Execute\` 里 pond worker goroutine、\`update*\`、\`Cancel\`、\`SetTotalSize\` 等修改；
- **读**：由 HTTP handler 经 \`GetTask\` / \`GetTasksByStatus\` 读，cron \`ClearTasks\` 也读，\`PauseTask\`/\`ResumeTask\`/\`CancelTask\` 在判定/修改 state 与 suspend 时也读。

完全没有任何同步。\`go test -race\` 必报，生产中表现为 API 偶发返回零进度、错乱状态、字符串字段被部分读取。

## 改动

给 \`Task\` 加 \`mu sync.RWMutex\`：

- 引入 \`taskSnapshot\` 值类型 + \`(t *Task).snapshot()\` 在一次 RLock 下复制出一致视图，供报告路径使用；\`getState()\` 给只需 state 的场景。
- \`Execute\` 中的所有写、\`update*\`、\`SetTotalSize\`、defer 中的 \`endAt/running\` 复位、\`Cancel\` 的 state 切换都在 \`mu.Lock()\` 下完成。
- 取数据时只 \`mu.RLock()\`：\`GetTask\` / \`GetTasksByStatus\` / \`ClearTasks\` 改用 \`snapshot()\` / \`getState()\`，不再直接访问底层字段。
- \`PauseTask\` / \`ResumeTask\` / \`CancelTask\` 在写 \`suspend\` / \`wasPaused\` / \`state\` 前先取锁，并在临界区内做状态前置校验。

## 范围说明

本 PR 关注 **worker ↔ HTTP 报告路径** 的 race。Task 结构内还有几个字段被 worker 自己跨 phase 读写（\`pausedParam\`、\`pausedPhase\`、\`wasPaused\` 在 \`task_paste_*.go\` 多处使用）。这部分留给后续 PR：

- 每个 user 的 pond 池并发度是 1，worker 自己对自己的写互不并发；
- Pause/Resume 的 happens-before 通过 \`Cancel → Execute\` 重入链路构成，目前实际行为正确；
- 进一步加锁需要触碰 \`task_paste_*.go\` 里几十处读写，单独一个 PR 来做更合适。

## 验证方式

- [ ] \`go build ./pkg/tasks/ && go vet ./pkg/tasks/\` 通过。
- [ ] \`go test -race ./pkg/tasks/...\`（如有测试）通过；或手工：起两个 goroutine，一个不停 \`GetTasksByStatus\`，一个 paste 大文件，运行 \`-race\` 程序确认无报警。
- [ ] 手工：paste 进行中调用 GET /api/tasks，进度从 0% 到 100% 平滑变化、状态字段完整。

Made with [Cursor](https://cursor.com)