### PR TITLE
fix(integration): NewIntegrationManager 改为返回 error，不再 panic

### DIFF
--- a/cmd/backend/app/root.go
+++ b/cmd/backend/app/root.go
@@ -180,7 +180,9 @@ user created with the credentials from options "username" and "password".`,
 		seaserv.InitSeaRPC()
 
 		// step8: integration
-		integration.NewIntegrationManager()
+		if err := integration.NewIntegrationManager(); err != nil {
+			klog.Fatalf("init integration manager: %v", err)
+		}
 		upload.Start()
 
 		coord := lifecycle.New()

--- a/pkg/integration/integration.go
+++ b/pkg/integration/integration.go
@@ -48,21 +48,26 @@ type authToken struct {
 	expire time.Time
 }
 
-func NewIntegrationManager() {
+// NewIntegrationManager builds the global IntegrationService and
+// starts its background watcher. It returns an error instead of
+// panicking, so callers (cmd/backend/app) can decide whether to
+// klog.Fatal or continue with degraded functionality. The previous
+// `panic(err)` made any transient API-server hiccup at startup
+// produce a panic stack instead of a single clear log line.
+func NewIntegrationManager() error {
 	config, err := ctrl.GetConfig()
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("ctrl.GetConfig: %w", err)
 	}
 
 	client, err := dynamic.NewForConfig(config)
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("dynamic.NewForConfig: %w", err)
 	}
 
 	kubeClient, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		klog.Errorf("Failed to create kube client: %v", err)
-		panic(err)
+		return fmt.Errorf("kubernetes.NewForConfig: %w", err)
 	}
 
 	IntegrationService = &integration{
@@ -73,6 +78,7 @@ func NewIntegrationManager() {
 	}
 
 	IntegrationService.watch()
+	return nil
 }
 
 func IntegrationManager() *integration {


### PR DESCRIPTION
## 概要

\`pkg/integration/integration.go\` 的 \`NewIntegrationManager\` 在三处 K8s client 构造失败时直接 \`panic(err)\`：

\`\`\`go
config, err := ctrl.GetConfig();              if err != nil { panic(err) }
client, err := dynamic.NewForConfig(config);  if err != nil { panic(err) }
kubeClient, err := kubernetes.NewForConfig(); if err != nil { panic(err) }
\`\`\`

启动期 API server 短暂抖动就会让进程吐 panic stack 而不是一行清晰的失败原因。库代码 panic 也让上层无法选择是 fatal 还是降级。

## 改动

- \`NewIntegrationManager() error\`：三处错误改成 \`fmt.Errorf(\"<step>: %w\", err)\` 返回；
- \`cmd/backend/app/root.go\`：调用方改为 \`if err := integration.NewIntegrationManager(); err != nil { klog.Fatalf(...) }\`。

观感和原来一致（启动失败就退出），但日志里看到的是 \"init integration manager: ...\" 而非 panic backtrace。

## 验证方式

- [ ] \`go build ./pkg/integration/ ./cmd/backend/app/\` 通过。
- [ ] 手工：把 \`KUBECONFIG\` 指向一个不存在的文件启动；进程退出，最后一行日志是 \"init integration manager: ctrl.GetConfig: ...\"。

Made with [Cursor](https://cursor.com)