### PR TITLE
fix(global/pvc): pvc 刷新 ticker 接受 ctx 并接入 lifecycle

### DIFF
--- a/cmd/backend/app/root.go
+++ b/cmd/backend/app/root.go
@@ -192,6 +192,9 @@ user created with the credentials from options "username" and "password".`,
 		coord.Add("redis", 5*time.Second, func(context.Context) error {
 			return redisutils.Close()
 		})
+		coord.Add("global-data", 3*time.Second, func(ctx context.Context) error {
+			return global.GlobalData.Stop(ctx)
+		})
 
 		// step9: watcher
 		watcherCtx, watcherCancel := context.WithCancel(context.Background())

--- a/pkg/global/pvc.go
+++ b/pkg/global/pvc.go
@@ -32,29 +32,59 @@ type Data struct {
 	UserPvcMap   map[string]string
 	CachePvcMap  map[string]string
 	mu           sync.RWMutex
+
+	// Background-refresh lifecycle.
+	cancel context.CancelFunc
+	done   chan struct{}
 }
 
 func InitGlobalData(config *rest.Config) error {
+	ctx, cancel := context.WithCancel(context.Background())
 	GlobalData = &Data{
 		k8sClient:    kubernetes.NewForConfigOrDie(config),
 		k8sInterface: dynamic.NewForConfigOrDie(config),
 		UserPvcMap:   make(map[string]string),
 		CachePvcMap:  make(map[string]string),
+		cancel:       cancel,
+		done:         make(chan struct{}),
 	}
 
 	if err := GlobalData.getGlobalData(); err != nil {
+		cancel()
+		close(GlobalData.done)
 		return err
 	}
 
 	go func() {
+		defer close(GlobalData.done)
 		ticker := time.NewTicker(120 * time.Second)
 		defer ticker.Stop()
-		for range ticker.C {
-			GlobalData.getGlobalData()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				GlobalData.getGlobalData()
+			}
 		}
 	}()
 
 	return nil
+}
+
+// Stop ends the background refresh goroutine and waits for it to
+// exit. Safe to call multiple times.
+func (g *Data) Stop(ctx context.Context) error {
+	if g == nil || g.cancel == nil {
+		return nil
+	}
+	g.cancel()
+	select {
+	case <-g.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func (g *Data) GetPvcUser(user string) string {


### PR DESCRIPTION
## 概要

\`pkg/global/pvc.go\` 的 \`InitGlobalData\` 同 B8b 模式：

\`\`\`go
go func() {
    ticker := time.NewTicker(120 * time.Second)
    defer ticker.Stop()
    for range ticker.C {
        GlobalData.getGlobalData()
    }
}()
\`\`\`

\`for range ticker.C\` 永远不退出，graceful-shutdown 后仍每 120s 打 K8s。

## 改动

- \`Data\` 结构加 \`cancel context.CancelFunc\` + \`done chan struct{}\`。
- goroutine 改为 \`select { case <-ctx.Done(): return; case <-tick }\`。
- 提供 \`(*Data).Stop(ctx)\`：取消 + 等 done。
- \`cmd/backend/app/root.go\` 注册 \`coord.Add(\"global-data\", 3*time.Second, ...)\`。

## 验证方式

- [ ] \`go build\` 通过。
- [ ] 手工：触发 SIGTERM，确认 \"global-data\" 钩子在 redis/postgres 之前完成。

Made with [Cursor](https://cursor.com)