### PR TITLE
test(tasks): \u8865 Task snapshot \u4e0e update \u5e76\u53d1\u7684 -race \u56de\u5f52\u6d4b\u8bd5

### DIFF
--- a/pkg/tasks/task_test.go
+++ b/pkg/tasks/task_test.go
@@ -1,0 +1,114 @@
+package tasks
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestTask_SnapshotUnderConcurrentUpdates pins the property that
+// PR #241 (B2) added: concurrent worker-side state updates and
+// HTTP-side snapshot reads must not race and must produce
+// internally consistent views.
+//
+// The HTTP path is modelled by snapshot(); the worker path is
+// modelled by updateProgress and updateTotalSize (the locked
+// accessors that already exist on main today; helpers added by
+// PR #266 / #267 such as appendDetail / setTidyDirs / pausedSnap
+// will get their own follow-up tests once those PRs land).
+//
+// Run with -race to catch any future regression that drops the
+// mutex on either side.
+func TestTask_SnapshotUnderConcurrentUpdates(t *testing.T) {
+	const (
+		updaters = 4
+		readers  = 4
+		duration = 200 * time.Millisecond
+	)
+
+	task := &Task{id: "test"}
+	deadline := time.Now().Add(duration)
+	var wg sync.WaitGroup
+
+	// Updater goroutines: model the worker phase doing progress
+	// updates and total-size resets.
+	for i := 0; i < updaters; i++ {
+		wg.Add(1)
+		go func(seed int) {
+			defer wg.Done()
+			n := int64(seed)
+			for time.Now().Before(deadline) {
+				n++
+				task.updateProgress(int(n%100), n)
+				if n%3 == 0 {
+					task.updateTotalSize(n * 1024)
+				}
+			}
+		}(i)
+	}
+
+	// Reader goroutines: model HTTP GetTask / GetTasksByStatus
+	// projecting through snapshot(). The only invariant we can pin
+	// down without coordinating with updaters is: Progress is in
+	// [0, 100] and TotalSize is non-negative. Any tear of multi-word
+	// fields (string `state`, int64 sizes) would be flagged by the
+	// race detector.
+	var snapshots int64
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for time.Now().Before(deadline) {
+				snap := task.snapshot()
+				atomic.AddInt64(&snapshots, 1)
+				if snap.Progress < 0 || snap.Progress >= 100 {
+					t.Errorf("snapshot Progress out of range: %d", snap.Progress)
+					return
+				}
+				if snap.TotalSize < 0 {
+					t.Errorf("snapshot TotalSize negative: %d", snap.TotalSize)
+					return
+				}
+				_ = snap.State
+				_ = snap.Message
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	if atomic.LoadInt64(&snapshots) == 0 {
+		t.Fatalf("no snapshots taken; reader goroutines never ran")
+	}
+}
+
+// TestTask_GetStateConsistent makes sure getState() is callable
+// concurrently with updateProgress (which writes other fields under
+// the same mutex). Race detector is the real assertion here; the
+// returned value just has to be the empty string we never set.
+func TestTask_GetStateConsistent(t *testing.T) {
+	task := &Task{id: "test"}
+
+	const duration = 100 * time.Millisecond
+	deadline := time.Now().Add(duration)
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for n := int64(0); time.Now().Before(deadline); n++ {
+			task.updateProgress(int(n%100), n)
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for time.Now().Before(deadline) {
+			_ = task.getState()
+		}
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
## 概要

PR #241（B2）给 \`Task\` 加了 \`t.mu sync.RWMutex\` 和 \`snapshot()\`，让 HTTP-端读 (\`GetTask\`/\`GetTasksByStatus\`) 与 worker-端写 (\`updateProgress\`/\`updateTotalSize\` 等) 互不 race。补上**针对性回归测试**，钉死这个契约：

| 测试 | 覆盖 |
|---|---|
| \`TestTask_SnapshotUnderConcurrentUpdates\` | 4 个 updater × 4 个 reader 互相打 200ms；断言 snapshot 字段在合法范围内、至少有 snapshot 被读到 |
| \`TestTask_GetStateConsistent\` | \`getState()\` 与 \`updateProgress\` 并发不 race |

两个测试**主要在 \`-race\` 模式下生效**——race detector 才是真正的断言；不开 race 也能跑，但只验证轻量 invariant。

## 范围

故意只用 main 当前已有的 helper（\`updateProgress\`/\`updateTotalSize\`/\`snapshot\`/\`getState\`），保证本 PR 在干净 main 上能编译能跑。

PR #266（A.4a：\`appendDetail\`/\`setTidyDirs\`）和 PR #267（A.4b：\`pausedSnap\`/\`markPaused\`/\`takePausedParam\`/\`setPausedSyncMkdir\`）合并后会再补一个 follow-up 测试覆盖它们。

## 验证方式

- [ ] 本地：\`go test -race ./pkg/tasks/ -run TestTask -v -count=1\` 通过（已验证）。
- [ ] CI（PR #268 合并后）跑 \`go test -race ./pkg/tasks/...\` 自动覆盖。


Made with [Cursor](https://cursor.com)