### PR TITLE
fix(external): terminusd 响应用 LimitReader 封顶 4 MiB

### DIFF
--- a/pkg/hertz/biz/handler/api/external/external_service.go
+++ b/pkg/hertz/biz/handler/api/external/external_service.go
@@ -26,6 +26,12 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// maxTerminusdResponseBytes caps how much we read from a single
+// upstream response. Terminusd responses for these endpoints are
+// small JSON envelopes (<<1 MiB in practice); a hostile or buggy
+// peer that streams gigabytes would otherwise OOM the handler.
+const maxTerminusdResponseBytes = 4 << 20 // 4 MiB
+
 // MountedMethod .
 // @router /api/mounted/:node/ [GET]
 func MountedMethod(ctx context.Context, c *app.RequestContext) {
@@ -106,7 +112,7 @@ func MountMethod(ctx context.Context, c *app.RequestContext) {
 			continue
 		}
 
-		respBody, err := io.ReadAll(resp.Body)
+		respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxTerminusdResponseBytes))
 		if err != nil {
 			c.AbortWithStatusJSON(consts.StatusInternalServerError, utils.H{"error": err.Error()})
 			return
@@ -258,7 +264,7 @@ func UnmountMethod(ctx context.Context, c *app.RequestContext) {
 	}
 	defer response.Body.Close()
 
-	respBody, err := io.ReadAll(response.Body)
+	respBody, err := io.ReadAll(io.LimitReader(response.Body, maxTerminusdResponseBytes))
 	if err != nil {
 		c.AbortWithStatusJSON(consts.StatusInternalServerError, utils.H{"error": err.Error()})
 		return


### PR DESCRIPTION
## 概要

[\`pkg/hertz/biz/handler/api/external/external_service.go\`](pkg/hertz/biz/handler/api/external/external_service.go) 第 109、261 行用 \`io.ReadAll(resp.Body)\` 读 Terminusd 响应——**无上限**。Terminusd 返回小 JSON（实际 <<1 MiB），但若 peer 流过来若干 GB，handler 协程会 OOM。

## 改动

- 加常量 \`maxTerminusdResponseBytes = 4 << 20\`（4 MiB）。
- 两处 ReadAll 全部包 \`io.LimitReader(resp.Body, maxTerminusdResponseBytes)\`。

后续真要更大，改一行常量。

## 验证方式

- [ ] \`go build\` 通过（已验证）。
- [ ] 手工：上游返回 100 MB 响应，handler 最多读 4 MB；下游 \`json.Unmarshal\` 报错走原有错误路径。


Made with [Cursor](https://cursor.com)