### PR TITLE
fix(tasks): paused*/currentPhase \u8d70 accessor + \u9501\uff0c\u5173\u4e0a B2 \u9057\u7559

### DIFF
--- a/pkg/tasks/task.go
+++ b/pkg/tasks/task.go
@@ -136,6 +136,70 @@ func (t *Task) getState() string {
 	return t.state
 }
 
+// pausedSnapshot is a consistent view of the worker's pause /
+// resume state. Use Task.pausedSnap() to acquire one rather than
+// touching t.wasPaused / t.pausedParam / t.pausedPhase /
+// t.pausedSyncMkdir directly: PauseTask writes those fields from
+// the HTTP goroutine and the worker reads them across phases, so
+// without a mutex on both sides the writes are not guaranteed to
+// be visible per the Go memory model.
+type pausedSnapshot struct {
+	WasPaused bool
+	Param     *models.FileParam
+	Phase     int
+	SyncMkdir bool
+}
+
+func (t *Task) pausedSnap() pausedSnapshot {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return pausedSnapshot{
+		WasPaused: t.wasPaused,
+		Param:     t.pausedParam,
+		Phase:     t.pausedPhase,
+		SyncMkdir: t.pausedSyncMkdir,
+	}
+}
+
+// markPaused records the pause checkpoint when a phase decides to
+// stop progressing (typically after isCancel + suspend).
+func (t *Task) markPaused(param *models.FileParam, phase int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.pausedParam = param
+	t.pausedPhase = phase
+}
+
+// setPausedSyncMkdir sets t.pausedSyncMkdir under the lock.
+func (t *Task) setPausedSyncMkdir(v bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.pausedSyncMkdir = v
+}
+
+// clearPausedParam sets t.pausedParam to nil under the lock.
+func (t *Task) clearPausedParam() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.pausedParam = nil
+}
+
+// takePausedParam atomically reads and clears t.pausedParam.
+func (t *Task) takePausedParam() *models.FileParam {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	p := t.pausedParam
+	t.pausedParam = nil
+	return p
+}
+
+// setPausedParam writes t.pausedParam under the lock.
+func (t *Task) setPausedParam(p *models.FileParam) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.pausedParam = p
+}
+
 // ~ Cancel
 func (t *Task) Cancel() {
 	t.ctxCancel()

--- a/pkg/tasks/task_paste_cloud.go
+++ b/pkg/tasks/task_paste_cloud.go
@@ -37,25 +37,26 @@ func (t *Task) DownloadFromCloud() error {
 	var srcOwner = t.param.SrcOwner
 	var dstOwner = t.param.DstOwner
 
+	ps := t.pausedSnap()
+	snap := t.snapshot()
 	if t.param.Dst.IsSync() { // cloud->sync, if phase 1 complete
-		if t.pausedPhase == t.totalPhases {
-			klog.Infof("[Task] Id: %s, resume phase: %d", t.id, t.pausedPhase)
+		if ps.Phase == snap.TotalPhases {
+			klog.Infof("[Task] Id: %s, resume phase: %d", t.id, ps.Phase)
 			return nil
 		}
 	}
 
-	if t.wasPaused && t.pausedParam == nil {
+	if ps.WasPaused && ps.Param == nil {
 		klog.Errorf("[Task] Id: %s, paused param invalid", t.id)
 		return errors.New("pause param invalid")
 	}
 
-	if !t.param.Dst.IsSync() && t.wasPaused {
-		t.param.Dst = t.pausedParam
-		t.pausedParam = nil
+	if !t.param.Dst.IsSync() && ps.WasPaused {
+		t.param.Dst = t.takePausedParam()
 	}
 
 	if t.param.Dst.IsSync() {
-		if !t.wasPaused {
+		if !ps.WasPaused {
 			// copying files to Seahub, the files will first be downloaded to the local
 			srcName, isFile := files.GetFileNameFromPath(src.Path)
 			srcPath := srcName
@@ -71,8 +72,7 @@ func (t *Task) DownloadFromCloud() error {
 			}
 			dst = cacheParam
 		} else {
-			dst = t.pausedParam
-			t.pausedParam = nil
+			dst = t.takePausedParam()
 		}
 	} else {
 		dst = t.param.Dst // posix
@@ -83,7 +83,7 @@ func (t *Task) DownloadFromCloud() error {
 		dst.Owner = dstOwner
 	}
 
-	klog.Infof("[Task] Id: %s, start, downloadFromCloud, phase: %d/%d, paused: %v, user: %s, action: %s, src: %s, dst: %s", t.id, t.currentPhase, t.totalPhases, t.wasPaused, user, action, common.ToJson(src), common.ToJson(dst))
+	klog.Infof("[Task] Id: %s, start, downloadFromCloud, phase: %d/%d, paused: %v, user: %s, action: %s, src: %s, dst: %s", t.id, snap.CurrentPhase, snap.TotalPhases, ps.WasPaused, user, action, common.ToJson(src), common.ToJson(dst))
 
 	// check local free space
 	dstUri, err := dst.GetResourceUri()
@@ -111,8 +111,8 @@ func (t *Task) DownloadFromCloud() error {
 
 	t.updateTotalSize(cloudSize)
 
-	if !t.wasPaused {
-		if t.currentPhase == t.totalPhases {
+	if !ps.WasPaused {
+		if snap.CurrentPhase == snap.TotalPhases {
 			var newDstPath string
 			newDstPath, err = t.manager.GetCloudOrPosixDupNames(t.id, action, parentPath, src, dst, t.param.Src, t.param.Dst)
 			if err != nil {
@@ -136,8 +136,7 @@ func (t *Task) DownloadFromCloud() error {
 	}
 
 	if ctxCancel, ctxErr := t.isCancel(); ctxCancel {
-		t.pausedParam = dst
-		t.pausedPhase = t.currentPhase
+		t.markPaused(dst, t.snapshot().CurrentPhase)
 		return ctxErr
 	}
 
@@ -184,8 +183,7 @@ func (t *Task) DownloadFromCloud() error {
 	}
 
 	if err != nil {
-		t.pausedParam = dst
-		t.pausedPhase = t.currentPhase
+		t.markPaused(dst, t.snapshot().CurrentPhase)
 		return err
 	}
 
@@ -214,7 +212,7 @@ func (t *Task) DownloadFromCloud() error {
 
 	}
 
-	klog.Infof("[Task] Id: %s done! done: %v, phase: %d, error: %v", t.id, done, t.currentPhase, err)
+	klog.Infof("[Task] Id: %s done! done: %v, phase: %d, error: %v", t.id, done, t.snapshot().CurrentPhase, err)
 
 	return err
 }
@@ -236,9 +234,8 @@ func (t *Task) UploadToCloud() error {
 	var src *models.FileParam
 	var dst *models.FileParam
 
-	if t.pausedParam != nil {
-		dst = t.pausedParam
-		t.pausedParam = nil
+	if p := t.takePausedParam(); p != nil {
+		dst = p
 	} else {
 		dst = t.param.Dst
 	}
@@ -253,7 +250,8 @@ func (t *Task) UploadToCloud() error {
 		src = t.param.Src
 	}
 
-	klog.Infof("[Task] Id: %s, start, uploadToCloud, phase: %d/%d, user: %s, action: %s, uploadParentPath: %s, src: %s, dst: %s", t.id, t.currentPhase, t.totalPhases, user, action, uploadParentPath, common.ToJson(src), common.ToJson(dst))
+	snap := t.snapshot()
+	klog.Infof("[Task] Id: %s, start, uploadToCloud, phase: %d/%d, user: %s, action: %s, uploadParentPath: %s, src: %s, dst: %s", t.id, snap.CurrentPhase, snap.TotalPhases, user, action, uploadParentPath, common.ToJson(src), common.ToJson(dst))
 
 	if action == common.ActionUpload && uploadParentPath == "" {
 		return fmt.Errorf("uploaded parent path invalid")
@@ -272,9 +270,10 @@ func (t *Task) UploadToCloud() error {
 
 	t.updateTotalSize(posixSize)
 
-	if !t.wasPaused || (t.wasPaused && t.pausedPhase != t.currentPhase) {
+	ps := t.pausedSnap()
+	if !ps.WasPaused || (ps.WasPaused && ps.Phase != snap.CurrentPhase) {
 		// check duplicated names and generate new name
-		klog.Infof("[Task] Id: %s, check dup name, wasPaused: %v, pausedPhase: %d", t.id, t.wasPaused, t.pausedPhase)
+		klog.Infof("[Task] Id: %s, check dup name, wasPaused: %v, pausedPhase: %d", t.id, ps.WasPaused, ps.Phase)
 		var newDstPath string
 		newDstPath, err = t.manager.GetCloudOrPosixDupNames(t.id, action, uploadParentPath, src, dst, t.param.Src, t.param.Dst) // uploadToCloud
 		if err != nil {
@@ -288,8 +287,7 @@ func (t *Task) UploadToCloud() error {
 	}
 
 	if ctxCancel, ctxErr := t.isCancel(); ctxCancel {
-		t.pausedParam = dst
-		t.pausedPhase = t.currentPhase
+		t.markPaused(dst, t.snapshot().CurrentPhase)
 		return ctxErr
 	}
 
@@ -316,8 +314,7 @@ func (t *Task) UploadToCloud() error {
 	}
 
 	if err != nil {
-		t.pausedParam = dst
-		t.pausedPhase = t.currentPhase
+		t.markPaused(dst, t.snapshot().CurrentPhase)
 		return err
 	}
 
@@ -353,7 +350,7 @@ func (t *Task) UploadToCloud() error {
 		}
 	}
 
-	klog.Infof("[Task] Id: %s done! done: %v, phase: %d, error: %v", t.id, done, t.currentPhase, err)
+	klog.Infof("[Task] Id: %s done! done: %v, phase: %d, error: %v", t.id, done, t.snapshot().CurrentPhase, err)
 
 	return err
 }
@@ -369,9 +366,8 @@ func (t *Task) CopyToCloud() error {
 	var src = t.param.Src
 	var dst = t.param.Dst
 
-	if t.pausedParam != nil {
-		dst = t.pausedParam
-		t.pausedParam = nil
+	if p := t.takePausedParam(); p != nil {
+		dst = p
 	}
 
 	klog.Infof("[Task] Id: %s, start, copyToCloud, user: %s, action: %s, src: %s, dst: %s", t.id, user, action, common.ToJson(src), common.ToJson(dst))
@@ -384,8 +380,9 @@ func (t *Task) CopyToCloud() error {
 	}
 	t.updateTotalSize(srcSize)
 
-	if !t.wasPaused {
-		klog.Infof("[Task] Id: %s, check dup name, wasPaused: %v, pausedPhase: %d", t.id, t.wasPaused, t.pausedPhase)
+	ps2 := t.pausedSnap()
+	if !ps2.WasPaused {
+		klog.Infof("[Task] Id: %s, check dup name, wasPaused: %v, pausedPhase: %d", t.id, ps2.WasPaused, ps2.Phase)
 		var newDstPath string
 		newDstPath, err = t.manager.GetCloudOrPosixDupNames(t.id, action, parentPath, src, dst, t.param.Src, t.param.Dst)
 		if err != nil {
@@ -399,8 +396,7 @@ func (t *Task) CopyToCloud() error {
 	}
 
 	if ctxCancel, ctxErr := t.isCancel(); ctxCancel {
-		t.pausedParam = dst
-		t.pausedPhase = t.currentPhase
+		t.markPaused(dst, t.snapshot().CurrentPhase)
 		return ctxErr
 	}
 
@@ -447,8 +443,7 @@ func (t *Task) CopyToCloud() error {
 	}
 
 	if err != nil {
-		t.pausedParam = dst
-		t.pausedPhase = t.currentPhase
+		t.markPaused(dst, t.snapshot().CurrentPhase)
 		return err
 	}
 
@@ -459,7 +454,7 @@ func (t *Task) CopyToCloud() error {
 		}
 	}
 
-	klog.Infof("[Task] Id: %s done! done: %v, phase: %d, error: %v", t.id, done, t.currentPhase, err)
+	klog.Infof("[Task] Id: %s done! done: %v, phase: %d, error: %v", t.id, done, t.snapshot().CurrentPhase, err)
 
 	return err
 

--- a/pkg/tasks/task_paste_download.go
+++ b/pkg/tasks/task_paste_download.go
@@ -24,9 +24,9 @@ func (t *Task) DownloadFromFiles() error {
 	var src = t.param.Src
 	var dst *models.FileParam
 
-	if t.wasPaused {
-		t.param.Dst = t.pausedParam
-		t.pausedParam = nil
+	if ps := t.pausedSnap(); ps.WasPaused {
+		t.param.Dst = ps.Param
+		t.clearPausedParam()
 	}
 
 	dst = t.param.Dst
@@ -113,7 +113,7 @@ func (t *Task) DownloadFromFiles() error {
 
 	dstPath := dstUri + dstPathPrefix
 
-	if !t.wasPaused {
+	if !t.pausedSnap().WasPaused {
 		dupNames, err := files.CollectDupNames(dstPath, srcFilePrefix, srcFileExt, isSrcFile)
 		if err != nil {
 			klog.Errorf("[Task] Id: %s, get dup name error: %v", t.id, err)
@@ -137,8 +137,7 @@ func (t *Task) DownloadFromFiles() error {
 	}
 
 	if ctxCancel, ctxErr := t.isCancel(); ctxCancel {
-		t.pausedParam = dst
-		t.pausedPhase = t.currentPhase
+		t.markPaused(dst, t.snapshot().CurrentPhase)
 		return ctxErr
 	}
 
@@ -247,12 +246,12 @@ func (t *Task) DownloadFromFiles() error {
 	}
 
 	if err != nil {
-		t.pausedParam = dst
-		t.pausedPhase = t.currentPhase
+		snap := t.snapshot()
+		t.markPaused(dst, snap.CurrentPhase)
 		return err
 	}
 
-	klog.Infof("[Task] Id: %s done! phase: %d", t.id, t.currentPhase)
+	klog.Infof("[Task] Id: %s done! phase: %d", t.id, t.snapshot().CurrentPhase)
 
 	return err
 }

--- a/pkg/tasks/task_paste_posix.go
+++ b/pkg/tasks/task_paste_posix.go
@@ -66,7 +66,7 @@ func (t *Task) Rsync() error {
 	}
 	klog.Infof("[Task] Id: %s, dstFree: %d", t.id, dstFree)
 
-	if !t.wasPaused {
+	if !t.pausedSnap().WasPaused {
 		generatedDstNewName, generatedDstNewPath, err := t.generateNewName(pathMeta)
 		if err != nil {
 			return fmt.Errorf("generate dst name error: %v", err)
@@ -95,7 +95,7 @@ func (t *Task) Rsync() error {
 	err = t.rsync() // rsync
 	if err != nil {
 		klog.Errorf("[Task] Id: %s, copy dst error: %v", t.id, err)
-		t.pausedParam = t.param.Dst
+		t.setPausedParam(t.param.Dst)
 		return err
 	}
 

--- a/pkg/tasks/task_paste_sync.go
+++ b/pkg/tasks/task_paste_sync.go
@@ -45,25 +45,26 @@ func (t *Task) DownloadFromSync() error {
 	var tempParam *models.FileParam
 	var dst *models.FileParam
 
+	ps := t.pausedSnap()
+	snap := t.snapshot()
 	if t.param.Dst.IsCloud() { // sync->cloud, if phase 1 complete
-		if t.pausedPhase == t.totalPhases {
-			klog.Infof("[Task] Id: %s, resume phase: %d", t.id, t.pausedPhase)
+		if ps.Phase == snap.TotalPhases {
+			klog.Infof("[Task] Id: %s, resume phase: %d", t.id, ps.Phase)
 			return nil
 		}
 	}
 
-	if t.wasPaused && t.pausedParam == nil {
+	if ps.WasPaused && ps.Param == nil {
 		klog.Errorf("[Task] Id: %s, paused param invalid", t.id)
 		return errors.New("pause param invalid")
 	}
 
-	if !t.param.Dst.IsCloud() && t.wasPaused {
-		t.param.Dst = t.pausedParam
-		t.pausedParam = nil
+	if !t.param.Dst.IsCloud() && ps.WasPaused {
+		t.param.Dst = t.takePausedParam()
 	}
 
 	if t.param.Dst.IsCloud() {
-		if !t.wasPaused {
+		if !ps.WasPaused {
 			srcName, isFile := files.GetFileNameFromPath(src.Path)
 			srcPath := srcName
 			if !isFile {
@@ -78,8 +79,7 @@ func (t *Task) DownloadFromSync() error {
 			}
 			dst = tempParam
 		} else {
-			dst = t.pausedParam
-			t.pausedParam = nil
+			dst = t.takePausedParam()
 		}
 	} else {
 		dst = t.param.Dst
@@ -90,7 +90,7 @@ func (t *Task) DownloadFromSync() error {
 		dst.Owner = dstOwner
 	}
 
-	klog.Infof("[Task] Id: %s, start, downloadFormSync, phase: %d/%d, user: %s, action: %s, src: %s, dst: %s, psrc: %s, pdst: %s", t.id, t.currentPhase, t.totalPhases, user, action, common.ToJson(src), common.ToJson(dst), common.ToJson(t.param.Src), common.ToJson(t.param.Dst))
+	klog.Infof("[Task] Id: %s, start, downloadFormSync, phase: %d/%d, user: %s, action: %s, src: %s, dst: %s, psrc: %s, pdst: %s", t.id, snap.CurrentPhase, snap.TotalPhases, user, action, common.ToJson(src), common.ToJson(dst), common.ToJson(t.param.Src), common.ToJson(t.param.Dst))
 
 	// check local free space
 	srcTotalSize, err := t.GetFromSyncFileCount("size") // file and dir can both use this
@@ -133,8 +133,7 @@ func (t *Task) DownloadFromSync() error {
 	}
 
 	if err != nil {
-		t.pausedParam = dst
-		t.pausedPhase = t.currentPhase
+		t.markPaused(dst, t.snapshot().CurrentPhase)
 		return searpc.SyncConnectionFailedError(err)
 	}
 
@@ -178,13 +177,17 @@ func (t *Task) UploadToSync() error {
 		src = t.param.Src
 	}
 
-	if t.wasPaused && t.pausedPhase == t.totalPhases {
-		if t.pausedParam == nil {
-			return fmt.Errorf("[Task] Id: %s, pause param invalid", t.id)
+	{
+		ps := t.pausedSnap()
+		snap := t.snapshot()
+		if ps.WasPaused && ps.Phase == snap.TotalPhases {
+			if ps.Param == nil {
+				return fmt.Errorf("[Task] Id: %s, pause param invalid", t.id)
+			}
+			dst = ps.Param
+		} else {
+			dst = t.param.Dst
 		}
-		dst = t.pausedParam
-	} else {
-		dst = t.param.Dst
 	}
 
 	if share == 1 {
@@ -209,7 +212,10 @@ func (t *Task) UploadToSync() error {
 
 	_, isFile := src.IsFile()
 
-	klog.Infof("[Task] Id: %s, start, uploadToSync, phase: %d/%d, user: %s, action: %s, src: %s, dst: %s", t.id, t.currentPhase, t.totalPhases, user, action, common.ToJson(src), common.ToJson(dst))
+	{
+		snap := t.snapshot()
+		klog.Infof("[Task] Id: %s, start, uploadToSync, phase: %d/%d, user: %s, action: %s, src: %s, dst: %s", t.id, snap.CurrentPhase, snap.TotalPhases, user, action, common.ToJson(src), common.ToJson(dst))
+	}
 
 	if isFile {
 		err = t.UploadFileToSync(src, dst)
@@ -224,9 +230,8 @@ func (t *Task) UploadToSync() error {
 	}
 
 	if err != nil {
-		t.pausedParam = dst
-		t.pausedPhase = t.currentPhase
-		t.pausedSyncMkdir = true
+		t.markPaused(dst, t.snapshot().CurrentPhase)
+		t.setPausedSyncMkdir(true)
 		return err
 	}
 
@@ -287,7 +292,10 @@ func (t *Task) SyncCopy() error {
 		return err
 	}
 
-	klog.Infof("[Task] Id: %s, start, syncCopy, phase: %d/%d, user: %s, action: %s, src: %s, dst: %s", t.id, t.currentPhase, t.totalPhases, user, action, common.ToJson(t.param.Src), common.ToJson(t.param.Dst))
+	{
+		snap := t.snapshot()
+		klog.Infof("[Task] Id: %s, start, syncCopy, phase: %d/%d, user: %s, action: %s, src: %s, dst: %s", t.id, snap.CurrentPhase, snap.TotalPhases, user, action, common.ToJson(t.param.Src), common.ToJson(t.param.Dst))
+	}
 
 	t.updateTotalSize(totalSize)
 
@@ -422,7 +430,7 @@ func (t *Task) DownloadDirFromSync(src, dst *models.FileParam, root bool) error 
 
 	if root {
 		if !t.param.Dst.IsCloud() {
-			if !t.wasPaused {
+			if !t.pausedSnap().WasPaused {
 				downloadPath = AddVersionSuffix(downloadPath, dst, true, "")
 			}
 
@@ -550,7 +558,7 @@ func (t *Task) DownloadFileFromSync(src, dst *models.FileParam, root bool) error
 		return fmt.Errorf("unrecognizable response format")
 	}
 
-	if !t.wasPaused {
+	if !t.pausedSnap().WasPaused {
 		downloadFilePath = AddVersionSuffix(downloadPath+"/"+dstFileName, dst, false, "")
 	} else {
 		downloadFilePath = filepath.Join(downloadPath, dstFileName)
@@ -710,7 +718,8 @@ func (t *Task) UploadDirToSync(src, dst *models.FileParam, root bool) error {
 	var fdstBase = strings.TrimPrefix(dstFullPath, dstUri)
 
 	if root {
-		if !t.wasPaused || !t.pausedSyncMkdir {
+		ps := t.pausedSnap()
+		if !ps.WasPaused || !ps.SyncMkdir {
 			dstFullPath = AddVersionSuffix(dstFullPath, dst, true, "")
 			fdstBase = strings.TrimPrefix(dstFullPath, dstUri)
 		}
@@ -832,7 +841,8 @@ func (t *Task) UploadFileToSync(src, dst *models.FileParam) error {
 
 	_, isUploadFile := t.param.Src.IsFile()
 
-	if isUploadFile && !t.wasPaused {
+	wasPaused := t.pausedSnap().WasPaused
+	if isUploadFile && !wasPaused {
 		newDstPath, err := t.manager.GetSyncDupName(t.id, src, dst, t.param.Src, t.param.Dst)
 		if err != nil {
 			return err
@@ -842,7 +852,7 @@ func (t *Task) UploadFileToSync(src, dst *models.FileParam) error {
 		klog.Infof("[Task] Id: %s, generate dup name: %s, dst: %s", t.id, newDstPath, common.ToJson(dst))
 	}
 
-	if t.wasPaused {
+	if wasPaused {
 
 		getFileId, _ := seahub.GetUploadFile(dst)
 		if getFileId != "" {
@@ -1198,8 +1208,7 @@ func (t *Task) CalculateSyncProgressRange(currentFileSize int64) (left, mid, rig
 
 func (t *Task) DoSyncCopy(src, dst *models.FileParam, root bool) error {
 	if ctxCancel, ctxErr := t.isCancel(); ctxCancel {
-		t.pausedParam = dst
-		t.pausedPhase = t.currentPhase
+		t.markPaused(dst, t.snapshot().CurrentPhase)
 		return ctxErr
 	}
 
@@ -1223,8 +1232,7 @@ func (t *Task) DoSyncCopy(src, dst *models.FileParam, root bool) error {
 	}
 
 	if err != nil {
-		t.pausedParam = dst
-		t.pausedPhase = t.currentPhase
+		t.markPaused(dst, t.snapshot().CurrentPhase)
 		return err
 	}
 


### PR DESCRIPTION
## 概要

PR #241（B2）给 \`Task\` 加了 \`mu sync.RWMutex\`，但当时**故意只覆盖了 HTTP 报告路径**，把 worker 内部跨 goroutine 共享的几个字段留给后续：

- \`t.wasPaused\`：HTTP \`PauseTask\` 写、worker 跨多个 phase 读；
- \`t.pausedParam\` / \`t.pausedPhase\`：worker 写、Cancel 读；
- \`t.pausedSyncMkdir\`：worker 内部跨调用读写；
- \`t.currentPhase\` / \`t.totalPhases\`：worker 写、worker 自己日志里读、HTTP 报告读。

per Go memory model，**没有 mutex 在写端，读端取再大锁也不保证可见**。\`go test -race\` 在每个读点都会报。

## 改动

### 新增 accessors（[\`pkg/tasks/task.go\`](pkg/tasks/task.go)）

- \`pausedSnap() pausedSnapshot\`：一次 RLock 拿出 4 个 paused* 字段的一致视图
- \`markPaused(param, phase)\`：写 paused checkpoint（替代 \`t.pausedParam = ...; t.pausedPhase = ...\`）
- \`clearPausedParam()\` / \`takePausedParam()\` / \`setPausedParam(p)\`
- \`setPausedSyncMkdir(v)\`

### 全面替换调用点

- 12 处 \`if ctxCancel { t.pausedParam = dst; t.pausedPhase = t.currentPhase; return ctxErr }\` 收成 \`t.markPaused(dst, snap.CurrentPhase)\`。
- \`dst = t.pausedParam; t.pausedParam = nil\` 收成 \`dst = t.takePausedParam()\`。
- \`t.wasPaused\` / \`t.pausedPhase\` 等读访问改用 \`pausedSnap()\`，单函数内一次取齐。
- 日志中读 \`t.currentPhase\` / \`t.totalPhases\` 改用 \`t.snapshot()\` 字段，一个 log 行内值一致。

文件覆盖：4 个 \`task_paste_*.go\` 全部清扫。

## 范围

至此 B2 留下的 worker-internal race 已经基本闭合。\`pkg/tasks/task.go\` 内部的少量直接访问都在已经持锁的临界区内（snapshot / Cancel / Execute），无需改。

## 验证方式

- [ ] \`go build ./pkg/tasks/ && go vet ./pkg/tasks/\` 通过。
- [ ] \`go test -race ./pkg/tasks/...\`（待 C.3 测试落地）应当不再报这几个字段相关的 race。
- [ ] 手工：cloud→cloud / sync→cloud / cloud→sync / posix paste 各跑一次完整流程；中途 Pause + Resume 各一次；行为与之前一致（state、details、tidyDirs、paused* 在 GET /api/task 中正确显示）。


Made with [Cursor](https://cursor.com)