### PR TITLE
fix(dal): 实现 QueryShareMembers（之前是静默 stub）

### DIFF
--- a/pkg/hertz/biz/dal/database/share.go
+++ b/pkg/hertz/biz/dal/database/share.go
@@ -282,9 +282,27 @@ func GetShareToken(token string) (*share.ShareToken, error) {
 	return res, nil
 }
 
+// QueryShareMembers returns all share_members rows for the given
+// share path id.
+//
+// History note: this used to be a silent stub:
+//
+//	DB.Table("share_members").Where("path_id = ?", shareId)
+//	return nil, nil
+//
+// The chain was built and immediately discarded; callers got an
+// empty list with nil error and no DB query was issued. There were
+// no callers in-tree, so the bug was latent -- but anyone wiring
+// this up would silently see "no members" forever.
 func QueryShareMembers(shareId string) ([]*share.ShareMember, error) {
-	DB.Table("share_members").Where("path_id = ?", shareId)
-	return nil, nil
+	var res []*share.ShareMember
+	if err := DB.Table("share_members").Where("path_id = ?", shareId).Find(&res).Error; err != nil {
+		if err != gorm.ErrRecordNotFound {
+			return nil, err
+		}
+		return nil, nil
+	}
+	return res, nil
 }
 
 func DeleteShareToken(token string, db *gorm.DB) error {


### PR DESCRIPTION
## 概要

[\`pkg/hertz/biz/dal/database/share.go\`](pkg/hertz/biz/dal/database/share.go) 第 285 行的 \`QueryShareMembers\` 之前是个静默 stub：

\`\`\`go
func QueryShareMembers(shareId string) ([]*share.ShareMember, error) {
    DB.Table(\"share_members\").Where(\"path_id = ?\", shareId)  // <-- chain \u4e22\u4e86
    return nil, nil
}
\`\`\`

\`Where\` 的返回 chain 被丢掉，根本没有执行 SQL；调用方拿到 \`(nil, nil)\`、永远看到"无成员"。

仓库内目前**没有调用方**，所以是潜伏 bug 而非线上 bug。但下次有人 import 这个函数会非常难排查。

## 改动

按文件其它 \`Query*\` 函数的写法实现：\`Find\` 进 slice，\`ErrRecordNotFound\` 当 (nil, nil)，其它错误返回。

## 验证方式

- [ ] \`go build ./pkg/hertz/biz/dal/database/\` 通过（已验证）。
- [ ] 手工：在 sqlite/postgres 上手动 \`INSERT\` 几行 share_members，调 \`QueryShareMembers(shareId)\` 应返回非空 slice 而不是 nil。


Made with [Cursor](https://cursor.com)