### PR TITLE
fix(share): SMB 用户密码不再在 JSON 响应中回显

### DIFF
--- a/pkg/hertz/biz/handler/api/share/share_service.go
+++ b/pkg/hertz/biz/handler/api/share/share_service.go
@@ -2385,13 +2385,19 @@ func ListSmbUser(ctx context.Context, c *app.RequestContext) {
 		return
 	}
 
+	// Do NOT include the SMB password in the response. We previously
+	// returned the base64-decoded plaintext to anyone who could call
+	// this endpoint as `owner`; that was a credential disclosure path
+	// (logs / proxies / browser dev-tools / frontend caches all
+	// retain it). The id/name pair is enough for UI listing; the
+	// caller already has the password if they need it for a separate
+	// flow (e.g. mounting), and there is no other legitimate reason
+	// to read it back from the server.
 	var data = make([]map[string]string, 0)
 	for _, r := range res {
-		p, _ := common.Base64Decode(r.Password)
 		var d = make(map[string]string)
 		d["id"] = r.UserID
 		d["name"] = r.UserName
-		d["password"] = p
 		data = append(data, d)
 	}
 
@@ -2439,10 +2445,14 @@ func CreateSmbUser(ctx context.Context, c *app.RequestContext) {
 		return
 	}
 
+	// Do NOT echo the password back. The caller just sent it, so this
+	// is not new information for them, but echoing it lengthens the
+	// surface where the credential can leak (response logs, browser
+	// network panel screenshots, proxy buffers, etc.). Return id/name
+	// only to confirm the create.
 	var result = make(map[string]string)
 	result["id"] = userId
 	result["name"] = userName
-	result["password"] = req.Password
 
 	handler.RespSuccess(c, result)
 }


### PR DESCRIPTION
## 概要

\`pkg/hertz/biz/handler/api/share/share_service.go\` 中两处 SMB 用户接口在响应里直接放了密码明文：

\`\`\`go
// ListSmbUser
p, _ := common.Base64Decode(r.Password)
d[\"password\"] = p   // base64 解码后的明文回写

// CreateSmbUser
result[\"password\"] = req.Password   // 调用方刚发的密码再 echo 回去
\`\`\`

只要任意能调 \`/api/share/smb_share_users/\` 的客户端通过身份校验，就能把所有 SMB 用户的明文密码拉回来。即便密码本来就来自调用方（CreateSmbUser），把它写进响应体的副作用是：

- 响应日志、反向代理缓冲、浏览器开发者工具网络面板、前端缓存都会留存它；
- 任意一份 HAR 截图都等于把凭证泄漏出去。

## 改动

- \`ListSmbUser\`：响应中删掉 \`password\` 字段，同时移除上面那行 \`Base64Decode\`（不再需要）；只返回 \`id\` 和 \`name\`。
- \`CreateSmbUser\`：响应中删掉 \`password\` 字段；只返回 \`id\` 和 \`name\`。
- 两处都加注释说明为什么不能把密码放进响应。

## ⚠️ 行为变更（前端注意）

这两个接口的响应不再包含 \`password\` 字段：

| 接口 | 旧响应字段 | 新响应字段 |
|---|---|---|
| GET \`/api/share/smb_share_users/\` | \`{id, name, password}\` | \`{id, name}\` |
| POST \`/api/share/smb_share_user/\` | \`{id, name, password}\` | \`{id, name}\` |

前端如果有读 \`response.password\` 的逻辑，需要同步改成"用调用时自己持有的那份密码"——本就该如此。

## 验证方式

- [ ] \`go build ./pkg/hertz/biz/handler/api/share/\` 通过。
- [ ] 手工：以正常 owner 调 GET / POST 两个接口，确认响应 JSON 中不再含 \`password\`。
- [ ] 前端联调：确认涉及 SMB 用户列表 / 创建的页面不依赖 \`response.password\`。

Made with [Cursor](https://cursor.com)