### PR TITLE
fix(searpc): CreateRPCMethod 未知 retType 返回 error 不再 panic

### DIFF
--- a/pkg/drivers/sync/seahub/searpc/client.go
+++ b/pkg/drivers/sync/seahub/searpc/client.go
@@ -310,7 +310,11 @@ func CreateRPCMethod(
 		case "json":
 			fret = func(s string) (interface{}, error) { return _fret_json(s) }
 		default:
-			panic(&SearpcError{"Invalid return type"})
+			// Previously panicked on a bad retType, killing the
+			// process from inside an RPC dispatcher. Return an
+			// error instead so a misconfigured method only fails
+			// its own call.
+			return nil, &SearpcError{"Invalid return type: " + retType}
 		}
 
 		if len(args) != len(paramTypes) {


### PR DESCRIPTION
## 概要

\`pkg/drivers/sync/seahub/searpc/client.go\` 的 \`CreateRPCMethod\`：

\`\`\`go
default:
    panic(&SearpcError{\"Invalid return type\"})
\`\`\`

只要某处 \`CreateRPCMethod(...)\` 注册时 \`retType\` 写错（例如 \"int32\" 而不是 \"int\"），首次调用该方法就把整个进程 panic 掉。一个本应只影响单次 RPC 的错误，被放大成全局故障。

## 改动

把 \`default\` 分支改为返回 \`&SearpcError{\"Invalid return type: \" + retType}\`，错误只影响这一次调用，便于排查（带上具体 retType 字符串）。

## 验证方式

- [ ] \`go build ./pkg/drivers/sync/...\` 通过。
- [ ] 手工：注册一个 retType 写错的方法并调用，确认调用方收到 SearpcError 而进程继续运行。

Made with [Cursor](https://cursor.com)