### PR TITLE
fix(tasks): SimulateProgress goroutine \u968f phase \u9000\u51fa\uff0c\u4e0d\u518d\u6cc4\u6f0f

### DIFF
--- a/pkg/tasks/task_paste_sync.go
+++ b/pkg/tasks/task_paste_sync.go
@@ -1203,7 +1203,15 @@ func (t *Task) DoSyncCopy(src, dst *models.FileParam, root bool) error {
 		return ctxErr
 	}
 
-	go t.SimulateProgress(0, 99, 50000000)
+	// Bound the SimulateProgress goroutine to *this phase* with a
+	// per-invocation done channel. Previously we passed it the
+	// task ctx, which only fires on Cancel/Pause -- so a
+	// successfully completed DoSyncCopy left the goroutine running
+	// until process exit, ticking once per second and overwriting
+	// progress with stale values.
+	stopProgress := make(chan struct{})
+	defer close(stopProgress)
+	go t.SimulateProgress(stopProgress, 0, 99, 50000000)
 
 	var err error
 	srcParentDir := filepath.Dir(strings.TrimSuffix(src.Path, "/"))
@@ -1233,22 +1241,32 @@ func (t *Task) DoSyncCopy(src, dst *models.FileParam, root bool) error {
 	return err
 }
 
-func (t *Task) SimulateProgress(left, right int, speed int64) {
+// SimulateProgress drives a synthetic progress bar for phases that
+// don't otherwise report progress (e.g. DoSyncCopy that just calls
+// HandleBatch* and waits for a result).
+//
+// stop must be closed by the caller when the phase is over -
+// previously this loop only exited on t.ctx.Done(), so successful
+// completions left the goroutine ticking forever and overwriting
+// later phase progress.
+func (t *Task) SimulateProgress(stop <-chan struct{}, left, right int, speed int64) {
 	startTime := time.Now()
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-t.ctx.Done():
 			return
-		default:
-			// Simulate progress update
-			usedTime := int(time.Now().Sub(startTime).Seconds())
+		case <-stop:
+			return
+		case <-ticker.C:
+			usedTime := int(time.Since(startTime).Seconds())
 			status, _, _, size := t.GetProgress()
 			progress := MapProgressByTime(left, right, size, speed, usedTime)
 
 			if status == "running" {
 				t.updateProgress(progress, 0)
 			}
-			time.Sleep(1 * time.Second)
 		}
 	}
 }


### PR DESCRIPTION
## 概要

[\`pkg/tasks/task_paste_sync.go\`](pkg/tasks/task_paste_sync.go) 的 \`DoSyncCopy\` 起了一个 \"假进度\" goroutine：

\`\`\`go
go t.SimulateProgress(0, 99, 50000000)
\`\`\`

\`SimulateProgress\` 内部只 \`select <-t.ctx.Done()\`。但 \`t.ctx\` 是 **任务级** ctx——只在 Pause/Cancel 时才 cancel。所以 \`DoSyncCopy\` 正常 return 后，这个 goroutine 还在每秒 tick：

- **goroutine 泄漏**：每次成功的 sync copy 漏一个 goroutine，进程内堆积；
- **覆盖后续 phase 的进度**：当前 sync copy 已经走完，下一个 phase 在更新 progress，但泄漏的 \`SimulateProgress\` 仍然在按旧公式 \`updateProgress(...)\` 写假数据，UI 上看到进度反复跳动。

## 改动

- \`SimulateProgress\` 增加 \`stop <-chan struct{}\` 参数；
- \`DoSyncCopy\` 创建 per-call \`stopProgress\` channel 并 \`defer close(stopProgress)\`，phase 返回时立刻关闭；
- 保留原来的 \`<-t.ctx.Done()\` 分支，cancel 仍然能立即终止；
- 内部 \`time.Sleep\` 改为 \`time.Ticker\`，配 \`defer ticker.Stop()\`，cancel 后不再要等满 1s。

## 验证方式

- [ ] \`go build ./pkg/tasks/\` 通过。
- [ ] 手工：连续触发 N 次 sync copy，观察 \`pprof goroutine\` 数稳定。
- [ ] 手工：sync copy 完成后立即开始下一阶段，UI progress 不再被旧 SimulateProgress 数字覆盖。


Made with [Cursor](https://cursor.com)