### PR TITLE
fix(tasks): getOrCreateUserPool 用 LoadOrStore 避免并发双写

### DIFF
--- a/pkg/tasks/manager.go
+++ b/pkg/tasks/manager.go
@@ -53,19 +53,30 @@ func NewTaskManager() {
 
 func (t *taskManager) getOrCreateUserPool(owner string) *userPool {
 	if pool, ok := t.userPools.Load(owner); ok {
-		userPool := pool.(*userPool)
-		return userPool
+		return pool.(*userPool)
 	}
 
-	userPool := &userPool{
+	// Build a candidate pool, then atomically install it via
+	// LoadOrStore. The previous Load+Store dance allowed two
+	// concurrent callers for the same owner to both miss the Load
+	// and both Store, ending up with two different *userPool values
+	// for the same user (and so two distinct pond pools and two
+	// distinct task maps - tasks could land in either, breaking
+	// GetTask / CancelTask lookups).
+	candidate := &userPool{
 		owner: owner,
 		tasks: sync.Map{},
 		pool:  pond.NewPool(1, pond.WithContext(context.Background()), pond.WithNonBlocking(true)),
 	}
 
-	t.userPools.Store(owner, userPool)
+	actual, loaded := t.userPools.LoadOrStore(owner, candidate)
+	if loaded {
+		// Another goroutine won the race; drop our candidate and
+		// release the pool we just built.
+		candidate.pool.StopAndWait()
+	}
 
-	return userPool
+	return actual.(*userPool)
 }
 
 // create


### PR DESCRIPTION
## 概要

\`pkg/tasks/manager.go\` 的 \`getOrCreateUserPool\` 是经典的 \"Load + Store\" 两步：

\`\`\`go
if pool, ok := t.userPools.Load(owner); ok { return pool }
new := &userPool{...}
t.userPools.Store(owner, new)
return new
\`\`\`

两个并发的同 owner 调用都可能 miss Load，各自 \`Store\` 一份新 \`userPool\`：

- 每个新 userPool 内含独立的 pond 池（worker goroutine）和独立的 \`tasks sync.Map\`；
- 第二个 Store 会"覆盖"第一个；
- 走第一个 pool 创建的任务，会落在被覆盖的 \`tasks\` 里，**之后任何 GetTask / CancelTask / GetTasksByStatus 都找不到它们**；
- 同时多了一个永远没人用的 pond pool / goroutine。

## 改动

- 用 \`sync.Map.LoadOrStore\` 原子地装入 candidate；
- 若被别的 goroutine 抢先（\`loaded == true\`），把刚刚构造的多余 pond 池 \`StopAndWait()\` 释放掉，不泄漏 worker goroutine。

## 验证方式

- [ ] 手工：起两个 goroutine 同时为同一个新 owner 调用 getOrCreateUserPool，确认拿回同一个 \`*userPool\`。
- [ ] 正常单线程使用不受影响。
- [ ] \`go test -race ./pkg/tasks/...\` 通过。

Made with [Cursor](https://cursor.com)