### PR TITLE
fix(repos): DeleteRepoMethod 补 database.DB nil 判断

### DIFF
--- a/pkg/hertz/biz/handler/api/repos/repos_service.go
+++ b/pkg/hertz/biz/handler/api/repos/repos_service.go
@@ -140,6 +140,15 @@ func DeleteReposMethod(ctx context.Context, c *app.RequestContext) {
 
 	klog.Infof("Repo delete repo, user: %s, id: %s", owner, repoId)
 
+	// dal.Init can legitimately leave database.DB as nil when PG env
+	// vars are unset (see PR #277). Without this guard the next
+	// database.DB.Begin() call nil-derefs and panics the request.
+	if database.DB == nil {
+		klog.Errorf("Repo delete repo, database not configured")
+		c.AbortWithStatusJSON(consts.StatusServiceUnavailable, utils.H{"error": "database not configured"})
+		return
+	}
+
 	tx := database.DB.Begin()
 	// sync relative must be done before real delete, or else dir or repo will not be found
 	deleteFileParam := &models.FileParam{


### PR DESCRIPTION
## 概要

[\`pkg/hertz/biz/handler/api/repos/repos_service.go\`](pkg/hertz/biz/handler/api/repos/repos_service.go) \`DeleteRepoMethod\` 第 143 行直接 \`tx := database.DB.Begin()\`，未判 \`database.DB == nil\`。

PR #277 把 \`dal.Init\` 设计成"PG 环境变量缺失就跳过"——这种部署下 \`database.DB\` 就是 nil。当前 handler 在那种部署下接到请求会 nil-deref panic。

## 改动

调用 \`Begin\` 前补一行：

\`\`\`go
if database.DB == nil {
    klog.Errorf(\"Repo delete repo, database not configured\")
    c.AbortWithStatusJSON(consts.StatusServiceUnavailable, utils.H{\"error\": \"database not configured\"})
    return
}
\`\`\`

\`503 Service Unavailable\` 比模糊的 500 更能让前端区分 "操作失败" vs "服务器没配 DB"。

## 验证方式

- [ ] \`go build ./pkg/hertz/biz/handler/api/repos/\` 通过（已验证）。
- [ ] 手工：不设 PG 环境变量启动 backend，调 \`DELETE /api/repos/...\` 应返 503，不再 panic。


Made with [Cursor](https://cursor.com)