### PR TITLE
fix: 剩余硬编码 /data 成批改 common.RootPrefix

### DIFF
--- a/pkg/drivers/clouds/download.go
+++ b/pkg/drivers/clouds/download.go
@@ -42,7 +42,7 @@ func (d *Download) download() error {
 		return err
 	}
 
-	_, err := common.CheckDiskSpace("/data", d.fileSize, true) // d.checkFreeDiskSpace()
+	_, err := common.CheckDiskSpace(common.RootPrefix, d.fileSize, true) // d.checkFreeDiskSpace()
 	if err != nil {
 		return err
 	}
@@ -121,7 +121,11 @@ func (d *Download) download() error {
 func (d *Download) generateBufferFolder() (string, error) {
 	var owner = d.fileParam.Owner
 	var exists = false
-	var bufferFolder = path.Join(common.ROOT_PREFIX, common.CacheBuffer, owner)
+	// Use RootPrefix (env-driven, fallback /data) so the buffer dir
+	// resolves to the same root the rest of the codebase uses (see
+	// PR #261/#262). ROOT_PREFIX is a hardcoded "/data" constant
+	// and ignores the deployment override.
+	var bufferFolder = path.Join(common.RootPrefix, common.CacheBuffer, owner)
 	if files.FilePathExists(bufferFolder) {
 		exists = true
 	}

--- a/pkg/drivers/posix/posix/posix.go
+++ b/pkg/drivers/posix/posix/posix.go
@@ -613,7 +613,7 @@ func (s *PosixStorage) UploadLink(fileUploadArg *models.FileUploadArgs) ([]byte,
 
 	if fileUploadArg.TotalSize != 0 {
 		if fileUploadArg.FileParam.IsSystem() {
-			_, err := common.CheckDiskSpace("/data", fileUploadArg.TotalSize, true)
+			_, err := common.CheckDiskSpace(common.RootPrefix, fileUploadArg.TotalSize, true)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/drivers/sync/sync.go
+++ b/pkg/drivers/sync/sync.go
@@ -797,7 +797,7 @@ func (s *SyncStorage) UploadLink(fileUploadArg *models.FileUploadArgs) ([]byte, 
 
 	// sync also use system storage space
 	if fileUploadArg.TotalSize != 0 {
-		_, err := common.CheckDiskSpace("/data", fileUploadArg.TotalSize, true)
+		_, err := common.CheckDiskSpace(common.RootPrefix, fileUploadArg.TotalSize, true)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/files/dir.go
+++ b/pkg/files/dir.go
@@ -3,10 +3,21 @@ package files
 import (
 	"os"
 	"path/filepath"
+
+	"files/pkg/common"
 )
 
 func FindExistingDir(targetDir string) string {
 	currentDir := filepath.Clean(targetDir)
+
+	// Stop walking up the chain at "/", at the configurable
+	// data root (RootPrefix, default "/data"), or at the External
+	// mount point under that root. Previously the comparison was
+	// against the literal "/data" / "/data/External", which
+	// silently never triggered when ROOT_PREFIX was set to
+	// anything else and the loop would walk all the way up.
+	rootStop := common.RootPrefix
+	externalStop := filepath.Join(common.RootPrefix, "External")
 
 	for {
 		if dirExists(currentDir) {
@@ -15,7 +26,7 @@ func FindExistingDir(targetDir string) string {
 
 		parentDir := filepath.Dir(currentDir)
 
-		if parentDir == currentDir || parentDir == "/" || parentDir == "/data" || parentDir == "/data/External" {
+		if parentDir == currentDir || parentDir == "/" || parentDir == rootStop || parentDir == externalStop {
 			break
 		}
 

--- a/pkg/files/file.go
+++ b/pkg/files/file.go
@@ -523,7 +523,14 @@ func (i *FileInfo) readDirents() ([]os.FileInfo, error) {
 			return nil, err
 		}
 
-		err = filepath.WalkDir("/data"+i.Path, func(path string, d fs.DirEntry, err error) error {
+		// SMB/CIFS fallback: walk the host filesystem under
+		// RootPrefix so the path matches DefaultFs's view of the
+		// data root. The literal "/data" used to be hardcoded here
+		// and would diverge whenever ROOT_PREFIX was set to
+		// anything else (PR #261/#262 made the rest of the codebase
+		// honor RootPrefix; this site was missed).
+		walkRoot := common.RootPrefix + i.Path
+		err = filepath.WalkDir(walkRoot, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				if strings.Contains(err.Error(), "host is down") {
 					klog.Warningf("[WARN] skipping %s: %v\n", path, err)
@@ -533,11 +540,11 @@ func (i *FileInfo) readDirents() ([]os.FileInfo, error) {
 				return err
 			}
 
-			if path == "/data"+i.Path {
+			if path == walkRoot {
 				return nil
 			}
 
-			relPath, err := filepath.Rel("/data"+i.Path, path)
+			relPath, err := filepath.Rel(walkRoot, path)
 			if err != nil {
 				return nil
 			}

--- a/pkg/hertz/biz/handler/api/external/external_service.go
+++ b/pkg/hertz/biz/handler/api/external/external_service.go
@@ -202,7 +202,7 @@ func UnmountMethod(ctx context.Context, c *app.RequestContext) {
 
 	file, err := files.NewFileInfo(files.FileOptions{
 		Fs:         files.DefaultFs,
-		Path:       strings.TrimPrefix(urlPath, "/data"),
+		Path:       strings.TrimPrefix(urlPath, common.RootPrefix),
 		Modify:     true,
 		Expand:     false,
 		ReadHeader: true,

--- a/pkg/hertz/biz/handler/api/md5/md5_service.go
+++ b/pkg/hertz/biz/handler/api/md5/md5_service.go
@@ -50,7 +50,7 @@ func Md5Method(ctx context.Context, c *app.RequestContext) {
 	urlPath := uri + fileParam.Path
 	file, err := files.NewFileInfo(files.FileOptions{
 		Fs:         files.DefaultFs,
-		Path:       strings.TrimPrefix(urlPath, "/data"),
+		Path:       strings.TrimPrefix(urlPath, common.RootPrefix),
 		Modify:     true,
 		Expand:     false,
 		ReadHeader: true,

--- a/pkg/hertz/biz/handler/api/permission/permission_service.go
+++ b/pkg/hertz/biz/handler/api/permission/permission_service.go
@@ -47,7 +47,7 @@ func GetPermissionMethod(ctx context.Context, c *app.RequestContext) {
 		return
 	}
 	urlPath := uri + fileParam.Path
-	dealUrlPath := strings.TrimPrefix(urlPath, "/data")
+	dealUrlPath := strings.TrimPrefix(urlPath, common.RootPrefix)
 
 	exists, err := afero.Exists(files.DefaultFs, dealUrlPath)
 	if err != nil {
@@ -111,7 +111,7 @@ func PutPermissionMethod(ctx context.Context, c *app.RequestContext) {
 		return
 	}
 	urlPath := uri + fileParam.Path
-	dealUrlPath := strings.TrimPrefix(urlPath, "/data")
+	dealUrlPath := strings.TrimPrefix(urlPath, common.RootPrefix)
 
 	exists, err := afero.Exists(files.DefaultFs, dealUrlPath)
 	if err != nil {

--- a/pkg/tasks/task_paste_sync.go
+++ b/pkg/tasks/task_paste_sync.go
@@ -203,7 +203,7 @@ func (t *Task) UploadToSync() error {
 		return err
 	}
 
-	_, err = common.CheckDiskSpace("/data", posixSize, true)
+	_, err = common.CheckDiskSpace(common.RootPrefix, posixSize, true)
 	if err != nil {
 		return err
 	}
@@ -287,7 +287,7 @@ func (t *Task) SyncCopy() error {
 		return err
 	}
 
-	_, err = common.CheckDiskSpace("/data", totalSize, true)
+	_, err = common.CheckDiskSpace(common.RootPrefix, totalSize, true)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## 概要

PR #261 / #262 让 \`DefaultFs\` 与启动 buffer 清理使用 \`common.RootPrefix\`（环境变量驱动、默认 \`/data\`），但**漏了一批同样硬编码 \`/data\` 的位置**。任何非默认 \`ROOT_PREFIX\` 部署都会在这些点出错。

## 改动

按文件清单：

| 文件 | 修复 |
|---|---|
| [\`pkg/drivers/clouds/download.go\`](pkg/drivers/clouds/download.go) | \`CheckDiskSpace(\"/data\", ...)\` → \`CheckDiskSpace(common.RootPrefix, ...)\`；buffer folder 用 \`common.RootPrefix\` 而不是 \`common.ROOT_PREFIX\`（前者是变量、可被环境变量覆盖；后者是写死的常量）。 |
| [\`pkg/drivers/posix/posix/posix.go\`](pkg/drivers/posix/posix/posix.go) | upload-link 的 disk check |
| [\`pkg/drivers/sync/sync.go\`](pkg/drivers/sync/sync.go) | sync-upload 的 disk check |
| [\`pkg/tasks/task_paste_sync.go\`](pkg/tasks/task_paste_sync.go) | 两处 disk check（206、290 行） |
| [\`pkg/files/file.go\`](pkg/files/file.go) \`readDirents\` | SMB/CIFS fallback 用 \`/data\`+i.Path 走 \`filepath.WalkDir\`，改为 \`RootPrefix\`+i.Path，与 DefaultFs 同根 |
| [\`pkg/files/dir.go\`](pkg/files/dir.go) \`FindExistingDir\` | 终止比较 \`parentDir == \"/data\"\` / \`\"/data/External\"\` 在自定义 ROOT_PREFIX 下永不触发，循环会一路走到 \"/\"。用 \`RootPrefix\` + \`filepath.Join(RootPrefix, \"External\")\` |
| [\`pkg/hertz/biz/handler/api/permission/permission_service.go\`](pkg/hertz/biz/handler/api/permission/permission_service.go) | 两处 \`strings.TrimPrefix(urlPath, \"/data\")\`：自定义 ROOT_PREFIX 下 strip 不掉，\`afero.Exists(DefaultFs, ...)\` 会双前缀解析（DefaultFs 自己已经加了 RootPrefix），路径错乱。改用 \`common.RootPrefix\` |
| [\`pkg/hertz/biz/handler/api/md5/md5_service.go\`](pkg/hertz/biz/handler/api/md5/md5_service.go) | 同上 |
| [\`pkg/hertz/biz/handler/api/external/external_service.go\`](pkg/hertz/biz/handler/api/external/external_service.go) | 同上 |

## 验证方式

- [ ] \`go build ./pkg/... ./cmd/...\`（除 pkg/media 预存错误外）通过（已验证）。
- [ ] grep \`\"/data\"\` 只剩注释和 \`pkg/common/utils.go\`/\`constant.go\` 自身的声明，没有功能代码。
- [ ] 手工：\`ROOT_PREFIX=/tmp/files-data\` 启动，所有读写都走 \`/tmp/files-data\`，CheckDiskSpace 也不再错误地检查根 \`/data\` 的空间。


Made with [Cursor](https://cursor.com)