### PR TITLE
fix(integration): watcher ticker 接受 ctx 并接入 lifecycle

### DIFF
--- a/cmd/backend/app/root.go
+++ b/cmd/backend/app/root.go
@@ -192,6 +192,9 @@ user created with the credentials from options "username" and "password".`,
 		coord.Add("redis", 5*time.Second, func(context.Context) error {
 			return redisutils.Close()
 		})
+		coord.Add("integration-watcher", 5*time.Second, func(ctx context.Context) error {
+			return integration.IntegrationManager().Stop(ctx)
+		})
 
 		// step9: watcher
 		watcherCtx, watcherCancel := context.WithCancel(context.Background())

--- a/pkg/integration/integration.go
+++ b/pkg/integration/integration.go
@@ -40,6 +40,12 @@ type integration struct {
 	authTokenMu sync.Mutex
 	authToken   map[string]*authToken
 
+	// watcher lifecycle: cancel ends the periodic GetIntegrations
+	// loop; <-watcherDone returns once the goroutine has fully
+	// exited, so a graceful-shutdown coordinator can wait on it.
+	cancelWatcher context.CancelFunc
+	watcherDone   chan struct{}
+
 	sync.RWMutex
 }
 
@@ -80,11 +86,40 @@ func IntegrationManager() *integration {
 }
 
 func (i *integration) watch() {
+	ctx, cancel := context.WithCancel(context.Background())
+	i.cancelWatcher = cancel
+	i.watcherDone = make(chan struct{})
+
 	go func() {
-		for range time.NewTicker(15 * time.Second).C {
-			i.GetIntegrations()
+		defer close(i.watcherDone)
+		ticker := time.NewTicker(15 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				i.GetIntegrations()
+			}
 		}
 	}()
+}
+
+// Stop ends the background watcher goroutine and waits for it to
+// exit. Safe to call multiple times. Intended to be wired into the
+// process-wide lifecycle coordinator so the loop does not keep
+// running (and making API calls) past graceful-shutdown.
+func (i *integration) Stop(ctx context.Context) error {
+	if i == nil || i.cancelWatcher == nil {
+		return nil
+	}
+	i.cancelWatcher()
+	select {
+	case <-i.watcherDone:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func (i *integration) HandlerEvent() cache.ResourceEventHandler {


### PR DESCRIPTION
## 概要

\`pkg/integration/integration.go\` 的 \`(*integration).watch\` 启动了一个永不退出的 goroutine：

\`\`\`go
go func() {
    for range time.NewTicker(15 * time.Second).C {
        i.GetIntegrations()
    }
}()
\`\`\`

- 没有 ctx；
- 没有 \`ticker.Stop()\`；
- 没有任何 done 通知。

进程进入 graceful-shutdown 后这个循环还在以 15s 一次的频率打 K8s API，与其它子系统的关闭逻辑互相干扰。

## 改动

- \`integration\` 结构加 \`cancelWatcher context.CancelFunc\` + \`watcherDone chan struct{}\`。
- \`watch()\` 改写为标准的 \`for { select { case <-ctx.Done(): return; case <-tick } }\` 模式，\`defer ticker.Stop()\` + \`defer close(watcherDone)\`。
- 新增 \`(*integration).Stop(ctx context.Context) error\`：取消 watcher，再等 \`watcherDone\` 关闭（或 ctx.Err 超时）。
- \`cmd/backend/app/root.go\` 注册 \`coord.Add(\"integration-watcher\", 5*time.Second, ...)\`，钩子 reverse 顺序保证 watcher 早于 redis/postgres 关闭。

## 验证方式

- [ ] \`go build\` 通过。
- [ ] 手工：触发 SIGTERM，确认日志中看到 integration-watcher 收尾后 redis、postgres 才关闭，且 15s 内停止 GetIntegrations 调用。

Made with [Cursor](https://cursor.com)