### PR TITLE
fix(crontab): 拆分 cleanupMux 为每任务独立锁，用 TryLock 跳过重叠

### DIFF
--- a/cmd/backend/app/crontab.go
+++ b/cmd/backend/app/crontab.go
@@ -13,7 +13,16 @@ import (
 	"k8s.io/klog/v2"
 )
 
-var cleanupMux sync.Mutex
+// Per-job mutexes prevent two invocations of the *same* cron job
+// from overlapping (cron.Cron does not synchronize jobs internally).
+// Distinct jobs no longer share a single global lock - the previous
+// `cleanupMux` covered both the slow daily cleanup and the every-5min
+// mount refresh, so a long-running daily run could block mount data
+// from updating for the duration of its execution.
+var (
+	dailyCleanupMux sync.Mutex
+	mountRefreshMux sync.Mutex
+)
 
 // InitCrontabs registers all scheduled jobs and starts the scheduler. It
 // returns the running *cron.Cron so callers can wire its Stop()/ctx into
@@ -23,8 +32,14 @@ func InitCrontabs() *cron.Cron {
 	c := cron.New()
 
 	_, err := c.AddFunc("5 0 * * *", func() {
-		cleanupMux.Lock()
-		defer cleanupMux.Unlock()
+		// TryLock so a previous slow run (e.g. >24h, however
+		// unlikely) doesn't queue up a second concurrent cleanup.
+		if !dailyCleanupMux.TryLock() {
+			klog.Warning("Crontab: daily cleanup still running, skipping this tick")
+			return
+		}
+		defer dailyCleanupMux.Unlock()
+
 		seahub.ClearAccessTokens()
 		redisutils.CleanupOldFilesAndRedisEntries(7 * 24 * time.Hour)
 
@@ -38,8 +53,11 @@ func InitCrontabs() *cron.Cron {
 	}
 
 	_, err = c.AddFunc("*/5 * * * *", func() {
-		cleanupMux.Lock()
-		defer cleanupMux.Unlock()
+		if !mountRefreshMux.TryLock() {
+			klog.Warning("Crontab: mount refresh still running, skipping this tick")
+			return
+		}
+		defer mountRefreshMux.Unlock()
 
 		global.GlobalMounted.Updated()
 	})


### PR DESCRIPTION
## 概要

\`cmd/backend/app/crontab.go\` 里两个完全无关的 cron 任务共享同一把 \`cleanupMux\`：

- 每天 00:05 的 \"daily cleanup\"：清 access token、清 Redis 旧缩略图、清完成任务、清缓存目录——慢操作；
- 每 5 分钟一次的 \`global.GlobalMounted.Updated()\`——挂载信息刷新，需要保证近似实时。

只要 daily cleanup 跑得慢，挂载刷新会被串行化卡住，挂载信息长时间陈旧。即便 daily 跑完，期间堆积的 mount 任务也都会一次性追着跑。

## 改动

- 每个 cron 任务一把独立 mutex：\`dailyCleanupMux\` / \`mountRefreshMux\`，互不影响。
- 改用 \`TryLock\`：同一任务的上一次还没跑完时，本次直接跳过并打 warning，**不再排队累积**。robfig/cron 不会强制 job 之间互斥，本次 PR 的 TryLock 只针对"同一 job 的并发实例"。

## 验证方式

- [ ] 手工：人为让 daily 任务里某步 sleep 10 分钟，确认期间 \`*/5\` 的 mount refresh 仍在按时执行（看到 \"Crontab: mount refresh ...\" 之类日志）。
- [ ] 模拟同一 job 重叠（修改 cron 表达式让 mount refresh 每 1s 跑一次 + 内部 sleep 5s），确认看到 \"still running, skipping this tick\" warning，不会有并发重入。

Made with [Cursor](https://cursor.com)