### PR TITLE
fix(tasks): UploadDirToSync \u8865 Close \u4e0e Open \u9519\u8bef\u5904\u7406

### DIFF
--- a/pkg/tasks/task_paste_sync.go
+++ b/pkg/tasks/task_paste_sync.go
@@ -750,8 +750,20 @@ func (t *Task) UploadDirToSync(src, dst *models.FileParam, root bool) error {
 		}
 	}
 
-	dir, _ := os.Open(srcFullPath)
+	// Open the source dir explicitly so we can:
+	//   1. propagate the os.Open error (previously discarded with `_`,
+	//      meaning a missing/permission-denied source caused dir to be
+	//      nil and the next dir.Readdir call to nil-deref panic the
+	//      worker goroutine);
+	//   2. close the file descriptor (previously leaked).
+	dir, err := os.Open(srcFullPath)
+	if err != nil {
+		return fmt.Errorf("UploadDirToSync open %s: %w", srcFullPath, err)
+	}
 	obs, err := dir.Readdir(-1)
+	if cerr := dir.Close(); cerr != nil && err == nil {
+		err = cerr
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## 概要

[\`pkg/tasks/task_paste_sync.go\`](pkg/tasks/task_paste_sync.go) \`UploadDirToSync\` 第 753 行：

\`\`\`go
dir, _ := os.Open(srcFullPath)
obs, err := dir.Readdir(-1)
\`\`\`

两个隐患：

1. \`os.Open\` 的错误被吞。源路径不存在 / 权限不足时 \`dir\` 是 nil，紧跟的 \`dir.Readdir(-1)\` 直接 nil panic worker goroutine。
2. \`dir\` 从来没有 \`Close()\`，每次调用泄漏一个 fd。多次 sync 上传后命中 \`ulimit\`，无关 I/O 也开始失败。

## 改动

- 收 \`os.Open\` 的 error，包成 \`UploadDirToSync open %s: %w\` 返回；
- \`Readdir\` 之后立即 \`Close\`，错误优先返回 Readdir 的（如果两个都失败保留第一个）。

## 验证方式

- [ ] \`go build ./pkg/tasks/\` 通过。
- [ ] 手工：把 \`srcFullPath\` 改成不存在的路径，触发 sync 上传；任务标 Failed 而不是 panic。
- [ ] 手工：连续上传 N 个目录，进程 \`/proc/<pid>/fd/\` 的 fd 数不再线性增长。


Made with [Cursor](https://cursor.com)