### PR TITLE
fix(tasks): checkJobStats / details append \u8865 t.mu \u9501

### DIFF
--- a/pkg/tasks/task.go
+++ b/pkg/tasks/task.go
@@ -136,6 +136,23 @@ func (t *Task) getState() string {
 	return t.state
 }
 
+// appendDetail appends one line to t.details under the lock.
+// Phase functions (rsync / move / checkJobStats / ...) call this
+// instead of `t.details = append(t.details, ...)` directly so
+// concurrent snapshot() readers do not race the slice header.
+func (t *Task) appendDetail(line string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.details = append(t.details, line)
+}
+
+// setTidyDirs flips t.tidyDirs to v under the lock.
+func (t *Task) setTidyDirs(v bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.tidyDirs = v
+}
+
 // ~ Cancel
 func (t *Task) Cancel() {
 	t.ctxCancel()

--- a/pkg/tasks/task_paste_cloud.go
+++ b/pkg/tasks/task_paste_cloud.go
@@ -473,7 +473,10 @@ func (t *Task) checkJobStats(jobId int, dstPath string) (bool, error) {
 	var transferFinished bool
 	var done bool
 
-	var totalSize = t.totalSize
+	// Snapshot once: t.totalSize is set by another phase via the
+	// locked updateTotalSize / SetTotalSize, so a one-time read
+	// under the snapshot lock is enough for this loop.
+	var totalSize = t.snapshot().TotalSize
 	var preTransfered int64 = 0
 
 	var ticker = time.NewTicker(3 * time.Second)
@@ -535,10 +538,11 @@ func (t *Task) checkJobStats(jobId int, dstPath string) (bool, error) {
 				}
 			}
 
+			snap := t.snapshot()
 			klog.Infof("[Task] Id: %s, job: %d, core stats: %s, status: %s", t.id, jobStatusData.Id, common.ToJson(data), common.ToJson(jobStatusData))
-			klog.Infof("[Task] Id: %s, job: %d, totalTransfer: %s(%s)", t.id, jobStatusData.Id, common.FormatBytes(t.transfer), common.FormatBytes(t.totalSize))
+			klog.Infof("[Task] Id: %s, job: %d, totalTransfer: %s(%s)", t.id, jobStatusData.Id, common.FormatBytes(snap.Transfer), common.FormatBytes(snap.TotalSize))
 
-			var totalTransfers = t.transfer
+			var totalTransfers = snap.Transfer
 
 			if jobStatusData.Success && jobStatusData.Finished {
 				klog.Infof("[Task] Id: %s, job finished: %v, dst: %s", t.id, jobStatusData.Finished, dstPath)
@@ -566,12 +570,12 @@ func (t *Task) checkJobStats(jobId int, dstPath string) (bool, error) {
 
 			if !jobStatusData.Finished {
 				if transferFinished {
-					t.tidyDirs = true
+					t.setTidyDirs(true)
 				}
 				continue
 			} else {
 				klog.Infof("[Task] Id: %s, job finished: %v, dst: %s", t.id, jobStatusData.Finished, dstPath)
-				t.details = append(t.details, "finished")
+				t.appendDetail("finished")
 				done = true
 				err = nil
 			}

--- a/pkg/tasks/task_paste_posix.go
+++ b/pkg/tasks/task_paste_posix.go
@@ -87,7 +87,7 @@ func (t *Task) Rsync() error {
 		}
 
 		klog.Infof("[Task] Id: %s, move done!", t.id)
-		t.details = append(t.details, "move done")
+		t.appendDetail("move done")
 
 		return nil
 	}
@@ -186,7 +186,7 @@ func (t *Task) move() error {
 	dstPath := dst + t.param.Dst.Path
 
 	klog.Infof("[Task] Id: %s, conditon move, srcPath: %s, dstPath: %s", t.id, srcPath, dstPath)
-	t.details = append(t.details, fmt.Sprintf("move %s -> %s", srcPath, dstPath))
+	t.appendDetail(fmt.Sprintf("move %s -> %s", srcPath, dstPath))
 
 	var args = []string{srcPath, dstPath}
 


### PR DESCRIPTION
## 概要

PR #241 (B2) 给 \`Task\` 加了 \`mu sync.RWMutex\`，覆盖了 HTTP 侧的 \`snapshot()\` 报告路径，但当时**没有**触动 worker 内部几处仍在裸写共享字段的地方。审计 A.4 发现的两处：

1. [\`pkg/tasks/task_paste_cloud.go\`](pkg/tasks/task_paste_cloud.go) \`checkJobStats\`：
   - 第 476 行 \`var totalSize = t.totalSize\` 不持锁；
   - 第 539 / 541 行读 \`t.transfer\` 不持锁；
   - 第 569 行 \`t.tidyDirs = true\` 写不持锁；
   - 第 574 行 \`t.details = append(...)\` 写不持锁；
   
   而 \`HTTP GetTask\` 路径走 \`snapshot()\` 同时读这些字段——\`-race\` 必报。

2. [\`pkg/tasks/task_paste_posix.go\`](pkg/tasks/task_paste_posix.go)：第 90、189 行 \`t.details = append(...)\` 不持锁。

## 改动

[\`pkg/tasks/task.go\`](pkg/tasks/task.go) 新增两个最小 helper：

\`\`\`go
func (t *Task) appendDetail(line string)   // \u52a0\u9501 append details
func (t *Task) setTidyDirs(v bool)         // \u52a0\u9501 \u5199 tidyDirs
\`\`\`

然后把 4 处直接写都换成 helper 调用。\`checkJobStats\` 顶部读 \`totalSize\` 改用 \`snapshot().TotalSize\`；循环里要读 \`t.transfer\` 也改用每 tick 取一次 snapshot 的 \`Transfer\` 字段。

## 范围说明

paste 任务里还有一类 \`t.wasPaused\` / \`t.pausedParam\` / \`t.pausedPhase\` / \`t.pausedSyncMkdir\` 跨 phase 读写——那是 worker 内部状态，本 PR 不动，留作 \"A.4b paused* 字段加锁\" 单独处理。

## 验证方式

- [ ] \`go build ./pkg/tasks/ && go vet ./pkg/tasks/\` 通过。
- [ ] \`go test -race ./pkg/tasks/...\`（待 C.3 测试落地后能跑）。
- [ ] 手工：跑一次 cloud → cloud 大文件 paste，期间持续 \`GET /api/task\`，进度字段平滑、tidyDirs 状态正确，无 race 报警。


Made with [Cursor](https://cursor.com)