### PR TITLE
fix(tasks): checkJobStats 防除零 + clamp 进度 [0,100]

### DIFF
--- a/pkg/tasks/task_paste_cloud.go
+++ b/pkg/tasks/task_paste_cloud.go
@@ -541,26 +541,24 @@ func (t *Task) checkJobStats(jobId int, dstPath string) (bool, error) {
 
 			if jobStatusData.Success && jobStatusData.Finished {
 				klog.Infof("[Task] Id: %s, job finished: %v, dst: %s", t.id, jobStatusData.Finished, dstPath)
-				var progress = (totalTransfers * 100) / totalSize
 				transferFinished = true
-				t.updateProgress(int(progress), transfers)
+				t.updateProgress(safeProgressPct(totalTransfers, totalSize), transfers)
 				done = true
 				err = nil
 				break
 			}
 
 			if transfers != totalSize {
-				var progress = (totalTransfers * 100) / totalSize
+				progress := safeProgressPct(totalTransfers, totalSize)
 				klog.Infof("[Task] Id: %s, dst: %s, progress: %d (%s/%s)", t.id, dstPath, progress, common.FormatBytes(totalTransfers), common.FormatBytes(totalSize))
-				t.updateProgress(int(progress), transfers)
+				t.updateProgress(progress, transfers)
 				continue
 			}
 
 			if transfers == totalSize && data.Transferring == nil && data.Bytes == data.TotalBytes {
 				klog.Infof("[Task] Id: %s, upload success, dst: %s", t.id, dstPath)
-				var progress = (totalTransfers * 100) / totalSize
 				transferFinished = true
-				t.updateProgress(int(progress), transfers)
+				t.updateProgress(safeProgressPct(totalTransfers, totalSize), transfers)
 			}
 
 			if !jobStatusData.Finished {
@@ -823,4 +821,26 @@ func (t *Task) encodeDuplicateNames(dirs []DriveDir) []DriveDir {
 		parentNameCount[parent][name]++
 	}
 	return result
+}
+
+// safeProgressPct returns floor(transferred * 100 / total), clamped to
+// [0, 100]. It returns 0 (rather than panicking) when total <= 0.
+//
+// checkJobStats originally had three sites that did
+// `(totalTransfers * 100) / totalSize` directly. Under any race that
+// produces totalSize == 0 (e.g. snapshot read before SetTotalSize on
+// the worker, or a phase that legitimately handles zero-sized inputs)
+// the integer divide blew up and crashed the worker goroutine.
+func safeProgressPct(transferred, total int64) int {
+	if total <= 0 {
+		return 0
+	}
+	pct := (transferred * 100) / total
+	if pct < 0 {
+		return 0
+	}
+	if pct > 100 {
+		return 100
+	}
+	return int(pct)
 }


### PR DESCRIPTION
## 概要

[\`pkg/tasks/task_paste_cloud.go\`](pkg/tasks/task_paste_cloud.go) \`checkJobStats\` 三处计算进度：

\`\`\`go
var progress = (totalTransfers * 100) / totalSize
\`\`\`

\`totalSize\` 一旦是 0（worker 还没调 \`SetTotalSize\`；零字节输入；snapshot 在 reset 和 update 之间被取——race），整数除法 panic worker goroutine，任务死掉。

## 改动

- 加 \`safeProgressPct(transferred, total int64) int\` 工具：
  - \`total <= 0\` → 返回 0；
  - 结果 clamp 到 \`[0, 100]\`（顺手防住 \`totalTransfers > totalSize\` 短暂 race 显示 200%+）。
- 三处直接除法都换成 \`safeProgressPct(totalTransfers, totalSize)\`。

## 验证方式

- [ ] \`go build && go test -race ./pkg/tasks/\` 通过（已验证）。
- [ ] 手工：构造一个 \`SetTotalSize\` 慢于 \`checkJobStats\` 进入循环的场景，进度显示 0%，不再 panic。


Made with [Cursor](https://cursor.com)