### PR TITLE
fix(tasks): DownloadFromFiles scanner \u8bb0\u9519\u4e86\u9519\u8bef\u53d8\u91cf

### DIFF
--- a/pkg/tasks/task_paste_download.go
+++ b/pkg/tasks/task_paste_download.go
@@ -74,7 +74,10 @@ func (t *Task) DownloadFromFiles() error {
 		line = strings.TrimPrefix(line, "data: ")
 		var fi files.FileInfo
 		if e := json.Unmarshal([]byte(line), &fi); e != nil {
-			klog.Errorf("[Task] Id: %s, serialize fileInfo error: %v, data: %s", t.id, err, line)
+			// Log the actual unmarshal error e, not the outer err
+			// variable (which is the unrelated, possibly nil, error
+			// from the previous block).
+			klog.Errorf("[Task] Id: %s, serialize fileInfo error: %v, data: %s", t.id, e, line)
 			return e
 		}
 		totalSize += fi.Size


### PR DESCRIPTION
## 概要

[\`pkg/tasks/task_paste_download.go\`](pkg/tasks/task_paste_download.go) 第 76-78 行：

\`\`\`go
if e := json.Unmarshal([]byte(line), &fi); e != nil {
    klog.Errorf(\"[Task] Id: %s, serialize fileInfo error: %v, data: %s\", t.id, err, line)  // <-- err 不是 e
    return e
}
\`\`\`

unmarshal 错误变量是 \`e\`，但 \`klog.Errorf\` 里写成了外层那个不相关的 \`err\`（来源是上面 \`http.Do\`，到这里很可能是 nil）。结果就是：

- 收到坏 SSE chunk，日志里打出 nil 或一条不相关的旧错误；
- 真正的 \`json.Unmarshal\` 错误根本看不到，无法排查。

## 改动

把 format 参数里的 \`err\` 改成 \`e\`，加注释说明为什么不能用 \`err\`。

## 验证方式

- [ ] \`go build ./pkg/tasks/\` 通过。
- [ ] 手工：让 files server 故意返回一行 \"data: {invalid json\" 给 DownloadFromFiles，确认日志中现在能看到真正的 unmarshal 错误信息。


Made with [Cursor](https://cursor.com)