### PR TITLE
fix(files): DefaultFs \u4e0e common.RootPrefix \u5bf9\u9f50

### DIFF
--- a/pkg/files/file.go
+++ b/pkg/files/file.go
@@ -26,7 +26,18 @@ import (
 	"github.com/spf13/afero"
 )
 
-var DefaultFs = afero.NewBasePathFs(afero.NewOsFs(), os.Getenv("ROOT_PREFIX"))
+// DefaultFs is the OS filesystem rooted at common.RootPrefix.
+//
+// Previously this read os.Getenv("ROOT_PREFIX") directly, which
+// produces an empty prefix when the env var is unset. Meanwhile
+// common.RootPrefix is initialized in common.init() to fall back to
+// "/data". The two views of "the data root" diverged when the env
+// var was missing, leading to subtle path bugs in tests / dev.
+//
+// Go guarantees imported packages' init() runs before the importing
+// package's variable initializers, so common.RootPrefix is already
+// resolved by the time this line is evaluated.
+var DefaultFs = afero.NewBasePathFs(afero.NewOsFs(), common.RootPrefix)
 var DefaultSorting = Sorting{
 	By:  "name",
 	Asc: true,


### PR DESCRIPTION
## 概要

[\`pkg/files/file.go\`](pkg/files/file.go) 声明：

\`\`\`go
var DefaultFs = afero.NewBasePathFs(afero.NewOsFs(), os.Getenv(\"ROOT_PREFIX\"))
\`\`\`

[\`pkg/common/utils.go\`](pkg/common/utils.go) 声明：

\`\`\`go
var RootPrefix = os.Getenv(\"ROOT_PREFIX\")
func init() { if RootPrefix == \"\" { RootPrefix = \"/data\" } }
\`\`\`

当 \`ROOT_PREFIX\` 没设（dev/test 或任何依赖 \"/data\" 默认值的部署）时，两套对"数据根"的认识不一致：

- 走 \`DefaultFs\` 的代码路径：根是空字符串，相当于不加前缀；
- 走 \`common.RootPrefix\` 的代码路径：根是 \`/data\`。

容易在路径拼接/比较时出现一类微妙 bug。

## 改动

[\`pkg/files/file.go\`](pkg/files/file.go) 的 \`DefaultFs\` 改用 \`common.RootPrefix\` 作为单一事实源。Go 保证 imported package 的 \`init()\` 在 importing package 的变量初始化器之前运行，所以 \`common.RootPrefix\` 此时已经是 \`/data\`。

注释里写明历史。

## 验证方式

- [ ] \`go build ./pkg/files/ ./pkg/drivers/posix/...\` 通过。
- [ ] 手工：不设 \`ROOT_PREFIX\`，\`files.DefaultFs.Stat(\"/foo\")\` 现在路径解析到 \`/data/foo\`，与 \`common.Md5File(\"/foo\")\` 走的根一致。


Made with [Cursor](https://cursor.com)