### PR TITLE
chore(lint): batch 6 — non-media ineffassign 清理 (24，含若干真 bug)

### DIFF
--- a/pkg/drivers/clouds/rclone/rclone.go
+++ b/pkg/drivers/clouds/rclone/rclone.go
@@ -400,7 +400,8 @@ func (r *rclone) CreateEmptyDirectories(src, target *models.FileParam) error {
 
 	// create
 	var localFs, localRemote string = fmt.Sprintf("%s:%s", common.Local, common.DefaultLocalRootPath), common.DefaultKeepFileName
-	var dstFs, dstRemote string = dstFsPrefix, ""
+	var dstFs string = dstFsPrefix
+	var dstRemote string
 
 	for _, item := range srcPathFormated {
 		dstRemote = dstPrefix + filepath.Join(dstName, item) + "/"
@@ -435,8 +436,8 @@ func (r *rclone) CreatePlaceHolder(dst *models.FileParam) error {
 	dstPrefix := files.GetPrefixPath(dst.Path)
 	dstName, isFile := files.GetFileNameFromPath(dst.Path)
 
-	var dstFs, dstRemote string = dstFsPrefix, ""
-	dstRemote = dstPrefix + dstName
+	var dstFs string = dstFsPrefix
+	dstRemote := dstPrefix + dstName
 
 	if isFile {
 		dstRemote = strings.TrimPrefix(dstRemote, "/")
@@ -609,6 +610,11 @@ func (r *rclone) Delete(param *models.FileParam, dirents []string) ([]string, er
 		klog.Infof("[rclone] delete, delete (%d/%d), user: %s, file: %s", current+1, total, user, dp)
 
 		fsPrefix, err := r.GetFsPrefix(param)
+		if err != nil {
+			klog.Errorf("[rclone] delete, get fs prefix error: %v", err)
+			deleteFailedPaths = append(deleteFailedPaths, dp)
+			continue
+		}
 		_, isFile := files.GetFileNameFromPath(dp)
 
 		var fs, remote string

--- a/pkg/drivers/clouds/rclone/utils/utils.go
+++ b/pkg/drivers/clouds/rclone/utils/utils.go
@@ -39,8 +39,7 @@ func Request(ctx context.Context, u string, method string, header *http.Header, 
 		return true
 	}, func() error {
 		var newRequest *http.Request
-		var requestBody *bytes.Buffer = nil
-		requestBody = bytes.NewBuffer(requestParams)
+		requestBody := bytes.NewBuffer(requestParams)
 
 		if requestParams != nil {
 			newRequest, err = http.NewRequestWithContext(ctx, method, u, requestBody)

--- a/pkg/drivers/clouds/service.go
+++ b/pkg/drivers/clouds/service.go
@@ -95,6 +95,10 @@ func (s *service) CreateFolder(param *models.FileParam) ([]byte, error) {
 	klog.Infof("[service] creatFolder, param: %s", common.ToJson(param))
 
 	fsPrefix, err := s.command.GetFsPrefix(param)
+	if err != nil {
+		klog.Errorf("[service] creatFolder, get fs prefix error: %v", err)
+		return nil, err
+	}
 	prefixPath := files.GetPrefixPath(param.Path)
 	fileName, _ := files.GetFileNameFromPath(param.Path)
 

--- a/pkg/drivers/posix/cache/cache_paste.go
+++ b/pkg/drivers/posix/cache/cache_paste.go
@@ -103,10 +103,14 @@ func (s *CacheStorage) copyToCache() (task *tasks.Task, err error) {
 	var srcNode = s.paste.Src.Extend
 	var dstNode = s.paste.Dst.Extend
 
-	// Route to the dst node
+	// Route to the dst node. If we're not the dst node, bail out
+	// before creating the task so the caller actually sees the
+	// "not master node" error. (Previously the err was set but
+	// immediately overwritten by task.Execute below.)
 	if dstNode != global.CurrentNodeName {
 		klog.Errorf("not dst node")
 		err = errors.New("Cache copyToCache, not master node")
+		return
 	}
 
 	if srcNode == dstNode {

--- a/pkg/drivers/posix/posix/posix.go
+++ b/pkg/drivers/posix/posix/posix.go
@@ -427,17 +427,12 @@ func (s *PosixStorage) Rename(contextArgs *models.HttpContextArgs) ([]byte, erro
 		return nil, nil
 	}
 
-	var srcFilenamePrefix = srcName
-	var dstFilenamePrefix = dstName
-	var srcFilenameExt, dstFilenameExt string
-
-	if isSrcFile {
-		_, srcFilenameExt = common.SplitNameExt(srcName)
-		srcFilenamePrefix = strings.TrimSuffix(srcFilenamePrefix, srcFilenameExt)
-
-		_, dstFilenameExt = common.SplitNameExt(dstName)
-		dstFilenamePrefix = strings.TrimSuffix(dstFilenamePrefix, dstFilenameExt)
-	}
+	// NOTE: previously this block computed srcFilenamePrefix /
+	// dstFilenamePrefix (name minus extension) for filename
+	// collision handling, but the values were never consumed by
+	// the rest of the function. Removed to keep the lint baseline
+	// clean. If extension-aware collision rename is added later,
+	// reintroduce these locals together with the consumer.
 
 	var afs = afero.NewOsFs()
 	var srcPrefixPath = files.GetPrefixPath(fileParam.Path)
@@ -508,6 +503,10 @@ func (s *PosixStorage) Edit(contextArgs *models.HttpContextArgs) (*models.EditHa
 	}
 
 	info, err := files.WriteFile(filePath, contextArgs.QueryParam.Body)
+	if err != nil {
+		klog.Errorf("Posix edit, write file %s failed: %v", filePath, err)
+		return nil, err
+	}
 	etag := fmt.Sprintf(`"%x%x"`, info.ModTime().UnixNano(), info.Size())
 
 	return &models.EditHandlerResponse{

--- a/pkg/drivers/posix/posix/posix_paste.go
+++ b/pkg/drivers/posix/posix/posix_paste.go
@@ -139,9 +139,14 @@ func (s *PosixStorage) copyToCloud() (task *tasks.Task, err error) {
 	var currentNodeName = global.CurrentNodeName
 	var isCurrentNodeMaster = global.GlobalNode.IsMasterNode(currentNodeName)
 
+	// Bail out before creating a task if we aren't the master node.
+	// (Previously the err was set then immediately overwritten by
+	// task.Execute below, so the "not master node" error was never
+	// surfaced to the caller.)
 	if !isCurrentNodeMaster {
 		klog.Error("not master node")
 		err = errors.New("Posix copyToCloud, not master node")
+		return
 	}
 
 	task = tasks.TaskManager.CreateTask(s.paste)

--- a/pkg/drivers/posix/upload/handlefunc.go
+++ b/pkg/drivers/posix/upload/handlefunc.go
@@ -193,11 +193,6 @@ func HandleUploadChunks(fileParam *models.FileParam, uploadId string, resumableI
 		}
 	}
 
-	p := resumableInfo.ParentDir
-	if !strings.HasSuffix(p, "/") {
-		p = p + "/"
-	}
-
 	// dst storage path, if shared, fileParam must be sharedby Param
 	// uploadPath = uri + fileParam.Path
 	if share != "" {

--- a/pkg/drivers/sync/seahub/batch.go
+++ b/pkg/drivers/sync/seahub/batch.go
@@ -266,6 +266,10 @@ func HandleBatchMove(owner, srcRepoId, srcParentDir string, srcDirents []string,
 	}
 
 	folderPerms, err := GetSubFolderPermissionByDir(username, srcRepoId, srcParentDir)
+	if err != nil {
+		klog.Errorf("get sub folder permission failed: %v", err)
+		return nil, err
+	}
 	for _, dirent := range srcDirents {
 		if perm, exists := folderPerms[dirent]; exists {
 			if perm != "rw" {

--- a/pkg/drivers/sync/seahub/dir.go
+++ b/pkg/drivers/sync/seahub/dir.go
@@ -653,6 +653,10 @@ func CheckFilenameWithRename(repoId, parentDir, objName string) string {
 	latestCommit := cmmts[0]
 
 	dirents, err := seaserv.GlobalSeafileAPI.ListDirByCommitAndPath(repoId, latestCommit["id"], parentDir, -1, -1)
+	if err != nil {
+		klog.Errorf("list dir by commit failed: %v", err)
+		return ""
+	}
 	existObjNames := make([]string, len(dirents))
 	for i, d := range dirents {
 		existObjNames[i] = d["obj_name"]

--- a/pkg/drivers/sync/seahub/seaserv/user.go
+++ b/pkg/drivers/sync/seahub/seaserv/user.go
@@ -83,6 +83,10 @@ func DeleteUser(username string) error {
 	}
 
 	ownedRepos, err := GlobalSeafileAPI.GetOwnedRepoList(username, false, -1, -1)
+	if err != nil {
+		klog.Errorf("get owned repo list for %s failed: %v", username, err)
+		return err
+	}
 
 	for _, repo := range ownedRepos {
 		resultCode, err = GlobalSeafileAPI.RemoveRepo(repo["id"])

--- a/pkg/drivers/sync/sync.go
+++ b/pkg/drivers/sync/sync.go
@@ -262,11 +262,11 @@ func (s *SyncStorage) Preview(contextArgs *models.HttpContextArgs) (*models.Prev
 		return nil, fmt.Errorf("invalid path")
 	}
 
-	var size = queryParam.PreviewSize
-	if size != "big" {
-		size = "thumb"
-	}
-
+	// Preview size selector is not used downstream by this function
+	// (the seafile API only exposes the original file via this
+	// path; thumb generation happens at the cache layer). Keep
+	// queryParam.PreviewSize as part of the cache key so big/thumb
+	// previews don't collide.
 	var previewFileName = fileParam.FileType + fileParam.Extend + fileInfo.Path + time.Unix(fileInfo.LastModified, 0).String() + queryParam.PreviewSize
 	klog.Infof("Preview preview, fileName: %s", previewFileName)
 	var key = diskcache.GenerateCacheKey(previewFileName)

--- a/pkg/files/file.go
+++ b/pkg/files/file.go
@@ -198,7 +198,7 @@ func MountPathIncluster(r *http.Request) (map[string]interface{}, error) {
 
 func UnmountPathIncluster(r *http.Request, path string) (map[string]interface{}, error) {
 	externalType := r.URL.Query().Get("external_type")
-	var url = ""
+	var url string
 	if externalType == "usb" {
 		url = "http://" + TerminusdHost + "/command/umount-usb-incluster"
 	} else if externalType == "smb" {

--- a/pkg/hertz/biz/router/middleware.go
+++ b/pkg/hertz/biz/router/middleware.go
@@ -165,8 +165,6 @@ func ShareMiddleware() app.HandlerFunc {
 
 		// if Paste, is's Source
 		var paramPath string
-		var urlShareType string
-		_ = urlShareType
 		var shareAccess = &ShareAccess{
 			Method: method,
 		}
@@ -262,8 +260,6 @@ func ShareMiddleware() app.HandlerFunc {
 			}
 			return
 		}
-
-		urlShareType = strings.ToLower(shared.ShareType)
 
 		klog.Infof("[share] share path: %s", common.ToJson(shared))
 

--- a/pkg/models/file_param_test.go
+++ b/pkg/models/file_param_test.go
@@ -456,7 +456,7 @@ func TestDataFrontUri(t *testing.T) {
 	initGlobal(owner)
 	var err error
 	var uri string
-	var fp = new(FileParam)
+	var fp *FileParam
 
 	uri = "/data/user-pvc-user1/Data/"
 	fp = &FileParam{}
@@ -482,7 +482,7 @@ func TestCacheFrontUri(t *testing.T) {
 	initGlobal(owner)
 	var err error
 	var uri string
-	var fp = new(FileParam)
+	var fp *FileParam
 
 	uri = "/appcache/cache-pvc-user1/tailscale/"
 	fp = &FileParam{}
@@ -509,7 +509,7 @@ func TestExternalFrontUri(t *testing.T) {
 	initGlobal(owner)
 	var err error
 	var uri string
-	var fp = new(FileParam)
+	var fp *FileParam
 
 	// ~ internal
 	uri = "/data/External/s3/"
@@ -562,7 +562,7 @@ func TestSyncFrontUri(t *testing.T) {
 	initGlobal(owner)
 	var err error
 	var uri string
-	var fp = new(FileParam)
+	var fp *FileParam
 
 	uri = "/sync/"
 	fp = &FileParam{}
@@ -594,7 +594,7 @@ func TestCloudFrontUri(t *testing.T) {
 	initGlobal(owner)
 	var err error
 	var uri string
-	var fp = new(FileParam)
+	var fp *FileParam
 
 	// google
 	uri = "/google/account@gmail.com/"

--- a/pkg/tasks/task_paste_cloud.go
+++ b/pkg/tasks/task_paste_cloud.go
@@ -541,7 +541,9 @@ func (t *Task) checkJobStats(jobId int, dstPath string) (bool, error) {
 
 			if jobStatusData.Success && jobStatusData.Finished {
 				klog.Infof("[Task] Id: %s, job finished: %v, dst: %s", t.id, jobStatusData.Finished, dstPath)
-				transferFinished = true
+				// transferFinished isn't read after break here; the
+				// only consumer is the !jobStatusData.Finished arm
+				// below where it gates t.setTidyDirs(true).
 				t.updateProgress(safeProgressPct(totalTransfers, totalSize), transfers)
 				done = true
 				err = nil

--- a/pkg/tasks/task_paste_sync.go
+++ b/pkg/tasks/task_paste_sync.go
@@ -573,7 +573,7 @@ func (t *Task) DownloadFileFromSync(src, dst *models.FileParam, root bool) error
 
 	var downloadFilePathShortName = t.manager.formatFilePathWithoutTask(downloadFilePath, t.id)
 
-	dstFileStat, err := os.Stat(downloadFilePath)
+	dstFileStat, _ := os.Stat(downloadFilePath)
 	if dstFileStat != nil && dstFileStat.Size() == fileSize {
 		var p = int(float64(t.transfer+fileSize) / float64(t.totalSize) * 100)
 		t.updateProgress(p, fileSize)


### PR DESCRIPTION
其中 8 条是真 bug：error 赋值后立即被覆盖，调用方拿不到。其余 16 条是 dead store。详见 commit message。

Made with [Cursor](https://cursor.com)