### PR TITLE
test(share): \u62bd ValidateShareTokenForPath helper + IDOR \u56de\u5f52\u6d4b\u8bd5

### DIFF
--- a/pkg/hertz/biz/handler/api/share/share_token_validate.go
+++ b/pkg/hertz/biz/handler/api/share/share_token_validate.go
@@ -1,0 +1,72 @@
+package share
+
+import (
+	"time"
+
+	"files/pkg/common"
+
+	share "files/pkg/hertz/biz/model/api/share"
+)
+
+// ShareTokenValidationError categorises the reason a share token
+// failed validation. The handler maps each reason to a specific
+// HTTP error envelope (token-expired vs link-expired) and to a
+// timestamp the client can use to display a "your link expired at
+// X" message.
+type ShareTokenValidationError int
+
+const (
+	// ShareTokenValidationOK means the token is valid for the
+	// requested path and not yet expired.
+	ShareTokenValidationOK ShareTokenValidationError = iota
+	// ShareTokenValidationNilToken means the token was nil (DB
+	// returned no row).
+	ShareTokenValidationNilToken
+	// ShareTokenValidationPathMismatch means the token is valid
+	// but was issued for a different path_id than the one the
+	// caller is asking about. This is the IDOR case PR #226 closed:
+	// without this rejection any valid token could be paired with
+	// an arbitrary path_id to read that share's metadata.
+	ShareTokenValidationPathMismatch
+	// ShareTokenValidationBadExpire means the token's expire_at
+	// string is malformed and cannot be parsed.
+	ShareTokenValidationBadExpire
+	// ShareTokenValidationExpired means the token expired before
+	// the validation moment.
+	ShareTokenValidationExpired
+)
+
+// ValidateShareTokenForPath enforces the contract documented above:
+// the token must be non-nil, must be issued for requestedPathID,
+// must have a parseable expire_at, and must not have expired.
+//
+// On any failure it returns:
+//   - the validation reason (use to pick the HTTP error envelope),
+//   - a unix timestamp the handler should report to the client. For
+//     "expired" cases this is the actual expiry time so the UI can
+//     say when the link died; for the other cases it is "now" (the
+//     handler must not leak a year-1 zero-Unix value back to the
+//     client when the timestamp is unparseable).
+//
+// On success it returns (ShareTokenValidationOK, 0).
+//
+// This is split out from the handler so the IDOR + expiry logic can
+// be unit-tested without spinning up Postgres or stubbing the DAL.
+// The handler refactor that replaces the inline checks with a call
+// to this function is intentionally a follow-up PR.
+func ValidateShareTokenForPath(token *share.ShareToken, requestedPathID string, now time.Time) (ShareTokenValidationError, int64) {
+	if token == nil {
+		return ShareTokenValidationNilToken, now.Unix()
+	}
+	if token.PathID != requestedPathID {
+		return ShareTokenValidationPathMismatch, now.Unix()
+	}
+	expired, ok := common.ParseRFC3339Nano(token.ExpireAt)
+	if !ok {
+		return ShareTokenValidationBadExpire, now.Unix()
+	}
+	if now.After(expired) {
+		return ShareTokenValidationExpired, expired.Unix()
+	}
+	return ShareTokenValidationOK, 0
+}

--- a/pkg/hertz/biz/handler/api/share/share_token_validate_test.go
+++ b/pkg/hertz/biz/handler/api/share/share_token_validate_test.go
@@ -1,0 +1,110 @@
+package share
+
+import (
+	"testing"
+	"time"
+
+	share "files/pkg/hertz/biz/model/api/share"
+)
+
+// fixedNow is a stable reference time the table tests below use.
+// All fixture expiry strings are computed relative to it.
+var fixedNow = time.Date(2026, 5, 6, 16, 30, 0, 0, time.UTC)
+
+func mkToken(pathID, expireAt string) *share.ShareToken {
+	return &share.ShareToken{
+		PathID:   pathID,
+		ExpireAt: expireAt,
+	}
+}
+
+// TestValidateShareTokenForPath covers the four failure modes that
+// PR #226 (the share token / path_id IDOR fix) introduced or pinned
+// down. Each case must produce the documented (reason, ts) pair.
+//
+// The IDOR case (PathMismatch) is the load-bearing one: removing
+// the PathID equality check would re-open the bug PR #226 fixed.
+func TestValidateShareTokenForPath(t *testing.T) {
+	const wantPath = "11111111-1111-1111-1111-111111111111"
+
+	cases := []struct {
+		name       string
+		token      *share.ShareToken
+		path       string
+		wantReason ShareTokenValidationError
+		wantTSNow  bool // true if returned ts must be == fixedNow.Unix()
+		wantTSAt   int64
+	}{
+		{
+			name:       "ok: matching path_id and future expiry",
+			token:      mkToken(wantPath, fixedNow.Add(time.Hour).Format(time.RFC3339Nano)),
+			path:       wantPath,
+			wantReason: ShareTokenValidationOK,
+			wantTSAt:   0, // OK -> ts unused; helper returns 0
+		},
+		{
+			name:       "nil token",
+			token:      nil,
+			path:       wantPath,
+			wantReason: ShareTokenValidationNilToken,
+			wantTSNow:  true,
+		},
+		{
+			// IDOR: token issued for some OTHER path. PR #226's
+			// regression test case. If the equality check is
+			// dropped from ValidateShareTokenForPath this case
+			// will start returning OK and this test fails.
+			name:       "path mismatch (IDOR)",
+			token:      mkToken("99999999-9999-9999-9999-999999999999", fixedNow.Add(time.Hour).Format(time.RFC3339Nano)),
+			path:       wantPath,
+			wantReason: ShareTokenValidationPathMismatch,
+			wantTSNow:  true,
+		},
+		{
+			name:       "malformed expire_at",
+			token:      mkToken(wantPath, "not-a-timestamp"),
+			path:       wantPath,
+			wantReason: ShareTokenValidationBadExpire,
+			wantTSNow:  true,
+		},
+		{
+			name:       "expired (1 hour ago)",
+			token:      mkToken(wantPath, fixedNow.Add(-time.Hour).Format(time.RFC3339Nano)),
+			path:       wantPath,
+			wantReason: ShareTokenValidationExpired,
+			wantTSAt:   fixedNow.Add(-time.Hour).Unix(),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotReason, gotTS := ValidateShareTokenForPath(tc.token, tc.path, fixedNow)
+			if gotReason != tc.wantReason {
+				t.Errorf("reason = %v, want %v", gotReason, tc.wantReason)
+			}
+			if tc.wantTSNow {
+				if gotTS != fixedNow.Unix() {
+					t.Errorf("ts = %d, want fixedNow.Unix() = %d", gotTS, fixedNow.Unix())
+				}
+			} else if gotTS != tc.wantTSAt {
+				t.Errorf("ts = %d, want %d", gotTS, tc.wantTSAt)
+			}
+		})
+	}
+}
+
+// TestValidateShareTokenForPath_NoYearOneLeak pins the explicit
+// guard against returning the year-1 Unix epoch (-62135596800) when
+// the expire string is malformed. The PR #226 fix and the
+// ParseRFC3339Nano helper both work toward "do not leak a year-1
+// timestamp into API responses"; this is a regression watch.
+func TestValidateShareTokenForPath_NoYearOneLeak(t *testing.T) {
+	tok := mkToken("path-x", "garbage")
+	_, ts := ValidateShareTokenForPath(tok, "path-x", fixedNow)
+	if ts < 0 {
+		t.Fatalf("returned ts = %d (negative); year-1 zero-time leak detected", ts)
+	}
+	if ts != fixedNow.Unix() {
+		t.Fatalf("returned ts = %d, want fixedNow.Unix() = %d (must coerce to a sane value)", ts, fixedNow.Unix())
+	}
+}


### PR DESCRIPTION
## 概要

PR #226 通过两条 inline 检查闭合了 share token 的 IDOR：

1. \`shareToken.PathID == req.PathId\`
2. \`shareToken.ExpireAt\` 可解析且未过期

但这两条检查都耦合在 \`GetExternalSharePath\` 内，且依赖包级 \`database.DB\` 全局，**无法用 DB stub / DAL interface 简单地写回归测试**。

## 改动

### 1. 抽出可测 helper

新增 [\`pkg/hertz/biz/handler/api/share/share_token_validate.go\`](pkg/hertz/biz/handler/api/share/share_token_validate.go)：

\`\`\`go
func ValidateShareTokenForPath(
    token *share.ShareToken,
    requestedPathID string,
    now time.Time,
) (ShareTokenValidationError, int64)
\`\`\`

输入是已取到的 \`*share.ShareToken\`，输出是失败原因 + 应返回给客户端的时间戳。5 种结果：

- \`ShareTokenValidationOK\`
- \`ShareTokenValidationNilToken\`（DB 没找到）
- \`ShareTokenValidationPathMismatch\`（**关键 IDOR 检查**）
- \`ShareTokenValidationBadExpire\`（\`expire_at\` 字符串非法）
- \`ShareTokenValidationExpired\`（已过期）

### 2. 表驱动单测

新增 [\`pkg/hertz/biz/handler/api/share/share_token_validate_test.go\`](pkg/hertz/biz/handler/api/share/share_token_validate_test.go)：

| 测试 | 覆盖 |
|---|---|
| \`TestValidateShareTokenForPath\` | 5 case：OK / nil / **path mismatch (IDOR)** / bad expire / expired |
| \`TestValidateShareTokenForPath_NoYearOneLeak\` | 钉死"\`expire_at\` 非法时不返回年-1 的负 Unix 值 (\`-62135596800\`)" |

如果未来谁不小心删掉 \`PathID != requestedPathID\` 这一条，\`path mismatch (IDOR)\` 那条 case 会变成 OK 直接 fail。

## 范围说明

handler 内部的 inline 检查**故意不在本 PR 替换**——避免和 PR #259（脱敏 token 日志）改同一段代码冲突。handler refactor 留给 follow-up：合掉 #259 之后做一个小 PR 把 inline 三步改成 \`ValidateShareTokenForPath\` 一行调用。

## 验证方式

- [ ] 本地：\`go test -race ./pkg/hertz/biz/handler/api/share/ -count=1\` 通过（已验证）。
- [ ] CI（PR #268 合并后）跑 \`go test -race\` 自动覆盖。


Made with [Cursor](https://cursor.com)