### PR TITLE
fix(dal): database.Init/dal.Init 返 error，nil DB 跳过 migration

### DIFF
--- a/cmd/backend/app/root.go
+++ b/cmd/backend/app/root.go
@@ -130,7 +130,9 @@ user created with the credentials from options "username" and "password".`,
 
 		// Step1：Init postgres (including migration).
 		// For share, search and other features in the future
-		dal.Init()
+		if err := dal.Init(); err != nil {
+			klog.Fatalf("dal.Init: %v", err)
+		}
 
 		// Step2: Init redis
 		// For watcher, preview, smb and other features in the future

--- a/cmd/samba/main.go
+++ b/cmd/samba/main.go
@@ -29,7 +29,9 @@ const (
 var rootCmd = &cobra.Command{
 	Use: "samba-share-server",
 	Run: func(cmd *cobra.Command, args []string) {
-		database.Init()
+		if err := database.Init(); err != nil {
+			klog.Fatalf("database.Init: %v", err)
+		}
 
 		f, err := client.NewFactory()
 		if err != nil {

--- a/pkg/hertz/biz/dal/database/init.go
+++ b/pkg/hertz/biz/dal/database/init.go
@@ -17,22 +17,32 @@ var PGDB1 = os.Getenv("PGDB1")
 
 var DB *gorm.DB
 
-func Init() {
-	var err error
+// Init connects the package-level DB to Postgres if all required
+// PG* environment variables are set. If any of them is missing the
+// function returns nil and DB is left as nil; callers must handle
+// the "no DB" case (see dal.Init).
+//
+// On a real connection failure Init now returns the error instead
+// of panicking; callers can decide whether to klog.Fatal or run
+// degraded. The previous panic produced a backtrace into the log
+// for what is conceptually a fatal-with-clear-message situation.
+func Init() error {
 	if PGHOST == "" || PGPORT == "" || PGUSER == "" || PGPASSWORD == "" || PGDB1 == "" {
 		klog.Infoln("Postgres Database required environment variables are not set. Won't link to database.")
-		return
+		return nil
 	}
 	dsn := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=disable timezone=UTC",
 		PGHOST, PGPORT, PGUSER, PGPASSWORD, PGDB1)
-	DB, err = gorm.Open(postgres.Open(dsn), &gorm.Config{
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
 		SkipDefaultTransaction: true,
 		PrepareStmt:            true,
 		Logger:                 logger.Default.LogMode(logger.Silent),
 	})
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("postgres open: %w", err)
 	}
+	DB = db
+	return nil
 }
 
 // Close releases the underlying *sql.DB connection pool. Safe to call when

--- a/pkg/hertz/biz/dal/init.go
+++ b/pkg/hertz/biz/dal/init.go
@@ -35,8 +35,23 @@ func migration(table interface{}, tableName string, rebuild bool) {
 	}
 }
 
-func Init() {
-	database.Init()
+// Init connects to Postgres (via database.Init) and, if connected,
+// runs schema migrations and one-time data cleanups. Returns the
+// connection error, if any; the caller decides whether to fail
+// startup or run degraded.
+//
+// If database.Init returned nil DB (PG env vars unset), this
+// function logs a warning and returns nil without attempting any
+// migration -- the previous behavior nil-derefed inside
+// migration(...) on database.DB.Migrator() and crashed the process.
+func Init() error {
+	if err := database.Init(); err != nil {
+		return err
+	}
+	if database.DB == nil {
+		klog.Warning("dal.Init: database.DB is nil after database.Init (PG env not set); skipping migrations and cleanup")
+		return nil
+	}
 
 	rebuild := os.Getenv("REBUILD_DATABASE") == "true"
 	migration(&share.SharePath{}, "share_paths", rebuild)
@@ -46,6 +61,7 @@ func Init() {
 	migration(&share.ShareSmbMember{}, "share_smb_members", rebuild)
 
 	cleanupOwnerAsShareMember()
+	return nil
 }
 
 // cleanupOwnerAsShareMember removes any share_members rows whose


### PR DESCRIPTION
## 概要

启动期 DB 初始化的两个隐性崩溃：

1. [\`pkg/hertz/biz/dal/database/init.go\`](pkg/hertz/biz/dal/database/init.go) 的 \`Init\` 在 \`gorm.Open\` 失败时 \`panic(err)\`——把概念上"启动期致命+应该有清晰消息"的事退化为一份 panic backtrace，运维侧不友好。

2. [\`pkg/hertz/biz/dal/init.go\`](pkg/hertz/biz/dal/init.go) 的 \`Init\` 无条件 \`migration(...)\` 和 \`cleanupOwnerAsShareMember()\`，两者第一行就是 \`database.DB.Migrator()\` / \`database.DB.Table(...)\`。但 \`database.Init\` 自己显式容忍 \"PG env 没设就跳过\" 的情形（\`DB\` 留 nil）——一旦命中，\`migration\` 第一行直接 nil-deref panic。**等于"跳过 PG"这条容忍分支根本走不通**。

## 改动

- \`database.Init() error\`：失败返回 \`fmt.Errorf(\"postgres open: %w\", err)\`；用临时变量 \`db\` 接 \`gorm.Open\`，成功后才赋给全局 \`DB\`，避免半失败场景下 \`DB\` 指向不可用 handle。
- \`dal.Init() error\`：也返回错误。\`database.DB == nil\` 时 \`klog.Warning\` 一行后干净返回，不跑 migration 和 cleanup。
- 调用方更新：
  - [\`cmd/backend/app/root.go\`](cmd/backend/app/root.go) \`if err := dal.Init(); err != nil { klog.Fatalf(...) }\`
  - [\`cmd/samba/main.go\`](cmd/samba/main.go) \`if err := database.Init(); err != nil { klog.Fatalf(...) }\`

观察行为不变（启动失败仍退出），但日志里看到的是 \"dal.Init: postgres open: ...\" 而不是 panic backtrace。

## 验证方式

- [ ] \`go build ./pkg/hertz/biz/dal/... ./cmd/backend/app/ ./cmd/samba/\` 通过（已验证）。
- [ ] 手工：\`PGHOST=\` 等都不设启动 backend，应当看到 \"Postgres Database required environment variables are not set...\" + \"dal.Init: database.DB is nil after database.Init...\"，进程**不再** nil-deref panic 而是继续启动（或者你想要的话改 \`klog.Fatalf\`）。
- [ ] 手工：把 PG host 指向不可达地址，应当 \`klog.Fatalf(\"dal.Init: postgres open: ...\")\` 一行后退出。


Made with [Cursor](https://cursor.com)