### PR TITLE
fix(backend): \u542f\u52a8\u6e05\u7406 buffer \u8d70 RootPrefix \u4e0e CacheBuffer \u5e38\u91cf

### DIFF
--- a/cmd/backend/app/root.go
+++ b/cmd/backend/app/root.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -137,9 +138,15 @@ user created with the credentials from options "username" and "password".`,
 		// redisutils.InitFolderAndRedis() // todo
 
 		// step3-0: clean buffer
-		err := os.RemoveAll("/data/buffer")
-		if err != nil {
-			klog.Fatalf("clean buffer failed: %v", err)
+		//
+		// The buffer dir was previously hardcoded as "/data/buffer".
+		// That ignored the configurable common.RootPrefix (e.g. for
+		// dev / non-default deployments) and the CacheBuffer
+		// constant the rest of the code uses (see download.go,
+		// diskcache/cache.go).
+		bufferDir := filepath.Join(common.RootPrefix, common.CacheBuffer)
+		if err := os.RemoveAll(bufferDir); err != nil {
+			klog.Fatalf("clean buffer %s failed: %v", bufferDir, err)
 		}
 
 		// Step3-1: Build IMG service


### PR DESCRIPTION
## 概要

[\`cmd/backend/app/root.go\`](cmd/backend/app/root.go) 启动时：

\`\`\`go
err := os.RemoveAll(\"/data/buffer\")
\`\`\`

两个问题：

1. \`/data\` 写死。其它地方（[\`pkg/drivers/clouds/download.go\`](pkg/drivers/clouds/download.go)、[\`pkg/diskcache/cache.go\`](pkg/diskcache/cache.go)）都用 \`common.RootPrefix\` / \`common.ROOT_PREFIX\`。dev 或非默认部署里 \`ROOT_PREFIX\` 不是 \`/data\`，本行会去删错误的目录、还把真正的 buffer 留在 \`<RootPrefix>/buffer\` 里。
2. \`buffer\` 字面量写死。已有 \`common.CacheBuffer = \"buffer\"\` 常量。

## 改动

\`\`\`go
bufferDir := filepath.Join(common.RootPrefix, common.CacheBuffer)
if err := os.RemoveAll(bufferDir); err != nil {
    klog.Fatalf(\"clean buffer %s failed: %v\", bufferDir, err)
}
\`\`\`

fatal 日志同时带上实际路径，方便排查。

## 验证方式

- [ ] \`go build ./cmd/backend/app/\` 通过。
- [ ] 手工：\`ROOT_PREFIX=/tmp/files-data\` 启动，确认清理的是 \`/tmp/files-data/buffer\` 而不是 \`/data/buffer\`。
- [ ] 不设环境变量时行为与原来一致。


Made with [Cursor](https://cursor.com)