### PR TITLE
fix(health): 注册 /healthz 路由 + 修 Dockerfile HEALTHCHECK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -135,7 +135,7 @@ RUN if test "${PACKAGE_ARCH}" = "arm64"; then \
 ENV PATH="/usr/lib/jellyfin-ffmpeg:${PATH}"
 
 HEALTHCHECK --start-period=2s --interval=5s --timeout=3s \
-  CMD curl -f http://localhost/health || exit 1
+  CMD curl -f http://localhost:8080/healthz || exit 1
 
 VOLUME /srv
 EXPOSE 8080

--- a/pkg/hertz/router.go
+++ b/pkg/hertz/router.go
@@ -10,6 +10,12 @@ import (
 // customizeRegister registers customize routers.
 func customizedRegister(r *server.Hertz) {
 	r.GET("/ping", handler.Ping)
+	// /healthz and /health both alias to the simple liveness ping
+	// so Docker HEALTHCHECK / k8s liveness probes have a stable
+	// path. The Dockerfile previously hit /health and got 404
+	// every time, leaving the container perpetually unhealthy.
+	r.GET("/healthz", handler.Ping)
+	r.GET("/health", handler.Ping)
 
 	// your code ...
 }


### PR DESCRIPTION
## 概要

[\`Dockerfile\`](Dockerfile) 第 137-138 行 HEALTHCHECK 用 \`curl -f http://localhost/health\`，但：

1. **路径不存在**：[\`pkg/hertz/router.go\`](pkg/hertz/router.go) 只注册了 \`GET /ping\`，没有 \`/health\` / \`/healthz\`，请求 404。
2. **端口不对**：CLI 默认 / Dockerfile EXPOSE 都是 \`8080\`，但 HEALTHCHECK 用的是 \`localhost\`（隐含 80）。

容器**永远 unhealthy**，K8s liveness/readiness 全靠别的兜底，遮盖真实状态。

## 改动

- [\`pkg/hertz/router.go\`](pkg/hertz/router.go) 把 \`/healthz\`（k8s 标准）和 \`/health\`（兼容 Dockerfile / 任何外部探针）一起注册到现有 \`handler.Ping\`。
- [\`Dockerfile\`](Dockerfile) HEALTHCHECK 改为 \`http://localhost:8080/healthz\`，端口对齐。

## 范围

只修探针接通；更丰富的就绪探针（DB/Redis ping）留作 follow-up，避免一次改动牵涉太多。

## 验证方式

- [ ] \`go build ./pkg/hertz/ ./pkg/hertz/biz/handler/\` 通过（已验证）。
- [ ] \`docker build -t files .\` 后 \`docker run\` 起来，\`docker inspect\` 看 \`Health.Status\` 是 \`healthy\` 而不是 \`unhealthy\`。
- [ ] 直接访问 \`curl http://localhost:8080/healthz\` 返回 200 \`{\"message\":\"pong\"}\`。


Made with [Cursor](https://cursor.com)