### PR TITLE
fix(search): SyncSearch 检查 HandleSearch 错误

### DIFF
--- a/pkg/hertz/biz/handler/api/search/search_service.go
+++ b/pkg/hertz/biz/handler/api/search/search_service.go
@@ -183,6 +183,15 @@ func SyncSearch(ctx context.Context, c *app.RequestContext) {
 	}
 
 	res, err := seahub.HandleSearch(owner, req.Q)
+	if err != nil {
+		// Without this check we silently fell into json.Unmarshal
+		// of whatever res happened to be (often nil or a partial
+		// response), and clients got "Failed to unmarshal" as the
+		// only signal -- the actual upstream error was lost.
+		klog.Errorf("[sync search] HandleSearch error: %v", err)
+		c.AbortWithStatusJSON(consts.StatusBadGateway, utils.H{"error": fmt.Sprintf("search upstream error: %v", err)})
+		return
+	}
 	klog.Infof("[sync search] res=%s", string(res))
 
 	resp := new(search.SyncSearchResp)


### PR DESCRIPTION
## 概要

[\`pkg/hertz/biz/handler/api/search/search_service.go\`](pkg/hertz/biz/handler/api/search/search_service.go) 第 185 行：

\`\`\`go
res, err := seahub.HandleSearch(owner, req.Q)
klog.Infof(\"[sync search] res=%s\", string(res))

resp := new(search.SyncSearchResp)
if err := json.Unmarshal(res, &resp); ...   // <-- \u5916\u5c42 err \u4e22\u4e86
\`\`\`

\`HandleSearch\` 报错时 \`res\` 通常是 nil 或半响应，直接进 \`json.Unmarshal\` 之后客户端只能看到 \"Failed to unmarshal\"——真正的上游错误丢了，运维 / 前端都无从下手。

## 改动

补 \`if err != nil\` 检查，返回 \`502 Bad Gateway\` 并把上游错误信息带出来。这样能区分 \"search 后端宕机\" vs \"search 后端返回错误 JSON\"。

## 验证方式

- [ ] \`go build ./pkg/hertz/biz/handler/api/search/\` 通过（已验证）。
- [ ] 手工：把 \`HandleSearch\` 故意失败，调用 \`POST /api/search/sync\`，应该收到 502 + 真实 upstream 错误，而不是 500 \"Failed to unmarshal\"。


Made with [Cursor](https://cursor.com)