### PR TITLE
fix(common/rsync): 同步 gErr 读写并等待后台 goroutine 退出

### DIFF
--- a/pkg/common/rsync.go
+++ b/pkg/common/rsync.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 
 	"github.com/pkg/errors"
@@ -209,17 +210,44 @@ func (c *Command) Run() error {
 		}
 	}()
 
-	var gErr error
+	// gErr is written by two background goroutines (the ctx-watcher
+	// and the stdout reader) and read by the main goroutine after
+	// cmd.Wait. Without synchronization this is a classic data race
+	// (-race fails). Guard reads/writes with gErrMu.
+	var (
+		gErrMu sync.Mutex
+		gErr   error
+	)
+	setGErr := func(e error) {
+		gErrMu.Lock()
+		if gErr == nil {
+			gErr = e
+		}
+		gErrMu.Unlock()
+	}
+	getGErr := func() error {
+		gErrMu.Lock()
+		defer gErrMu.Unlock()
+		return gErr
+	}
+
+	// Use WaitGroup so we don't read gErr until both background
+	// goroutines have stopped writing.
+	var bg sync.WaitGroup
+	bg.Add(2)
+
 	go func() {
+		defer bg.Done()
 		select {
 		case <-c.ctx.Done():
-			gErr = c.ctx.Err()
+			setGErr(c.ctx.Err())
 			_ = syscall.Kill(-pgid, syscall.SIGKILL)
 		case <-waitDone:
 		}
 	}()
 
 	go func() {
+		defer bg.Done()
 		defer close(c.Ch)
 		var reader = bufio.NewReader(stdout)
 		for {
@@ -230,7 +258,7 @@ func (c *Command) Run() error {
 				if err == io.EOF || errors.Is(err, os.ErrClosed) {
 					return
 				}
-				gErr = err
+				setGErr(err)
 				return
 			}
 
@@ -250,19 +278,22 @@ func (c *Command) Run() error {
 
 	close(waitDone)
 	<-reaperDone
+	bg.Wait()
+
+	finalGErr := getGErr()
 
 	if err != nil {
 		if errors.Is(err, syscall.ECHILD) {
 			err = nil
 		}
-		if gErr != nil {
-			return gErr
+		if finalGErr != nil {
+			return finalGErr
 		}
 		return err
 	}
 
-	if gErr != nil {
-		return gErr
+	if finalGErr != nil {
+		return finalGErr
 	}
 
 	return nil


### PR DESCRIPTION
## 概要

\`pkg/common/rsync.go\` 的 \`(*Command).Run\` 起了两个后台 goroutine：

1. ctx 监听 goroutine：ctx 取消时写 \`gErr = c.ctx.Err()\` 并 SIGKILL 进程组；
2. stdout 读取 goroutine：读到非 EOF 错误时写 \`gErr = err\`。

主 goroutine 在 \`c.cmd.Wait()\` 之后读 \`gErr\`。所有读写都没有任何同步：

- \`go test -race\` 会直接报 data race；
- 更严重的是 \`close(waitDone)\` 之后主 goroutine 继续读 \`gErr\`，**并不等待两个后台 goroutine 真正退出**，因此两者在 close 窗口里写 \`gErr\` 的时机和主路径读 gErr 的时机会赛跑——可能漏掉真正的错误。

## 改动

- 加 \`gErrMu sync.Mutex\` 包住 \`gErr\` 的读写；提供小辅助 \`setGErr\` / \`getGErr\`，并保证 \`setGErr\` 只接受第一个错误（避免后到的 ctx error 覆盖读取错误，或反之）。
- 用 \`sync.WaitGroup\` 等两个后台 goroutine 都退出后再读取最终 \`gErr\`。
- \`close(c.Ch)\` 仍由 reader goroutine 自己关闭，外部消费者照常感知 channel 结束。

## 验证方式

- [ ] \`go test -race ./pkg/common/...\`（如有相关测试）通过。
- [ ] 手工：触发一次 paste 中途 cancel；rsync 进程被 KILL，调用方拿到 \`context canceled\`，没有"明明被取消却返回 nil\" 的情形。
- [ ] 手工：rsync 正常完成；\`Run\` 返回 nil。

Made with [Cursor](https://cursor.com)