### PR TITLE
ci: \u65b0\u589e .golangci.yml \u6700\u5c0f\u9ad8\u4fe1\u53f7 lint \u96c6

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,73 @@
+# golangci-lint config for the files backend.
+#
+# Scope: a small high-signal set targeting the bug classes the team
+# has actually been hit by. Each enabled linter maps to merged fixes:
+#
+#   govet (copylocks)  -> PR #240 (Listing copylocks)
+#   staticcheck (SA*)  -> general nil/dead/SA*
+#   errcheck           -> PR #229 (Chown ignored err),
+#                         PR #234 (download nil-deref)
+#   bodyclose          -> PR #238 (MountPathIncluster body leak),
+#                         PR #264 (UploadFileToSync chunk defer)
+#   ineffassign        -> would have caught PR #229's overwritten err
+#   misspell           -> hygiene
+#
+# Everything else is left default-off to keep noise down. We can add
+# `unused`, `gocritic`, `revive`, etc. once the team is comfortable
+# with this baseline.
+#
+# Once CI is wired (see follow-up to .github/workflows/ci.yml), the
+# linter is intended to run in advisory mode (continue-on-error)
+# until the existing report baseline is burned down. Use
+#   golangci-lint run --new-from-rev=origin/main
+# to fail only on issues introduced by the current PR.
+
+run:
+  timeout: 5m
+  tests: true
+  # The CI workflow precomputes the working package list into
+  # .ci-pkgs.txt (because pkg/media/api and pkg/media/mediabrowser/
+  # common/net have pre-existing build errors). Local invocations
+  # should pass the same list explicitly:
+  #   golangci-lint run $(cat .ci-pkgs.txt | sed 's,files/,./,')
+
+linters:
+  disable-all: true
+  enable:
+    - govet
+    - staticcheck
+    - errcheck
+    - bodyclose
+    - ineffassign
+    - misspell
+
+linters-settings:
+  errcheck:
+    # The repo uses klog and fmt as the primary log surfaces; their
+    # error returns are not interesting and would create thousands
+    # of false positives.
+    exclude-functions:
+      - (k8s.io/klog/v2).Errorln
+      - (k8s.io/klog/v2).Errorf
+      - (k8s.io/klog/v2).Infoln
+      - (k8s.io/klog/v2).Infof
+      - (k8s.io/klog/v2).Warningln
+      - (k8s.io/klog/v2).Warningf
+      - fmt.Println
+      - fmt.Printf
+      - fmt.Fprintln
+      - fmt.Fprintf
+  govet:
+    enable:
+      - copylocks
+      - shadow
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  exclude-dirs:
+    # Pre-existing legacy media subpackages with build errors that
+    # cmd/backend does not actually import. Match what ci.yml's
+    # .ci-pkgs.txt skips.
+    - pkg/media/api
+    - pkg/media/mediabrowser/common/net


### PR DESCRIPTION
## 概要

新增项目级 \`golangci-lint\` 配置文件 [\`.golangci.yml\`](.golangci.yml)，启用一个小但高信号的 linter 集合。每条都能对应回最近合并的修复：

| Linter | 对应的已合并 PR |
|---|---|
| \`govet\`（含 \`copylocks\`） | #240 |
| \`staticcheck\` | 通用 SA* / 死代码 / nil |
| \`errcheck\` | #229（chown 吞 err）、#234（download nil-deref） |
| \`bodyclose\` | #238（mount body 泄漏）、#264（chunk defer） |
| \`ineffassign\` | 也能抓到 #229 那种"被覆盖的赋值" |
| \`misspell\` | 一致性 |

\`errcheck\` 排除 \`klog.*\` 和 \`fmt.Print*/Fprint*\`——它们的 error 返回不重要，否则会有数千个 false positive。

## 当前 baseline

本地跑了一次（\`golangci-lint v1.62.0\`），共 ~270 条已存在的报告：

\`\`\`
 123 govet
  73 errcheck
  38 ineffassign
  27 staticcheck
   8 misspell
   1 bodyclose
\`\`\`

所以**不能立刻 blocking**。建议：

1. 本 PR 只落配置；
2. CI 接入留给 #268（CI workflow PR）合并后做一行 follow-up，advisory 模式跑；
3. 团队按 linter 顺序逐步 burn down baseline；
4. 全部清零后 \`continue-on-error\` 改 \`false\` 变 blocking。或者立刻用 \`--new-from-rev=origin/main\` 只对新引入的报告 fail。

## 验证方式

- [ ] \`golangci-lint config verify\` 通过（已本地验证）。
- [ ] 本地：

  \`\`\`
  golangci-lint run $(go list ./... 2>/dev/null \\
    | grep -v -E '^files/pkg/media/mediabrowser/common/net$|^files/pkg/media/api$' \\
    | sed 's|^files/|./|')
  \`\`\`
  
  能跑出报告（基线 ~270 条）。


Made with [Cursor](https://cursor.com)