### PR TITLE
fix(global/external): watchMounted 加锁读取 Mounted map

### DIFF
--- a/pkg/global/external.go
+++ b/pkg/global/external.go
@@ -76,6 +76,32 @@ func (m *Mount) GetMountedData() []files.DiskInfo {
 	return res
 }
 
+// hasMount reports whether the mount map contains base under read lock.
+// watchMounted previously read m.Mounted directly without the lock,
+// racing with getMounted's full-map replacement and the cron-driven
+// Updated() refresh. The Go runtime treats this as a map race and may
+// crash with a fatal error.
+func (m *Mount) hasMount(base string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	_, ok := m.Mounted[base]
+	return ok
+}
+
+// snapshotMountedJSON returns a JSON encoding of the current mount
+// map taken under read lock. Used by watchMounted log lines that
+// previously dumped m.Mounted directly while another goroutine could
+// be replacing the map.
+func (m *Mount) snapshotMountedJSON() string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make(map[string]*files.DiskInfo, len(m.Mounted))
+	for k, v := range m.Mounted {
+		out[k] = v
+	}
+	return common.ToJson(out)
+}
+
 //func (m *Mount) watchDiskUsage() {
 //	go func() {
 //		ticker := time.NewTicker(10 * time.Second)
@@ -136,9 +162,10 @@ func (m *Mount) watchMounted() {
 				if e.Op == fsnotify.Create {
 					found := false
 					m.getMounted()
-					if _, exists := m.Mounted[filepath.Base(e.Name)]; exists {
+					base := filepath.Base(e.Name)
+					if m.hasMount(base) {
 						found = true
-						klog.Infof("Found %s in mounted disks (immediate), mounted: %+v", e.Name, m.Mounted)
+						klog.Infof("Found %s in mounted disks (immediate), mounted: %s", e.Name, m.snapshotMountedJSON())
 					} else {
 						retryDelay := 1 * time.Second
 						for i := 0; i < maxRetries; i++ {
@@ -146,9 +173,9 @@ func (m *Mount) watchMounted() {
 							klog.Infof("Retry %d for %s (wait %v)", i+1, e.Name, retryDelay)
 
 							m.getMounted()
-							if _, exists = m.Mounted[filepath.Base(e.Name)]; exists {
+							if m.hasMount(base) {
 								found = true
-								klog.Infof("Found %s in mounted disks after %d retries, mounted: %+v", e.Name, i+1, m.Mounted)
+								klog.Infof("Found %s in mounted disks after %d retries, mounted: %s", e.Name, i+1, m.snapshotMountedJSON())
 								break
 							}
 							retryDelay *= 2
@@ -156,7 +183,7 @@ func (m *Mount) watchMounted() {
 					}
 
 					if !found {
-						klog.Warningf("Failed to find %s in mounted disks after %d attempts, mounted: %+v", e.Name, maxRetries, m.Mounted)
+						klog.Warningf("Failed to find %s in mounted disks after %d attempts, mounted: %s", e.Name, maxRetries, m.snapshotMountedJSON())
 					}
 				} else {
 					m.getMounted()


### PR DESCRIPTION
## 概要

\`pkg/global/external.go\` 的 \`watchMounted\` goroutine 在调用 \`m.getMounted()\`（内部已 \`mu.Lock\`）之后，立刻 **不持锁** 直接读 \`m.Mounted[...]\`，并把整个 \`m.Mounted\` 当作 \`%+v\` 打到日志。同一时刻 cron 每 5 分钟一次的 \`Updated()\` 也会进 \`getMounted\` 重建 map。

Go runtime 对并发 map 读写会直接 \`fatal error: concurrent map read and map write\`，进程会被打挂；即便不 fatal，日志里也可能拿到一个正在被替换的 map。

## 改动

新增两个辅助方法，全部在 RLock 下完成：

- \`hasMount(base string) bool\`：替代 \`_, exists := m.Mounted[base]\` 的非锁化判断；
- \`snapshotMountedJSON() string\`：在 RLock 下复制一份再做 \`common.ToJson\`，给日志使用。

\`watchMounted\` 中所有直接访问 \`m.Mounted\` 的地方都改用这两个方法。

## 验证方式

- [ ] \`go build ./pkg/global/\` 通过。
- [ ] 手工：起一个 goroutine 高频触发 \`Updated()\`，同时人为产生 \`/data/External\` 下的 fsnotify Create 事件；旧版本应当能跑出 \"concurrent map read\" fatal，新版本不再出现。
- [ ] 正常流程：插拔外部存储设备，watchMounted 仍能正确发现/失败重试若干次。

Made with [Cursor](https://cursor.com)