### PR TITLE
fix(share): GetExternalSharePath 调用 ValidateShareTokenForPath helper

### DIFF
--- a/pkg/hertz/biz/handler/api/share/share_service.go
+++ b/pkg/hertz/biz/handler/api/share/share_service.go
@@ -2295,29 +2295,29 @@ func GetExternalSharePath(ctx context.Context, c *app.RequestContext) {
 		return
 	}
 
-	// The token must be issued for *this* share. Without this check,
-	// any valid token could be paired with another share's path_id to
-	// read that share's metadata (IDOR).
-	//
-	// NB: do not log the token itself — it is a bearer credential and
-	// would otherwise be persisted to centralized log storage. The
-	// path_id pair is enough to debug the mismatch (see PR #226 review
-	// comment that introduced this check).
-	if shareToken.PathID != req.PathId {
+	// All token-vs-path validation lives in ValidateShareTokenForPath
+	// (PR #273) so the IDOR + expiry contract is testable without a
+	// DB. NilToken / PathMismatch / BadExpire / Expired all map onto
+	// the same client-facing CodeTokenExpired envelope; logs use
+	// path-only identifiers so the bearer token is never persisted
+	// (PR #259).
+	switch reason, ts := ValidateShareTokenForPath(shareToken, req.PathId, time.Now()); reason {
+	case ShareTokenValidationOK:
+	case ShareTokenValidationPathMismatch:
+		var tokenPath string
+		if shareToken != nil {
+			tokenPath = shareToken.PathID
+		}
 		klog.Warningf("GetSharePath, token/path_id mismatch: req.path_id=%s, token belongs to path_id=%s",
-			req.PathId, shareToken.PathID)
-		handler.RespErrorExpired(c, common.CodeTokenExpired, common.ErrorMessageTokenExpired, time.Now().Unix())
+			req.PathId, tokenPath)
+		handler.RespErrorExpired(c, common.CodeTokenExpired, common.ErrorMessageTokenExpired, ts)
 		return
-	}
-
-	expired, err := time.Parse(time.RFC3339Nano, shareToken.ExpireAt)
-	if err != nil {
-		klog.Errorf("GetSharePath, parse token expire_at %q error: %v", shareToken.ExpireAt, err)
-		handler.RespErrorExpired(c, common.CodeTokenExpired, common.ErrorMessageTokenExpired, time.Now().Unix())
+	case ShareTokenValidationBadExpire:
+		klog.Errorf("GetSharePath, token expire_at unparseable for path_id=%s", req.PathId)
+		handler.RespErrorExpired(c, common.CodeTokenExpired, common.ErrorMessageTokenExpired, ts)
 		return
-	}
-	if time.Now().After(expired) {
-		handler.RespErrorExpired(c, common.CodeTokenExpired, common.ErrorMessageTokenExpired, expired.Unix())
+	case ShareTokenValidationExpired, ShareTokenValidationNilToken:
+		handler.RespErrorExpired(c, common.CodeTokenExpired, common.ErrorMessageTokenExpired, ts)
 		return
 	}
 
@@ -2333,9 +2333,11 @@ func GetExternalSharePath(ctx context.Context, c *app.RequestContext) {
 		return
 	}
 
-	expired, err = time.Parse(time.RFC3339Nano, sharePath.ExpireTime)
-	if err != nil {
-		klog.Errorf("GetSharePath, parse path expire_time %q error: %v", sharePath.ExpireTime, err)
+	// Use the same fail-closed parser the helper uses (PR #257) so
+	// a malformed sharePath.ExpireTime no longer produces a year-1
+	// Unix timestamp in the response payload.
+	expired, ok := common.ParseRFC3339Nano(sharePath.ExpireTime)
+	if !ok {
 		handler.RespErrorExpired(c, common.CodeLinkExpired, common.ErrorMessageLinkExpired, time.Now().Unix())
 		return
 	}


### PR DESCRIPTION
## 概要

PR #273 抽出了 \`ValidateShareTokenForPath\` helper 并补了单测，但**没有把 handler 切过去**。结果就是：

- \`GetExternalSharePath\` 还在 inline 重复一遍 IDOR + expire 检查；
- token 那段仍用 \`time.Parse(time.RFC3339Nano, ...)\` 而不是 PR #257 的 \`common.ParseRFC3339Nano\`——非法 expire 字符串依然会让响应里出现年-1 Unix 戳；
- helper 是死代码，所有单测的"防 IDOR"保证不能落到生产路径上。

## 改动

[\`pkg/hertz/biz/handler/api/share/share_service.go\`](pkg/hertz/biz/handler/api/share/share_service.go) \`GetExternalSharePath\`：

- token 校验段改为 \`switch reason, ts := ValidateShareTokenForPath(shareToken, req.PathId, time.Now()); reason\`，4 种失败原因（NilToken / PathMismatch / BadExpire / Expired）都映射到 \`CodeTokenExpired\`；helper 自己保证返回的 \`ts\` 是合理的 Unix 秒数（PR #226 + #257 契约）。
- \`PathMismatch\` 分支继续打"path-only"warning（保留 PR #259 的 token 不入日志的修复）。
- 后面 \`sharePath.ExpireTime\` 那段也从原生 \`time.Parse\` 切到 \`common.ParseRFC3339Nano\`，统一 fail-closed + 不漏年-1 戳。

## 验证方式

- [ ] \`go build ./pkg/hertz/biz/handler/api/share/\` 通过（已验证）。
- [ ] \`go test -race -count=1 ./pkg/hertz/biz/handler/api/share/\` 通过（已验证）。
- [ ] 手工：用 token A 配 path B 调 \`/api/share/get_share/\`，依旧返回 token expired；日志中只有 path_id 信息，没有 token。


Made with [Cursor](https://cursor.com)