### PR TITLE
fix(tasks): UploadFileToSync chunk \u5faa\u73af\u4e2d defer body.Close \u6539\u4e3a\u663e\u5f0f Close

### DIFF
--- a/pkg/tasks/task_paste_sync.go
+++ b/pkg/tasks/task_paste_sync.go
@@ -1121,19 +1121,29 @@ func (t *Task) UploadFileToSync(src, dst *models.FileParam) error {
 				if response != nil {
 					statusCode = response.StatusCode
 					statusMsg = response.Status
+					// Function returns immediately after this branch,
+					// so closing inline (rather than defer) keeps
+					// the lifetime obvious; no behavioral change.
 					if response.Body != nil {
-						defer response.Body.Close()
+						_ = response.Body.Close()
 					}
 				}
 
 				klog.Warningf("%d, %s after %d attempts", statusCode, statusMsg, maxRetries)
 				return searpc.SyncConnectionFailedError(fmt.Errorf("%d, %s after %d attempts", statusCode, statusMsg, maxRetries))
 			}
-			defer response.Body.Close()
 
-			// Read the response body as a string
+			// Read the response body as a string. NOTE: previously
+			// this used `defer response.Body.Close()` inside the
+			// chunk loop, which queued one defer per chunk -- for a
+			// large file (thousands of chunks) the queued bodies
+			// stayed open for the full function lifetime, eating
+			// connections/fds. Close inline now.
 			postBody, err := io.ReadAll(response.Body)
 			klog.Infoln("ReadAll")
+			if cerr := response.Body.Close(); cerr != nil && err == nil {
+				err = cerr
+			}
 			if err != nil {
 				klog.Errorln("ReadAll error: ", err)
 				return err


### PR DESCRIPTION
## 概要

[\`pkg/tasks/task_paste_sync.go\`](pkg/tasks/task_paste_sync.go) \`UploadFileToSync\` 在 chunk 循环（每 8MB 一个 chunk）里：

\`\`\`go
defer response.Body.Close()
postBody, err := io.ReadAll(response.Body)
\`\`\`

\`defer\` 在 for 循环里写 → 每个 chunk 注册一次 → 全部要等 **函数返回** 才执行。一个几 GB 的大文件（成千上万个 chunk）等于在 defer 栈上挂着同等数量的"半开 response"，连接和 fd 长时间不释放。

## 改动

- chunk 循环里的 \`defer response.Body.Close()\` 改成 \`io.ReadAll\` 之后立即 \`response.Body.Close()\`，错误优先保留 ReadAll 的，Close 失败兜底。
- 上面那个错误分支的 \`defer\` 紧跟着 \`return\`——不是泄漏，但改成显式 \`_ = response.Body.Close()\` 让意图直观，跟新分支风格一致。
- 加注释说明历史。

## 验证方式

- [ ] \`go build ./pkg/tasks/\` 通过。
- [ ] 手工：上传一个 5GB+ 的文件到 sync 后端，期间 \`ss -t state established\` 看 sync 端口连接数稳定，不再随上传时间持续累积。


Made with [Cursor](https://cursor.com)