### PR TITLE
chore: 删除 staticcheck U1000 扫描出的死代码

### DIFF
--- a/pkg/drivers/clouds/download.go
+++ b/pkg/drivers/clouds/download.go
@@ -4,10 +4,7 @@ import (
 	"context"
 	"errors"
 	"files/pkg/common"
-	"files/pkg/files"
 	"files/pkg/models"
-	"path"
-	"strings"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -118,30 +115,6 @@ func (d *Download) download() error {
 	}
 }
 
-func (d *Download) generateBufferFolder() (string, error) {
-	var owner = d.fileParam.Owner
-	var exists = false
-	// Use RootPrefix (env-driven, fallback /data) so the buffer dir
-	// resolves to the same root the rest of the codebase uses (see
-	// PR #261/#262). ROOT_PREFIX is a hardcoded "/data" constant
-	// and ignores the deployment override.
-	var bufferFolder = path.Join(common.RootPrefix, common.CacheBuffer, owner)
-	if files.FilePathExists(bufferFolder) {
-		exists = true
-	}
-
-	if !exists {
-		if err := files.MkdirAllWithChown(nil, bufferFolder, 0755, true, 1000, 1000); err != nil {
-			return "", err
-		}
-	}
-
-	if !strings.HasSuffix(bufferFolder, "/") {
-		bufferFolder = bufferFolder + "/"
-	}
-
-	return bufferFolder, nil
-}
 
 func (d *Download) checkCtx() error {
 	select {

--- a/pkg/drivers/clouds/rclone/config/config.go
+++ b/pkg/drivers/clouds/rclone/config/config.go
@@ -30,12 +30,6 @@ type config struct {
 	sync.RWMutex
 }
 
-var localConfig = &Config{
-	ConfigName: common2.Local,
-	Name:       common2.Local,
-	Type:       common2.Local,
-}
-
 var _ Interface = &config{}
 
 func NewConfig() *config {
@@ -181,13 +175,6 @@ func (c *config) parseCreateConfigParameters(param *Config) *ConfigParameters {
 	}
 
 	return &ConfigParameters{}
-}
-
-func (c *config) parseGoogleDrive(param *Config) *ConfigParameters {
-	return &ConfigParameters{
-		ConfigName: param.ConfigName,
-		Name:       param.Name,
-	}
 }
 
 func (c *config) parseDropboxParams(param *Config) *ConfigParameters {

--- a/pkg/drivers/clouds/rclone/operations/operations.go
+++ b/pkg/drivers/clouds/rclone/operations/operations.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	commonutils "files/pkg/common"
 	"files/pkg/drivers/clouds/rclone/common"
-	"files/pkg/drivers/clouds/rclone/config"
 	"files/pkg/drivers/clouds/rclone/utils"
 	"fmt"
 	"net/http"
@@ -46,9 +45,7 @@ type Interface interface {
 	BackendCommand(command string, fs string, args []string, async bool) (*OperationsAsyncJobResp, error)
 }
 
-type operations struct {
-	config config.Interface
-}
+type operations struct{}
 
 func NewOperations() *operations {
 	return &operations{}

--- a/pkg/drivers/sync/seahub/searpc/named_pipe.go
+++ b/pkg/drivers/sync/seahub/searpc/named_pipe.go
@@ -26,10 +26,6 @@ type NamedPipeTransport struct {
 	client     *NamedPipeClient
 }
 
-func (c *NamedPipeClient) validateTransport(t *NamedPipeTransport) bool {
-	return t.conn != nil
-}
-
 func (t *NamedPipeTransport) Connect() error {
 	if t.conn == nil {
 		conn, err := net.Dial("unix", t.socketPath)

--- a/pkg/files/file.go
+++ b/pkg/files/file.go
@@ -12,12 +12,10 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"io/fs"
 	"mime"
 	"net/http"
 	"os"
 	"path"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -506,73 +504,6 @@ func (i *FileInfo) detectSubtitles() {
 			}
 		}
 	}
-}
-
-func (i *FileInfo) readDirents() ([]os.FileInfo, error) {
-	var (
-		dir      []os.FileInfo
-		firstErr error
-		err      error
-	)
-
-	afs := &afero.Afero{Fs: i.Fs}
-	dir, err = afs.ReadDir(i.Path)
-	if err != nil {
-		klog.Error(err)
-		if !strings.Contains(err.Error(), "host is down") {
-			return nil, err
-		}
-
-		// SMB/CIFS fallback: walk the host filesystem under
-		// RootPrefix so the path matches DefaultFs's view of the
-		// data root. The literal "/data" used to be hardcoded here
-		// and would diverge whenever ROOT_PREFIX was set to
-		// anything else (PR #261/#262 made the rest of the codebase
-		// honor RootPrefix; this site was missed).
-		walkRoot := common.RootPrefix + i.Path
-		err = filepath.WalkDir(walkRoot, func(path string, d fs.DirEntry, err error) error {
-			if err != nil {
-				if strings.Contains(err.Error(), "host is down") {
-					klog.Warningf("[WARN] skipping %s: %v\n", path, err)
-					return nil
-				}
-				firstErr = fmt.Errorf("walk error %s: %w", path, err)
-				return err
-			}
-
-			if path == walkRoot {
-				return nil
-			}
-
-			relPath, err := filepath.Rel(walkRoot, path)
-			if err != nil {
-				return nil
-			}
-
-			if strings.Count(relPath, "/") > 0 {
-				return filepath.SkipDir
-			}
-
-			info, err := d.Info()
-			if err != nil {
-				if strings.Contains(err.Error(), "host is down") {
-					klog.Warningf("[WARN] skipping %s: %v\n", path, err)
-					return nil
-				}
-				firstErr = fmt.Errorf("get file info failed %s: %w", path, err)
-				return err
-			}
-
-			dir = append(dir, info)
-			return nil
-		})
-
-		if err != nil {
-			klog.Errorln(firstErr)
-			return nil, err
-		}
-	}
-	return dir, nil
 }
 
 func (i *FileInfo) readListing(readHeader bool) error {

--- a/pkg/tasks/task.go
+++ b/pkg/tasks/task.go
@@ -444,12 +444,6 @@ func (t *Task) GetProgress() (string, int, int64, int64) {
 	return t.state, t.progress, t.transfer, t.totalSize
 }
 
-func (t *Task) isLastPhase() bool {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-	return t.currentPhase == t.totalPhases
-}
-
 func (t *Task) isCancel() (bool, error) {
 	select {
 	case <-t.ctx.Done():


### PR DESCRIPTION
## 概要

使用 `staticcheck -checks U1000`（v0.7.0 / 2026.1）对非 media 包做层进式死代码扫描，删除所有确认无调用方的叶子级函数、方法、变量和结构体字段。

跳过了以下内容：测试文件、Hertz 生成的 middleware 桩、数据库模型结构体、`pkg/media/` 整个目录。

## 改动明细

| 文件 | 删除项 | 说明 |
|------|--------|------|
| `pkg/drivers/clouds/download.go` | `(*Download).generateBufferFolder` | 无调用方，27 行 |
| `pkg/drivers/clouds/rclone/config/config.go` | `var localConfig`、`(*config).parseGoogleDrive` | 均无调用方 |
| `pkg/drivers/clouds/rclone/operations/operations.go` | `operations.config` 字段 | 结构体内未使用字段，删除后同步清理了 unused import |
| `pkg/drivers/sync/seahub/searpc/named_pipe.go` | `(*NamedPipeClient).validateTransport` | 无调用方 |
| `pkg/files/file.go` | `(*FileInfo).readDirents` | SMB/CIFS fallback 方法，无调用方，69 行 |
| `pkg/tasks/task.go` | `(*Task).isLastPhase` | 无调用方 |

6 个文件，净删 123 行。

## 验证方式

- `go build ./pkg/drivers/... ./pkg/files/... ./pkg/tasks/...` 通过
- `go test ./pkg/models/... ./pkg/common/... ./pkg/files/...` 通过
- 第二轮 `staticcheck U1000` 扫描确认无新暴露的死代码（剩余项均为测试文件或 Hertz 生成桩）

Made with [Cursor](https://cursor.com)