### PR TITLE
fix(webhook/upload): notify httpClient 加上文档承诺的 30s 超时

### DIFF
--- a/pkg/webhook/upload/notify.go
+++ b/pkg/webhook/upload/notify.go
@@ -64,12 +64,17 @@ type newItemsBody struct {
 }
 
 var (
-	queue      chan NewItem
-	startOnce  sync.Once
-	stopOnce   sync.Once
-	workerWG   sync.WaitGroup
-	httpClient = &http.Client{} // intentionally no Timeout; keep-alive enabled by default transport
-	dropped    uint64           // atomic counter; updated when the queue is full
+	queue     chan NewItem
+	startOnce sync.Once
+	stopOnce  sync.Once
+	workerWG  sync.WaitGroup
+	// httpClient enforces the per-request 30s deadline documented in the
+	// package comment. The previous implementation used &http.Client{}
+	// (no timeout), which contradicted the doc and let a single stuck
+	// TCP connection block the only worker indefinitely - the queue
+	// would silently fill until items started dropping.
+	httpClient = &http.Client{Timeout: 30 * time.Second}
+	dropped    uint64 // atomic counter; updated when the queue is full
 )
 
 func enabled() bool {


### PR DESCRIPTION
## 概要

\`pkg/webhook/upload/notify.go\` 包注释里写：

> Per-request timeout of 30s. The batches are tiny (~KB JSON), so a stuck TCP connection that never errors must not be allowed to block the worker forever; without a timeout the queue would silently fill until items start dropping.

但实际：

\`\`\`go
httpClient = &http.Client{} // intentionally no Timeout; keep-alive enabled by default transport
\`\`\`

注释和实现完全相反。**只有一个 worker** 在串行 POST，一旦远端某个 TCP 连接被对端 hang（不超时也不出错），worker 就会无限期阻塞，\`Enqueue\` 队列填满后开始静默丢弃，运维侧看不到任何信号。

## 改动

- \`httpClient = &http.Client{Timeout: 30 * time.Second}\`，与文档一致；
- 注释改写说明历史 bug。

\`req\` 仍是 \`http.NewRequest\`（不带 ctx）已经够用——\`Client.Timeout\` 覆盖完整 dial+headers+body 阶段。

## 验证方式

- [ ] \`go build ./pkg/webhook/...\` 通过。
- [ ] 手工：让 webhook 端口 \`nc -l 18832\` 但不应答，触发若干次 upload；30s 后日志会出现 \"POST ... failed: ... context deadline exceeded\" 或 \"i/o timeout\"，worker 能继续处理后续 batch；旧版本会一直挂在第一个请求。

Made with [Cursor](https://cursor.com)