### PR TITLE
fix(models): file_param.convert() 未知 fileType 返回明确 error

### DIFF
--- a/pkg/models/file_param.go
+++ b/pkg/models/file_param.go
@@ -109,6 +109,13 @@ func (p *FileParam) convert(url string) (err error) {
 		p.Extend = extend
 		p.Path = subPath
 
+	} else {
+		// Previously this fell through and returned (nil, *FileParam)
+		// with FileType == "". Downstream GetResourceUri then reported
+		// "invalid file type:" and the caller saw a confusing
+		// half-built param. Surface the unsupported type explicitly
+		// so the offending URL is visible at the parse site.
+		return fmt.Errorf("unsupported file type: %q (url: %s)", fileType, url)
 	}
 	return nil
 }

--- a/pkg/models/file_param_test.go
+++ b/pkg/models/file_param_test.go
@@ -402,6 +402,30 @@ func TestExternal(t *testing.T) {
 	assert.Equal(t, resUri+param.Path, "/data/External/VendorCo-0/folder/pic.jpg")
 }
 
+// TestUnsupportedFileType pins the contract added when convert()
+// stopped silently returning a half-built FileParam (FileType == "")
+// for unknown top-level URL segments. Each input is a fileType that
+// none of the if/else branches in convert() match; all should
+// surface a parse error rather than slip through to GetResourceUri.
+func TestUnsupportedFileType(t *testing.T) {
+	owner = "user1"
+
+	cases := []string{
+		"unknown/foo/bar",   // bogus fileType
+		"USB/foo/bar",       // case-sensitive: convert lowercases, "usb" not handled
+		"hdd/foo/bar",       // historical mount subtype, never registered top-level
+		"smb/foo/bar",       // same
+		"fake-fs/foo/bar",   // arbitrary
+		"backup/foo/bar",    // arbitrary
+	}
+	for _, url := range cases {
+		_, err := CreateFileParam(owner, url)
+		if err == nil {
+			t.Errorf("CreateFileParam(%q) returned nil error; expected unsupported file type", url)
+		}
+	}
+}
+
 // + get file param from uri
 func TestAllFileParamFromUri(t *testing.T) {
 	TestHomeFrontUri(t)


### PR DESCRIPTION
## Summary

(p *FileParam).convert had a chain of if/else branches matching
known top-level URL segments (drive / cache / sync / awss3 /
dropbox / google / external / share). Anything else fell through
to `return nil` with a half-built FileParam (FileType=""):

- Downstream GetResourceUri then reported "invalid file type" without pointing at the offending URL.
- Callers that did not strictly check FileType could pass the empty-typed FileParam further into driver code.

Make the fall-through an explicit `fmt.Errorf("unsupported file type: %q (url: %s)", fileType, url)`.

Add a TestUnsupportedFileType table that pins the new contract.

## Verification

- [ ] go test -count=1 ./pkg/models/ -v passes (verified locally).
- [ ] grep -R "unsupported file type" hits the convert() site only.


Made with [Cursor](https://cursor.com)