### PR TITLE
fix(share): GetExternalSharePath warning \u4e0d\u518d\u6253\u5370\u5b8c\u6574 token

### DIFF
--- a/pkg/hertz/biz/handler/api/share/share_service.go
+++ b/pkg/hertz/biz/handler/api/share/share_service.go
@@ -2298,9 +2298,14 @@ func GetExternalSharePath(ctx context.Context, c *app.RequestContext) {
 	// The token must be issued for *this* share. Without this check,
 	// any valid token could be paired with another share's path_id to
 	// read that share's metadata (IDOR).
+	//
+	// NB: do not log the token itself — it is a bearer credential and
+	// would otherwise be persisted to centralized log storage. The
+	// path_id pair is enough to debug the mismatch (see PR #226 review
+	// comment that introduced this check).
 	if shareToken.PathID != req.PathId {
-		klog.Warningf("GetSharePath, token/path_id mismatch: token=%s wants path_id=%s, token belongs to path_id=%s",
-			req.Token, req.PathId, shareToken.PathID)
+		klog.Warningf("GetSharePath, token/path_id mismatch: req.path_id=%s, token belongs to path_id=%s",
+			req.PathId, shareToken.PathID)
 		handler.RespErrorExpired(c, common.CodeTokenExpired, common.ErrorMessageTokenExpired, time.Now().Unix())
 		return
 	}


### PR DESCRIPTION
## 概要

PR #226（share token/path_id IDOR 修复）里我加的一条 warning 日志带上了 \`req.Token\` 完整明文：

\`\`\`go
klog.Warningf(\"GetSharePath, token/path_id mismatch: token=%s wants path_id=%s, ...\",
    req.Token, ...)
\`\`\`

\`req.Token\` 是 bearer 凭证。任何从 klog 收集日志的链路（中心化日志、k8s log shipper、support bundle）会留一份拷贝——这正是 PR #211 / #222 那一轮"日志凭证脱敏"工作的反面教材，等于自己引入了回归。

## 改动

[\`pkg/hertz/biz/handler/api/share/share_service.go\`](pkg/hertz/biz/handler/api/share/share_service.go) 第 2298-2306 行：

- 把 \`token=%s\` 从 format string 里删除；
- 改为只打印 \`req.PathId\` 和 \`shareToken.PathID\`——足够定位"哪个 token 串到了哪个 path\"；
- 加注释提醒后续不要再加回来。

## 备注

\`pkg/common/redact\` 自己的 package doc 写得很清楚："for one-off log call sites that just contain a secret, the right answer is do not log it" rather than calling these helpers——本 PR 走的就是"不打"，而非脱敏。

## 验证方式

- [ ] grep 全仓 \`klog\` 中再无 \`token=%s\` / \`req\\.Token\` 配对。
- [ ] \`go build ./pkg/hertz/biz/handler/api/share/\` 通过。
- [ ] 触发一次 token 与 path_id 不匹配的请求，确认日志只有 path_id 信息。


Made with [Cursor](https://cursor.com)