### PR TITLE
fix(watchers): convert 用 comma-ok 类型断言，避免事件流 panic

### DIFF
--- a/pkg/watchers/watchers.go
+++ b/pkg/watchers/watchers.go
@@ -126,7 +126,19 @@ func AddToWatchers[R any](w *Watchers, gvr schema.GroupVersionResource, handler 
 
 	if handler != nil {
 		convert := func(obj interface{}, newObj *R) error {
-			err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.(*unstructured.Unstructured).Object, newObj)
+			// Use the comma-ok form: a malformed event (cache
+			// tombstone, future API gymnastics, test injections, ...)
+			// would otherwise panic the watch goroutine with a
+			// "interface conversion" runtime error. Returning an
+			// error here makes the FilterFunc / handler simply
+			// drop the event.
+			u, ok := obj.(*unstructured.Unstructured)
+			if !ok {
+				err := fmt.Errorf("watchers: expected *unstructured.Unstructured, got %T", obj)
+				klog.Error(err)
+				return err
+			}
+			err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, newObj)
 			if err != nil {
 				klog.Error("convert obj error, ", err)
 				return err


### PR DESCRIPTION
## 概要

\`pkg/watchers/watchers.go\` 中 \`AddToWatchers\` 内部的 \`convert\` 闭包：

\`\`\`go
err := runtime.DefaultUnstructuredConverter.FromUnstructured(
    obj.(*unstructured.Unstructured).Object, newObj)
\`\`\`

直接做了类型断言。一旦事件流送进来的对象不是 \`*unstructured.Unstructured\`（典型场景：cache tombstone \`DeletedFinalStateUnknown\` 包装、测试注入、未来 informer 变更），整条 watch worker goroutine 会被 \"interface conversion\" panic 掉。\`AddEventHandler\` 又在 Add/Update/Delete 三处都包了这个 closure，影响面更大。

## 改动

改用 comma-ok 形式：

\`\`\`go
u, ok := obj.(*unstructured.Unstructured)
if !ok {
    err := fmt.Errorf(\"watchers: expected *unstructured.Unstructured, got %T\", obj)
    klog.Error(err)
    return err
}
\`\`\`

错误 log 里带上实际 %T 类型，返回 error 给上层 FilterFunc / handler，只丢弃这个事件而不是把整个 watcher 干掉。

## 验证方式

- [ ] \`go build ./pkg/watchers/\` 通过。
- [ ] 手工：注入一个非 \`*unstructured.Unstructured\` 的对象到 informer cache（或在测试里直接调 convert），watcher goroutine 不再 panic，日志看到 \"watchers: expected *unstructured.Unstructured, got <type>\"。

Made with [Cursor](https://cursor.com)