### PR TITLE
fix(tasks): 重做 PR #266 被合并冲掉的 appendDetail/setTidyDirs

### DIFF
--- a/pkg/tasks/task.go
+++ b/pkg/tasks/task.go
@@ -133,6 +133,31 @@ func (t *Task) getState() string {
 	return t.state
 }
 
+// appendDetail appends one line to t.details under the lock.
+//
+// Phase functions (rsync / move / checkJobStats / ...) call this
+// instead of `t.details = append(t.details, ...)` directly so
+// concurrent snapshot() readers do not race the slice header.
+//
+// History note: an earlier version of this helper landed in
+// PR #266 but was lost when PR #267's merge resolved task.go's
+// conflict by taking the A.4b side, dropping the A.4a additions.
+// task_test.go.TestTask_HelpersUseLock pins the existence of
+// this function and setTidyDirs so a future merge that drops
+// them again fails CI rather than silently regressing.
+func (t *Task) appendDetail(line string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.details = append(t.details, line)
+}
+
+// setTidyDirs flips t.tidyDirs to v under the lock.
+func (t *Task) setTidyDirs(v bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.tidyDirs = v
+}
+
 // pausedSnapshot is a consistent view of the worker's pause /
 // resume state. Use Task.pausedSnap() to acquire one rather than
 // touching t.wasPaused / t.pausedParam / t.pausedPhase /

--- a/pkg/tasks/task_paste_cloud.go
+++ b/pkg/tasks/task_paste_cloud.go
@@ -565,12 +565,12 @@ func (t *Task) checkJobStats(jobId int, dstPath string) (bool, error) {
 
 			if !jobStatusData.Finished {
 				if transferFinished {
-					t.tidyDirs = true
+					t.setTidyDirs(true)
 				}
 				continue
 			} else {
 				klog.Infof("[Task] Id: %s, job finished: %v, dst: %s", t.id, jobStatusData.Finished, dstPath)
-				t.details = append(t.details, "finished")
+				t.appendDetail("finished")
 				done = true
 				err = nil
 			}

--- a/pkg/tasks/task_paste_posix.go
+++ b/pkg/tasks/task_paste_posix.go
@@ -87,7 +87,7 @@ func (t *Task) Rsync() error {
 		}
 
 		klog.Infof("[Task] Id: %s, move done!", t.id)
-		t.details = append(t.details, "move done")
+		t.appendDetail("move done")
 
 		return nil
 	}
@@ -186,7 +186,7 @@ func (t *Task) move() error {
 	dstPath := dst + t.param.Dst.Path
 
 	klog.Infof("[Task] Id: %s, conditon move, srcPath: %s, dstPath: %s", t.id, srcPath, dstPath)
-	t.details = append(t.details, fmt.Sprintf("move %s -> %s", srcPath, dstPath))
+	t.appendDetail(fmt.Sprintf("move %s -> %s", srcPath, dstPath))
 
 	var args = []string{srcPath, dstPath}
 

--- a/pkg/tasks/task_test.go
+++ b/pkg/tasks/task_test.go
@@ -112,3 +112,57 @@ func TestTask_GetStateConsistent(t *testing.T) {
 
 	wg.Wait()
 }
+
+// TestTask_AppendDetailAndSetTidyDirsAreLockProtected pins the
+// existence and locking contract of appendDetail and setTidyDirs.
+//
+// History note: an earlier version of these helpers landed in PR
+// #266 but was lost when PR #267's merge resolved task.go's
+// conflict by taking the A.4b side, dropping the A.4a additions.
+// The unsynchronized writes (`t.tidyDirs = true`,
+// `t.details = append(t.details, ...)`) returned to the worker
+// path and the race detector started catching them again.
+//
+// If a future merge drops these helpers a third time, this test
+// fails to compile (call to undefined func) - a clear signal in
+// CI long before any real -race symptom shows up.
+func TestTask_AppendDetailAndSetTidyDirsAreLockProtected(t *testing.T) {
+	task := &Task{id: "test"}
+
+	const (
+		writers  = 4
+		readers  = 4
+		duration = 200 * time.Millisecond
+	)
+
+	deadline := time.Now().Add(duration)
+	var wg sync.WaitGroup
+
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func(seed int) {
+			defer wg.Done()
+			n := 0
+			for time.Now().Before(deadline) {
+				n++
+				task.appendDetail("tick")
+				if n%3 == 0 {
+					task.setTidyDirs(n%6 == 0)
+				}
+			}
+		}(i)
+	}
+
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for time.Now().Before(deadline) {
+				snap := task.snapshot()
+				_ = snap.TidyDirs
+			}
+		}()
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
## 概要

PR #266（A.4a）原本：

1. 在 \`pkg/tasks/task.go\` 加了两个加锁的小 helper：
   - \`func (*Task) appendDetail(line string)\`
   - \`func (*Task) setTidyDirs(v bool)\`
2. 把 \`pkg/tasks/task_paste_cloud.go\` 的 \`checkJobStats\` 中两处写：
   - \`t.tidyDirs = true\` → \`t.setTidyDirs(true)\`
   - \`t.details = append(t.details, \"finished\")\` → \`t.appendDetail(\"finished\")\`
3. 把 \`pkg/tasks/task_paste_posix.go\` 的 \`move\` 流程里两处 \`t.details = append(...)\` 也换成 helper。

PR #267（A.4b）的分支基于 PR #266 之前的 main。它和 PR #266 都改 \`task.go\`，**合 PR #267 时冲突按 A.4b 这一侧解决**，把 A.4a 的增补全部丢了；连带 cloud/posix 那 4 处直写也回到了原状。

结果：现在的 main 上 **helper 不存在了，4 处 race 又回来了**。\`go test -race\` 必报。

## 改动

把 PR #266 完整重做：

- \`pkg/tasks/task.go\`：加回 \`appendDetail\` 和 \`setTidyDirs\`。
- \`pkg/tasks/task_paste_cloud.go\`：\`checkJobStats\` 内的两处直写改为 helper 调用。
- \`pkg/tasks/task_paste_posix.go\`：\`move\` 流程里两处 \`t.details = append(...)\` 改为 \`t.appendDetail(...)\`。

新增 \`pkg/tasks/task_test.go\` 中的 \`TestTask_AppendDetailAndSetTidyDirsAreLockProtected\`：

- 4 个 writer × 4 个 reader 互打 200ms；
- 写端用 helper，读端用 \`snapshot()\`；
- \`-race\` 检测器是真正断言；
- **更重要的副作用**：以后再有 merge 把 helper 删掉，这个测试**编译都过不了**（call to undefined func），CI 直接 fail——比靠 race symptom 早得多。

## 验证方式

- [ ] 本地：\`go test -race -count=1 ./pkg/tasks/ -run TestTask\` 通过（已验证）。
- [ ] CI（PR #268）跑 \`go test -race ./pkg/tasks/...\` 自动覆盖。
- [ ] grep \`t\\.tidyDirs = \` / \`t\\.details = append(t\\.details\` 在 \`pkg/tasks/task_paste_*.go\` 里现已为零（task.go 内 Execute 里的几处仍保留——它们已经在 mu.Lock 临界区内）。


Made with [Cursor](https://cursor.com)