### PR TITLE
fix(samba): deleteExpiredShares ticker 接受 ctx 并接入 lifecycle

### DIFF
--- a/cmd/samba/main.go
+++ b/cmd/samba/main.go
@@ -55,6 +55,9 @@ var rootCmd = &cobra.Command{
 		coord.Add("external-fsnotify", 2*time.Second, func(context.Context) error {
 			return global.ExternalWatcherClose()
 		})
+		coord.Add("samba-cleanup", 5*time.Second, func(ctx context.Context) error {
+			return samba.SambaService.Stop(ctx)
+		})
 
 		watcherCtx, watcherCancel := context.WithCancel(context.Background())
 		var w = watchers.NewWatchers(watcherCtx, config)

--- a/pkg/samba/samba.go
+++ b/pkg/samba/samba.go
@@ -73,6 +73,14 @@ type samba struct {
 	commands *commands
 	users    []string
 	runTime  time.Time
+
+	// Background-cleanup lifecycle. cancel ends the periodic
+	// deleteExpiredShares loop; <-done blocks until the goroutine
+	// has fully exited so a graceful-shutdown coordinator can wait
+	// on it.
+	cancelCleanup context.CancelFunc
+	cleanupDone   chan struct{}
+
 	sync.RWMutex
 }
 
@@ -184,8 +192,21 @@ func (s *samba) HandlerEvent() cache.ResourceEventHandler {
 }
 
 func (s *samba) deleteExpiredShares() {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.cancelCleanup = cancel
+	s.cleanupDone = make(chan struct{})
+
 	go func() {
-		for range time.NewTicker(5 * time.Minute).C {
+		defer close(s.cleanupDone)
+		ticker := time.NewTicker(5 * time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+
 			klog.Info("samba delete crds with ticker")
 			cli, err := s.factory.DynamicClient()
 			if err != nil {
@@ -193,7 +214,7 @@ func (s *samba) deleteExpiredShares() {
 				continue
 			}
 
-			res, err := cli.Resource(SambaGVR).Namespace(common.DefaultNamespace).List(context.Background(), metav1.ListOptions{})
+			res, err := cli.Resource(SambaGVR).Namespace(common.DefaultNamespace).List(ctx, metav1.ListOptions{})
 			if err != nil {
 				klog.Errorf("samba get shares list error: %v", err)
 				continue
@@ -211,7 +232,7 @@ func (s *samba) deleteExpiredShares() {
 					continue
 				}
 
-				if err := cli.Resource(SambaGVR).Namespace(common.DefaultNamespace).Delete(context.Background(), v.Name, metav1.DeleteOptions{}); err != nil {
+				if err := cli.Resource(SambaGVR).Namespace(common.DefaultNamespace).Delete(ctx, v.Name, metav1.DeleteOptions{}); err != nil {
 					klog.Errorf("samba delete, delete failed, error: %v, operate: %s", err, v.Spec.Operator)
 					continue
 				}
@@ -220,6 +241,22 @@ func (s *samba) deleteExpiredShares() {
 			}
 		}
 	}()
+}
+
+// Stop ends the background expired-share cleanup loop and waits
+// for it to exit (or returns ctx.Err() on shutdown deadline).
+// Safe to call multiple times.
+func (s *samba) Stop(ctx context.Context) error {
+	if s == nil || s.cancelCleanup == nil {
+		return nil
+	}
+	s.cancelCleanup()
+	select {
+	case <-s.cleanupDone:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func (s *samba) getUsers() {


### PR DESCRIPTION
## 概要

\`pkg/samba/samba.go\` 的 \`(*samba).deleteExpiredShares\`：

\`\`\`go
go func() {
    for range time.NewTicker(5 * time.Minute).C {
        // ... List + Delete 都用 context.Background()
    }
}()
\`\`\`

- goroutine 永不退出；
- 内部 K8s List / Delete 用 \`context.Background()\`，graceful-shutdown 也无法打断在途请求；
- \`cmd/samba/main.go\` 的 lifecycle 协调器完全不知道这个 goroutine 存在。

SIGTERM 之后 5 分钟内还可能发出 Delete 请求，与其它子系统的关闭交叉。

## 改动

- \`samba\` 结构加 \`cancelCleanup context.CancelFunc\` + \`cleanupDone chan struct{}\`。
- goroutine 改为 \`select { case <-ctx.Done(): return; case <-tick }\` 模式，K8s 调用也改用循环 ctx。
- 新增 \`(*samba).Stop(ctx)\`：取消 + 等 cleanupDone（或 ctx 超时）。
- \`cmd/samba/main.go\` 注册 \`coord.Add(\"samba-cleanup\", 5*time.Second, ...)\`。
- \`cmd/backend/app/root.go\` 不调用 \`Start()\`，因此不需要 hook。

## 验证方式

- [ ] \`go build ./pkg/samba/ ./cmd/samba/\` 通过。
- [ ] 手工：在 samba 二进制中触发 SIGTERM，确认 \`samba-cleanup\` 钩子完成；之后没有任何 \"samba delete crds with ticker\" 日志，也没有新的 Delete API 调用。

Made with [Cursor](https://cursor.com)