### PR TITLE
fix(backend): close missing braces in root.go coord.Add calls

### DIFF
--- a/cmd/backend/app/root.go
+++ b/cmd/backend/app/root.go
@@ -196,8 +196,10 @@ user created with the credentials from options "username" and "password".`,
 		})
 		coord.Add("global-data", 3*time.Second, func(ctx context.Context) error {
 			return global.GlobalData.Stop(ctx)
+		})
 		coord.Add("global-nodes", 3*time.Second, func(ctx context.Context) error {
 			return global.GlobalNode.Stop(ctx)
+		})
 		coord.Add("integration-watcher", 5*time.Second, func(ctx context.Context) error {
 			return integration.IntegrationManager().Stop(ctx)
 		})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In `cmd/backend/app/root.go`, three consecutive `coord.Add(...)` calls at lines 197–203 are written back-to-back, but the first two (`global-data` and `global-nodes`) are missing their closing `})` after the inline error-returning func. As a result, the file fails to parse starting at line 199.

Running `gofmt -e cmd/backend/app/root.go` currently reports 70+ cascading syntax errors, ultimately failing with `expected '}', found 'EOF'`. All of them trace back to these two missing closers.

Snippet before the fix:

```go
coord.Add("global-data", 3*time.Second, func(ctx context.Context) error {
    return global.GlobalData.Stop(ctx)
coord.Add("global-nodes", 3*time.Second, func(ctx context.Context) error {
    return global.GlobalNode.Stop(ctx)
coord.Add("integration-watcher", 5*time.Second, func(ctx context.Context) error {
    return integration.IntegrationManager().Stop(ctx)
})
```

## Change

Add the missing `})` to close the first two `coord.Add` calls so they match the third one:

```go
coord.Add("global-data", 3*time.Second, func(ctx context.Context) error {
    return global.GlobalData.Stop(ctx)
})
coord.Add("global-nodes", 3*time.Second, func(ctx context.Context) error {
    return global.GlobalNode.Stop(ctx)
})
coord.Add("integration-watcher", 5*time.Second, func(ctx context.Context) error {
    return integration.IntegrationManager().Stop(ctx)
})
```

## Verification

After the fix, `gofmt -e cmd/backend/app/root.go` exits 0 and produces no diff against the source, confirming both syntax and formatting are clean.

## Impact

- Only `cmd/backend/app/root.go` is touched; +2 lines (the two `})`).
- No runtime behavior change: this restores the originally intended lifecycle registration logic; previously the file simply did not compile.
- The remaining top-level declarations (`getRunParams`, `getParamB`, `getParam`, `setupLog`, `initConfig`) were being misparsed as part of the `rootCmd` composite literal because of the unbalanced braces; they now parse correctly as top-level functions again.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-745d902d-8a76-46cb-9cae-4eca7f9e6109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-745d902d-8a76-46cb-9cae-4eca7f9e6109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

