### PR TITLE
fix(global/node): node 刷新 ticker 接受 ctx 并接入 lifecycle

### DIFF
--- a/cmd/backend/app/root.go
+++ b/cmd/backend/app/root.go
@@ -192,6 +192,9 @@ user created with the credentials from options "username" and "password".`,
 		coord.Add("redis", 5*time.Second, func(context.Context) error {
 			return redisutils.Close()
 		})
+		coord.Add("global-nodes", 3*time.Second, func(ctx context.Context) error {
+			return global.GlobalNode.Stop(ctx)
+		})
 
 		// step9: watcher
 		watcherCtx, watcherCancel := context.WithCancel(context.Background())

--- a/pkg/global/node.go
+++ b/pkg/global/node.go
@@ -37,29 +37,62 @@ type Node struct {
 	k8sClient *kubernetes.Clientset
 	Nodes     map[string]*v1.Node
 	mu        sync.RWMutex
+
+	// Background-refresh lifecycle. cancel ends the periodic
+	// getGlobalNodes loop; <-done blocks until the goroutine has
+	// fully exited so a graceful-shutdown coordinator can wait on
+	// it. Both are nil until InitGlobalNodes runs.
+	cancel context.CancelFunc
+	done   chan struct{}
 }
 
 func InitGlobalNodes(config *rest.Config) error {
 	CurrentNodeName = os.Getenv("NODE_NAME")
 
+	ctx, cancel := context.WithCancel(context.Background())
 	GlobalNode = &Node{
 		k8sClient: kubernetes.NewForConfigOrDie(config),
 		Nodes:     make(map[string]*v1.Node),
+		cancel:    cancel,
+		done:      make(chan struct{}),
 	}
 
 	if err := GlobalNode.getGlobalNodes(); err != nil {
+		cancel()
+		close(GlobalNode.done)
 		return err
 	}
 
 	go func() {
+		defer close(GlobalNode.done)
 		ticker := time.NewTicker(30 * time.Second)
 		defer ticker.Stop()
-		for range ticker.C {
-			GlobalNode.getGlobalNodes()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				GlobalNode.getGlobalNodes()
+			}
 		}
 	}()
 
 	return nil
+}
+
+// Stop ends the background refresh goroutine and waits for it to
+// exit. Safe to call multiple times.
+func (g *Node) Stop(ctx context.Context) error {
+	if g == nil || g.cancel == nil {
+		return nil
+	}
+	g.cancel()
+	select {
+	case <-g.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func (g *Node) IsMasterNode(nodeName string) bool {


### PR DESCRIPTION
## 概要

\`pkg/global/node.go\` 的 \`InitGlobalNodes\` 起了一个 goroutine：

\`\`\`go
go func() {
    ticker := time.NewTicker(30 * time.Second)
    defer ticker.Stop()
    for range ticker.C {
        GlobalNode.getGlobalNodes()
    }
}()
\`\`\`

虽然 \`ticker.Stop()\` 已经 defer 了，但 \`for range ticker.C\` 永远不会退出（除非 ticker 被 GC，但永远不会）。生命周期上等于一个泄漏的 goroutine，graceful-shutdown 后还在每 30s 打一次 K8s。

## 改动

- \`Node\` 结构加 \`cancel context.CancelFunc\` + \`done chan struct{}\`。
- goroutine 改为 \`select { case <-ctx.Done(): return; case <-tick }\` 模式。
- 提供 \`(*Node).Stop(ctx)\`：取消 watcher，等 done close（或 ctx 超时）。
- \`cmd/backend/app/root.go\` 注册 \`coord.Add(\"global-nodes\", 3*time.Second, ...)\`。

## 验证方式

- [ ] \`go build\` 通过。
- [ ] 手工：触发 SIGTERM，确认 \"global-nodes\" 钩子在 redis/postgres 之前完成，\`getGlobalNodes\` 不再被调用。

Made with [Cursor](https://cursor.com)