### PR TITLE
fix(share): ShareMiddleware / proxySharePaste 转发补 ctx 与 err 检查

### DIFF
--- a/pkg/hertz/biz/router/middleware.go
+++ b/pkg/hertz/biz/router/middleware.go
@@ -244,7 +244,7 @@ func ShareMiddleware() app.HandlerFunc {
 		}
 
 		if shareAccess.Paste {
-			proxySharePaste(c, bflName, pasteAction, shareParam, pasteDstParam)
+			proxySharePaste(ctx, c, bflName, pasteAction, shareParam, pasteDstParam)
 			return
 		}
 
@@ -399,7 +399,11 @@ func ShareMiddleware() app.HandlerFunc {
 		klog.Infof("[share] share rewrite url: %s, access: %s, shareby: %s, method: %s", url, bflName, shareBy, method)
 
 		var br io.Reader
-		req, err := http.NewRequest(string(c.Request.Method()), url, br)
+		// Tie the proxied request to the inbound request's ctx so a
+		// disconnect / cancellation propagates downstream and the
+		// shareProxyClient.Do call doesn't hang past the original
+		// caller's lifetime.
+		req, err := http.NewRequestWithContext(ctx, string(c.Request.Method()), url, br)
 		if err != nil {
 			klog.Errorf("[share] build proxy request error: %v, url: %s", err, url)
 			handler.RespError(c, fmt.Sprintf("build proxy request error: %v", err))
@@ -580,7 +584,7 @@ func checkNonSharedPath(path string) bool {
 	return isSharedPath
 }
 
-func proxySharePaste(c *app.RequestContext, owner string, action string, src, dst *models.FileParam) {
+func proxySharePaste(ctx context.Context, c *app.RequestContext, owner string, action string, src, dst *models.FileParam) {
 	var isSrcShare, isDstShare = src.FileType == common.Share, dst.FileType == common.Share
 
 	klog.Infof("[share] Paste, owner: %s, src: %s, dst: %s", owner, common.ParseString(src), common.ParseString(dst))
@@ -732,7 +736,17 @@ func proxySharePaste(c *app.RequestContext, owner string, action string, src, ds
 	}
 	br = bytes.NewBuffer(bodyBytes)
 
-	var req, _ = http.NewRequest(string(c.Request.Method()), url, br)
+	// Tie the proxied request to the inbound ctx so disconnects /
+	// cancellations propagate downstream. The previous bare
+	// http.NewRequest(...) also discarded its error, leaving req
+	// potentially nil before the immediate Header.Set calls
+	// nil-deref'd; surface that error explicitly now.
+	req, err := http.NewRequestWithContext(ctx, string(c.Request.Method()), url, br)
+	if err != nil {
+		klog.Errorf("[share] proxy paste build request error: %v, url: %s", err, url)
+		handler.RespError(c, fmt.Sprintf("build proxy request error: %v", err))
+		return
+	}
 
 	c.Request.Header.VisitAll(func(key, value []byte) {
 		req.Header.Set(string(key), string(value))


### PR DESCRIPTION
## 概要

[\`pkg/hertz/biz/router/middleware.go\`](pkg/hertz/biz/router/middleware.go) 两处对外转发：

1. **\`ShareMiddleware\` 第 401 行**：\`http.NewRequest(...)\` 不带 ctx——客户端断开 / 取消信号传不到下游，\`shareProxyClient.Do\` 可能比原请求生命周期还长。

2. **\`proxySharePaste\` 第 735 行**：

   \`\`\`go
   var req, _ = http.NewRequest(string(c.Request.Method()), url, br)
   c.Request.Header.VisitAll(func(...) { req.Header.Set(...) })  // <-- req \u53ef\u80fd nil
   \`\`\`

   \`NewRequest\` 错误丢，紧跟着 \`req.Header.Set\` 在 nil 上调，**panic**。

## 改动

- 两处都改为 \`http.NewRequestWithContext(ctx, ...)\`。
- \`proxySharePaste\` 函数签名加 \`ctx context.Context\` 参数，调用点（\`ShareMiddleware\` 第 247 行）传入。
- \`proxySharePaste\` 处补上 \`NewRequest\` err 检查，返回 \`build proxy request error: ...\`。

跟之前 PR #235（download 路径接 ctx）是同一类修复。

## 验证方式

- [ ] \`go build ./pkg/hertz/biz/router/\` 通过（已验证）。
- [ ] 手工：share paste 请求中途断开客户端，shareProxyClient 应立即取消，下游不再 hang。


Made with [Cursor](https://cursor.com)