### PR TITLE
fix(watchers): AddToWatchers 失败返回 error，不再 panic

### DIFF
--- a/cmd/backend/app/root.go
+++ b/cmd/backend/app/root.go
@@ -196,9 +196,15 @@ user created with the credentials from options "username" and "password".`,
 		// step9: watcher
 		watcherCtx, watcherCancel := context.WithCancel(context.Background())
 		var w = watchers.NewWatchers(watcherCtx, config)
-		watchers.AddToWatchers[corev1.Node](w, global.NodeGVR, global.GlobalNode.Handlerevent())
-		watchers.AddToWatchers[appsv1.StatefulSet](w, appsv1.SchemeGroupVersion.WithResource("statefulsets"), global.GlobalData.HandlerEvent())
-		watchers.AddToWatchers[models.User](w, models.UserGVR, integration.IntegrationManager().HandlerEvent())
+		if err := watchers.AddToWatchers[corev1.Node](w, global.NodeGVR, global.GlobalNode.Handlerevent()); err != nil {
+			klog.Fatalf("register Node watcher: %v", err)
+		}
+		if err := watchers.AddToWatchers[appsv1.StatefulSet](w, appsv1.SchemeGroupVersion.WithResource("statefulsets"), global.GlobalData.HandlerEvent()); err != nil {
+			klog.Fatalf("register StatefulSet watcher: %v", err)
+		}
+		if err := watchers.AddToWatchers[models.User](w, models.UserGVR, integration.IntegrationManager().HandlerEvent()); err != nil {
+			klog.Fatalf("register User watcher: %v", err)
+		}
 
 		var watcherWG sync.WaitGroup
 		watcherWG.Add(1)

--- a/cmd/samba/main.go
+++ b/cmd/samba/main.go
@@ -58,8 +58,12 @@ var rootCmd = &cobra.Command{
 
 		watcherCtx, watcherCancel := context.WithCancel(context.Background())
 		var w = watchers.NewWatchers(watcherCtx, config)
-		watchers.AddToWatchers[v1.ShareSamba](w, samba.SambaGVR, samba.SambaService.HandlerEvent())
-		watchers.AddToWatchers[models.User](w, models.UserGVR, samba.SambaService.UserHandlerEvent())
+		if err := watchers.AddToWatchers[v1.ShareSamba](w, samba.SambaGVR, samba.SambaService.HandlerEvent()); err != nil {
+			klog.Fatalf("register ShareSamba watcher: %v", err)
+		}
+		if err := watchers.AddToWatchers[models.User](w, models.UserGVR, samba.SambaService.UserHandlerEvent()); err != nil {
+			klog.Fatalf("register User watcher: %v", err)
+		}
 
 		var wg sync.WaitGroup
 		wg.Add(1)

--- a/pkg/watchers/watchers.go
+++ b/pkg/watchers/watchers.go
@@ -215,8 +215,12 @@ func AddToWatchers[R any](w *Watchers, gvr schema.GroupVersionResource, handler 
 		}
 		_, err := informer.Informer().AddEventHandler(newHandler)
 		if err != nil {
-			klog.Error("add to subscriber to watchers error, ", err, ", ", gvr.String())
-			panic(err)
+			// Previously this panicked, taking the whole process
+			// down at startup if a single GVR registration failed.
+			// AddToWatchers already returns an error - propagate it
+			// so the caller can decide (log+continue vs fatal).
+			klog.Errorf("add subscriber to watchers error, gvr=%s: %v", gvr.String(), err)
+			return fmt.Errorf("add event handler for %s: %w", gvr.String(), err)
 		}
 	}
 


### PR DESCRIPTION
## 概要

\`pkg/watchers/watchers.go\` 的 \`AddToWatchers\` 在 \`AddEventHandler\` 失败时直接 \`panic(err)\`，把整个进程拖垮在启动期。函数本身就有 \`error\` 返回值，调用方却把它忽略了。

## 改动

- \`AddToWatchers\`：失败时打 error 日志并返回 \`fmt.Errorf(\"add event handler for %s: %w\", gvr, err)\`，**不再 panic**。
- 更新两处调用点：
  - \`cmd/backend/app/root.go\`（Node、StatefulSet、User 三处）
  - \`cmd/samba/main.go\`（ShareSamba、User 两处）
  
  失败时 \`klog.Fatalf(\"register <kind> watcher: %v\", err)\`——对运维等价（进程退出且原因清楚），但不再从库内部丢一份 panic stack 到日志。

## 验证方式

- [ ] 编译通过：\`go build ./pkg/watchers/ ./cmd/backend/app/ ./cmd/samba/\`。
- [ ] 手工：构造一种 AddEventHandler 失败的场景（例如向已 stopped 的 informer 注册）；进程仍然退出，但日志里看到的是 \"register Node watcher: ...\" 而不是 panic backtrace。

Made with [Cursor](https://cursor.com)