### PR TITLE
fix(tasks): DownloadFromFiles 恢复路径检查 paused.Param 不为 nil

### DIFF
--- a/pkg/tasks/task_paste_download.go
+++ b/pkg/tasks/task_paste_download.go
@@ -3,6 +3,7 @@ package tasks
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"files/pkg/common"
 	"files/pkg/files"
 	"files/pkg/integration"
@@ -25,6 +26,14 @@ func (t *Task) DownloadFromFiles() error {
 	var dst *models.FileParam
 
 	if ps := t.pausedSnap(); ps.WasPaused {
+		// Match task_paste_sync.go and task_paste_cloud.go: a
+		// resume with no recorded paused param is corrupt state
+		// and should fail loudly, not nil out t.param.Dst and
+		// crash later in some unrelated downstream call.
+		if ps.Param == nil {
+			klog.Errorf("[Task] Id: %s, paused param invalid", t.id)
+			return errors.New("pause param invalid")
+		}
 		t.param.Dst = ps.Param
 		t.clearPausedParam()
 	}


### PR DESCRIPTION
## 概要

[\`pkg/tasks/task_paste_download.go\`](pkg/tasks/task_paste_download.go) \`DownloadFromFiles\` 第 27-30 行：

\`\`\`go
if ps := t.pausedSnap(); ps.WasPaused {
    t.param.Dst = ps.Param          // <-- ps.Param \u53ef\u80fd\u662f nil
    t.clearPausedParam()
}
\`\`\`

\`task_paste_sync.go\` 与 \`task_paste_cloud.go\` 的 resume 都显式判断 \`WasPaused && Param == nil\` 并返回 \"pause param invalid\"；download 是唯一漏判的一支：corrupt 状态下 \`t.param.Dst\` 被置 nil，后面 \`dst.GetResourceUri()\` 或拼路径直接 nil panic。

## 改动

补一个和其它两族 paste 任务字面一致的 \`errors.New(\"pause param invalid\")\`。\`errors\` 加到 import。

## 验证方式

- [ ] \`go build ./pkg/tasks/\` 通过（已验证）。
- [ ] 手工：人为把任务的 \`pausedParam\` 设为 nil 然后置 \`wasPaused=true\` 触发 download，应当返回 \"pause param invalid\"，不再 nil panic。


Made with [Cursor](https://cursor.com)