### PR TITLE
chore(lint): batch 1 — 修 misspell + bodyclose + unreachable（10 条）

### DIFF
--- a/cmd/backend/app/root.go
+++ b/cmd/backend/app/root.go
@@ -61,7 +61,7 @@ func init() {
 
 	persistent.StringVarP(&cfgFile, "config", "c", "", "config file path")
 	persistent.StringP("database", "d", "./filebrowser.db", "database path")
-	flags.Bool("noauth", false, "use the noauth auther when using quick setup")
+	flags.Bool("noauth", false, "use the noauth authenticator when using quick setup")
 	flags.String("username", "admin", "username for the first user when using quick config")
 	flags.String("password", "", "hashed password for the first user when using quick config (default \"admin\")")
 

--- a/pkg/drivers/clouds/rclone/serve/serve.go
+++ b/pkg/drivers/clouds/rclone/serve/serve.go
@@ -73,7 +73,13 @@ func (s *serve) Get(configName string, fpath string, header *http.Header) *Serve
 		}
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	// Body is intentionally passed up the call stack inside
+	// ServeResp.Body and consumed (and Close'd) by the Hertz
+	// RawHandler framework. bodyclose cannot follow that chain;
+	// the nolint pin documents the contract so future readers
+	// don't "fix" this into an immediate Close that would break
+	// streaming downloads.
+	resp, err := http.DefaultClient.Do(req) //nolint:bodyclose // Body returned in ServeResp; caller closes
 	if err != nil {
 		result.Error = err
 		return result

--- a/pkg/media/api/helpers/streaming_helpers.go
+++ b/pkg/media/api/helpers/streaming_helpers.go
@@ -229,7 +229,7 @@ func GetStreamingState(
 			mediaSource = &mediaInfo.MediaSourceInfo
 		}
 	} else {
-		// Enforce more restrictive transcoding profile for LiveTV due to compatability reasons
+		// Enforce more restrictive transcoding profile for LiveTV due to compatibility reasons
 		// Cap the MaxStreamingBitrate to 30Mbps, because we are unable to reliably probe source bitrate,
 		// which will cause the client to request extremely high bitrate that may fail the player/encoder
 		if *streamingRequest.VideoBitRate > 30000000 {

--- a/pkg/media/emby/server/implementations/appbase/base_configuration_manager.go
+++ b/pkg/media/emby/server/implementations/appbase/base_configuration_manager.go
@@ -83,10 +83,17 @@ func (cm *BaseConfigurationManager) AddParts(factories []cc.IConfigurationFactor
 	}
 }
 
-// SaveConfiguration saves the system configuration
+// SaveConfiguration saves the system configuration.
+//
+// Currently panics: this method is part of the partial Emby/Jellyfin
+// port and the underlying serializer wiring is not finished. The
+// code below the panic is the to-be-completed implementation kept
+// in place so the missing pieces are visible at the call site; it
+// is intentionally unreachable until the panic is removed.
 func (cm *BaseConfigurationManager) SaveConfiguration() error {
 	cm.logger.Info("Saving system configuration")
 	panic("Save")
+	//nolint:govet // unreachable: kept as TODO scaffold until panic is removed
 	path := cm.commonApplicationPaths.SystemConfigurationFilePath()
 
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {

--- a/pkg/media/mediabrowser/controller/mediaencoding/transcoding_job.go
+++ b/pkg/media/mediabrowser/controller/mediaencoding/transcoding_job.go
@@ -125,7 +125,7 @@ func (t *TranscodingJob) Stop() {
 	if !t.HasExited {
 		klog.Infoln(t.Path)
 		klog.Infoln(*t.Path)
-		t.Logger.Infomation("Stopping ffmpeg process with q command for %s", *t.Path)
+		t.Logger.Information("Stopping ffmpeg process with q command for %s", *t.Path)
 
 		/*
 			stdin, err := process.StdinPipe()
@@ -141,7 +141,7 @@ func (t *TranscodingJob) Stop() {
 
 		// Need to wait because killing is asynchronous.
 		if err := process.WaitForExit(5 * time.Second); err != nil {
-			t.Logger.Infomation("Killing FFmpeg process for %s %v", *t.Path, err)
+			t.Logger.Information("Killing FFmpeg process for %s %v", *t.Path, err)
 			process.Kill()
 		}
 	}

--- a/pkg/media/mediabrowser/mediaencoding/transcoding/transcode_manager.go
+++ b/pkg/media/mediabrowser/mediaencoding/transcoding/transcode_manager.go
@@ -809,7 +809,7 @@ func (t *TranscodeManager) DeleteProgressivePartialStreamFiles(outputFilePath st
 	if _, err := os.Stat(outputFilePath); err == nil {
 		err = os.Remove(outputFilePath)
 		if err != nil {
-			t.logger.Errorf("Error deleteing file %s: %v", outputFilePath, err)
+			t.logger.Errorf("Error deleting file %s: %v", outputFilePath, err)
 			return err
 		}
 	}

--- a/pkg/media/utils/logger.go
+++ b/pkg/media/utils/logger.go
@@ -31,7 +31,7 @@ func (l *Logger) Info(format string, v ...interface{}) {
         klog.Infof("[INFO] "+format, v...)
 }
 
-func (l *Logger) Infomation(format string, v ...interface{}) {
+func (l *Logger) Information(format string, v ...interface{}) {
         klog.Infof("[INFO] "+format, v...)
 }
 

--- a/pkg/tasks/task_paste_posix.go
+++ b/pkg/tasks/task_paste_posix.go
@@ -124,7 +124,7 @@ func (t *Task) rsync() error {
 	srcPath := src + t.param.Src.Path
 	dstPath := dst + t.param.Dst.Path
 
-	klog.Infof("[Task] Id: %s, conditon rsync, srcPath: %s, dstPath: %s", t.id, srcPath, dstPath)
+	klog.Infof("[Task] Id: %s, condition rsync, srcPath: %s, dstPath: %s", t.id, srcPath, dstPath)
 
 	var args = []string{
 		"-av",
@@ -185,7 +185,7 @@ func (t *Task) move() error {
 	srcPath := src + t.param.Src.Path
 	dstPath := dst + t.param.Dst.Path
 
-	klog.Infof("[Task] Id: %s, conditon move, srcPath: %s, dstPath: %s", t.id, srcPath, dstPath)
+	klog.Infof("[Task] Id: %s, condition move, srcPath: %s, dstPath: %s", t.id, srcPath, dstPath)
 	t.appendDetail(fmt.Sprintf("move %s -> %s", srcPath, dstPath))
 
 	var args = []string{srcPath, dstPath}


### PR DESCRIPTION
Burns 10 lint reports from baseline. After: 264 (was 274). See commit message for detail.

Made with [Cursor](https://cursor.com)