### PR TITLE
fix(common): 引入 ParseRFC3339Nano helper，清扫 time.Parse 静默吞错

### DIFF
--- a/pkg/common/timeparse.go
+++ b/pkg/common/timeparse.go
@@ -1,0 +1,37 @@
+package common
+
+import (
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+// ParseRFC3339Nano parses an RFC 3339 nano timestamp string.
+//
+// On success it returns (parsed, true).
+//
+// On failure it returns (time.Time{}, false) **and** logs the offending
+// string via klog.Errorf so the parse failure is visible in operations.
+// The previous pattern across share / driver code was:
+//
+//	expired, _ := time.Parse(time.RFC3339Nano, s)
+//
+// which silently coerces a malformed expire/last-modify string to the
+// zero year. For expiry checks that happens to "fail closed"
+// (`time.Now().After(time.Time{})` is true → treated as expired), which
+// is safe in spirit but invisible to operators and produces nonsensical
+// negative Unix timestamps in API responses (Unix epoch of year-1 is
+// -62135596800). Callers should switch to:
+//
+//	t, ok := common.ParseRFC3339Nano(s)
+//	if !ok { ...handle (typically: treat as expired, return time.Now()) }
+//
+// so the failure is both logged and explicitly handled.
+func ParseRFC3339Nano(s string) (time.Time, bool) {
+	t, err := time.Parse(time.RFC3339Nano, s)
+	if err != nil {
+		klog.Errorf("ParseRFC3339Nano: invalid timestamp %q: %v", s, err)
+		return time.Time{}, false
+	}
+	return t, true
+}

--- a/pkg/drivers/clouds/cloud.go
+++ b/pkg/drivers/clouds/cloud.go
@@ -209,7 +209,11 @@ func (s *CloudStorage) Raw(contextArgs *models.HttpContextArgs) (*models.RawHand
 
 	var serve = s.service.command.GetServe().Get(configName, path, &contextArgs.QueryParam.Header)
 
-	var modTime, _ = time.Parse(time.RFC3339Nano, fileMeta.Item.ModTime)
+	// Last-modified is informational, not an expiry check; on parse
+	// failure leave modTime as the zero value (same as before) but
+	// at least log it so a malformed cloud-provider timestamp is
+	// visible in operations.
+	modTime, _ := common.ParseRFC3339Nano(fileMeta.Item.ModTime)
 	return &models.RawHandlerResponse{
 		IsCloud:      true,
 		ReadCloser:   serve.Body,

--- a/pkg/hertz/biz/handler/api/share/share_service.go
+++ b/pkg/hertz/biz/handler/api/share/share_service.go
@@ -2239,7 +2239,13 @@ func GetToken(ctx context.Context, c *app.RequestContext) {
 
 	klog.Infof("GetToken, sharePath expireTime: %s, shareId: %s", sharePath.ExpireTime, req.PathId)
 
-	expireTime, _ := time.Parse(time.RFC3339Nano, sharePath.ExpireTime)
+	expireTime, ok := common.ParseRFC3339Nano(sharePath.ExpireTime)
+	if !ok {
+		// Treat unparseable expire as expired; do not return the
+		// year-1 zero-time Unix value to the client.
+		handler.RespErrorExpired(c, common.CodeLinkExpired, common.ErrorMessageLinkExpired, time.Now().Unix())
+		return
+	}
 	if time.Now().After(expireTime) {
 		handler.RespErrorExpired(c, common.CodeLinkExpired, common.ErrorMessageLinkExpired, expireTime.Unix())
 		return

--- a/pkg/hertz/biz/router/middleware.go
+++ b/pkg/hertz/biz/router/middleware.go
@@ -463,7 +463,12 @@ func checkSharePath(currentUser string, shareId string, fromShare bool) (*share.
 		return sharePath, 0, nil
 	}
 
-	expired, _ := time.Parse(time.RFC3339Nano, sharePath.ExpireTime)
+	expired, ok := common.ParseRFC3339Nano(sharePath.ExpireTime)
+	if !ok {
+		// Unparseable expire string -> treat as expired and surface
+		// a sane Unix timestamp (now) rather than the year-1 default.
+		return nil, time.Now().Unix(), errors.New(common.ErrorMessageLinkExpired)
+	}
 
 	if time.Now().After(expired) {
 		klog.Errorf("sharePath expired, expireTime: %s", sharePath.ExpireTime)
@@ -515,7 +520,12 @@ func checkExternal(currentUser string, token string, sharePaths *share.SharePath
 
 	klog.V(2).Infof("share token validated, shareId: %s, expireAt: %s", sharePaths.ID, shareToken.ExpireAt)
 
-	expired, _ := time.Parse(time.RFC3339Nano, shareToken.ExpireAt)
+	expired, ok := common.ParseRFC3339Nano(shareToken.ExpireAt)
+	if !ok {
+		// Unparseable token expire -> fail closed: report current time
+		// as the expiry boundary instead of leaking a year-1 timestamp.
+		return time.Now().Unix(), false, fmt.Errorf("shareToken expireAt unparseable: %q", shareToken.ExpireAt)
+	}
 	if time.Now().After(expired) {
 		klog.Errorf("[share] shareToken expired, expireAt: %s", shareToken.ExpireAt)
 		return expired.Unix(), false, fmt.Errorf("shareToken expired, shareToken.ExpireAt: %s", shareToken.ExpireAt)
@@ -748,11 +758,13 @@ func proxySharePaste(c *app.RequestContext, owner string, action string, src, ds
 }
 
 func checkExpired(expireAt string) bool {
-	expired, _ := time.Parse(time.RFC3339Nano, expireAt)
-	if time.Now().After(expired) {
+	expired, ok := common.ParseRFC3339Nano(expireAt)
+	if !ok {
+		// Unparseable -> treat as expired (fail closed). Logging
+		// already happens inside ParseRFC3339Nano.
 		return true
 	}
-	return false
+	return time.Now().After(expired)
 }
 
 func ShareUpload() app.HandlerFunc {


### PR DESCRIPTION
## 概要

仓库里多处用了同一种模式：

\`\`\`go
expired, _ := time.Parse(time.RFC3339Nano, s)
\`\`\`

\`time.Parse\` 失败时返回 \`time.Time{}\`（公元 1 年的零时间）+ error，但 error 被丢弃。后果：

- **操作不可见**：解析失败完全没有日志，运维侧不知道服务器收到了非法时间字符串；
- **API 响应中泄漏荒谬时间戳**：很多调用点把 \`expired.Unix()\` 回传给客户端，零时间的 Unix 值是 \`-62135596800\`（年-1 的负数 epoch），客户端拿到一脸懵；
- 表面"安全"是因为 \`time.Now().After(time.Time{})\` 恰好为 true（默认按"已过期"处理），但这是巧合，不该依赖。

## 改动

### 1. 新增 helper

\`pkg/common/timeparse.go\`：

\`\`\`go
func ParseRFC3339Nano(s string) (time.Time, bool) {
    t, err := time.Parse(time.RFC3339Nano, s)
    if err != nil {
        klog.Errorf(\"ParseRFC3339Nano: invalid timestamp %q: %v\", s, err)
        return time.Time{}, false
    }
    return t, true
}
\`\`\`

——返回 \`(t, ok)\`，并在失败时 log 出原始字符串。

### 2. 替换调用点

| 文件 | 位置 | 行为 |
|---|---|---|
| [\`share_service.go\`](pkg/hertz/biz/handler/api/share/share_service.go) | \`GetToken\` | 解析失败按已过期处理，回 \`time.Now().Unix()\` 而非年-1 |
| [\`middleware.go\`](pkg/hertz/biz/router/middleware.go) | \`checkSharePath\` | 同上 |
| [\`middleware.go\`](pkg/hertz/biz/router/middleware.go) | \`checkExternal\` | 同上，错误信息含原始 \`expireAt\` 字符串 |
| [\`middleware.go\`](pkg/hertz/biz/router/middleware.go) | \`checkExpired\` | \`!ok → return true\`，简洁 fail closed |
| [\`cloud.go\`](pkg/drivers/clouds/cloud.go) | Raw \`FileModified\` | **不是过期检查**，是云端返回的 ModTime；保持零时间回退（行为不变），仅 log |

### 与 PR #226 的协调

[\`share_service.go\`](pkg/hertz/biz/handler/api/share/share_service.go) 的 \`GetExternalSharePath\` 函数里还有两处 \`_ := time.Parse\`（第 2298、2310 行），**本 PR 故意不改**——PR #226 已经把这两处改成 \`err :=\` 形式（属于 IDOR + nil panic 修复的一部分），避免合并冲突。

## 验证方式

- [ ] \`go build ./pkg/common/ ./pkg/hertz/biz/handler/api/share/ ./pkg/hertz/biz/router/ ./pkg/drivers/clouds/\` 通过。
- [ ] 手工：把 \`share_paths\` 表里某条 \`expire_time\` 改成 \"garbage\"；调相关接口，日志里现在有 \`ParseRFC3339Nano: invalid timestamp \"garbage\"\`，HTTP 响应中的 \`expire\` 是合理的 Unix 秒数（约 1.7e9），而不是负的 \`-62135596800\`。
- [ ] 正常时间戳走过原路径，行为完全一致。

Made with [Cursor](https://cursor.com)