### PR TITLE
chore(lint): batch 7 — pkg/media/api shadow 重命名 (28)

### DIFF
--- a/pkg/media/api/controllers/configuration_controller.go
+++ b/pkg/media/api/controllers/configuration_controller.go
@@ -79,9 +79,10 @@ func (c *ConfigurationController) UpdateNamedConfiguration(ctx context.Context, 
 	// Create a new instance of the configuration type
 	configInstance := reflect.New(configType).Interface()
 
-	// Deserialize the JSON into the configuration type
-	if err := json.Unmarshal(config, configInstance); err != nil {
-		klog.Errorf("[media] UpdateNamedConfiguration, err: %v", err)
+	// Deserialize the JSON into the configuration type. Inner err
+	// renamed to e to avoid shadowing the function-scope err.
+	if e := json.Unmarshal(config, configInstance); e != nil {
+		klog.Errorf("[media] UpdateNamedConfiguration, err: %v", e)
 		handler.RespBadRequest(r, "failed to deserialize configuration")
 		return
 	}

--- a/pkg/media/api/controllers/dynamic_hls_controller.go
+++ b/pkg/media/api/controllers/dynamic_hls_controller.go
@@ -141,18 +141,22 @@ func (d *DynamicHlsController) GetMasterHlsVideoPlaylist(ctx context.Context, c 
 	maxAudioChannels, _ := strconv.Atoi(c.Query("MaxAudioChannels"))
 	profile := c.Query("Profile")
 	level := c.Query("Level")
+	// NOTE: each inner err in the following GetQuery blocks is
+	// renamed to `e` to avoid shadowing the function-scope err
+	// (govet shadow). The semantics of `if e != nil { ... = &tmp }`
+	// are preserved verbatim from the original Jellyfin port.
 	var framerate *float32
 	if fr := c.Query("Framerate"); fr != "" {
-		f64, err := strconv.ParseFloat(fr, 32)
-		if err != nil {
+		f64, e := strconv.ParseFloat(fr, 32)
+		if e != nil {
 			f32 := float32(f64)
 			framerate = &f32
 		}
 	}
 	var maxFramerate *float32
 	if p := c.Query("MaxFramerate"); p != "" {
-		f64, err := strconv.ParseFloat(p, 32)
-		if err != nil {
+		f64, e := strconv.ParseFloat(p, 32)
+		if e != nil {
 			f32 := float32(f64)
 			maxFramerate = &f32
 		}
@@ -162,29 +166,29 @@ func (d *DynamicHlsController) GetMasterHlsVideoPlaylist(ctx context.Context, c 
 	startTimeTicks, _ := strconv.ParseInt(c.Query("StartTimeTicks"), 10, 64)
 	var width *int
 	if _, ok := c.GetQuery("Width"); ok {
-		tmp, err := strconv.Atoi(c.Query("Width"))
-		if err != nil {
+		tmp, e := strconv.Atoi(c.Query("Width"))
+		if e != nil {
 			width = &tmp
 		}
 	}
 	var height *int
 	if _, ok := c.GetQuery("height"); ok {
-		tmp, err := strconv.Atoi(c.Query("height"))
-		if err != nil {
+		tmp, e := strconv.Atoi(c.Query("height"))
+		if e != nil {
 			height = &tmp
 		}
 	}
 	var maxWidth *int
 	if _, ok := c.GetQuery("MaxWidth"); ok {
-		tmp, err := strconv.Atoi(c.Query("MaxWidth"))
-		if err != nil {
+		tmp, e := strconv.Atoi(c.Query("MaxWidth"))
+		if e != nil {
 			maxWidth = &tmp
 		}
 	}
 	var maxHeight *int
 	if _, ok := c.GetQuery("MaxHeight"); ok {
-		tmp, err := strconv.Atoi(c.Query("MaxHeight"))
-		if err != nil {
+		tmp, e := strconv.Atoi(c.Query("MaxHeight"))
+		if e != nil {
 			maxHeight = &tmp
 		}
 	}
@@ -549,8 +553,8 @@ func (d *DynamicHlsController) GetHlsVideoSegment(ctx context.Context, c *app.Re
 
 	var segmentLength *int
 	if _, ok := c.GetQuery("SegmentLength"); ok {
-		tmp, err := strconv.Atoi(c.Query("SegmentLength"))
-		if err != nil {
+		tmp, e := strconv.Atoi(c.Query("SegmentLength"))
+		if e != nil {
 			segmentLength = &tmp
 		}
 	}
@@ -569,14 +573,21 @@ func (d *DynamicHlsController) GetHlsVideoSegment(ctx context.Context, c *app.Re
 	if _, ok := c.GetQuery("AudioChannels"); ok {
 		tmp, _ := strconv.Atoi(c.Query("AudioChannels"))
 		if err != nil {
+			// NOTE: this block intentionally still references the
+			// outer (function-scope) err; keeping the original
+			// (likely-buggy) port behavior. Renamed err in the
+			// peer blocks (segmentLength, framerate, ...) above
+			// to silence shadow.
 			audioChannels = &tmp
 		}
 
 	}
+	// NOTE: each inner err in the GetQuery blocks below is renamed
+	// to `e` to avoid shadowing the function-scope err.
 	var maxAudioChannels *int
 	if _, ok := c.GetQuery("MaxAudioChannels"); ok {
-		tmp, err := strconv.Atoi(c.Query("MaxAudioChannels"))
-		if err != nil {
+		tmp, e := strconv.Atoi(c.Query("MaxAudioChannels"))
+		if e != nil {
 			maxAudioChannels = &tmp
 		}
 	}
@@ -584,8 +595,8 @@ func (d *DynamicHlsController) GetHlsVideoSegment(ctx context.Context, c *app.Re
 	level := c.Query("Level")
 	var framerate *float32
 	if _, ok := c.GetQuery("Framerate"); ok {
-		f64, err := strconv.ParseFloat(c.Query("Framerate"), 32)
-		if err != nil {
+		f64, e := strconv.ParseFloat(c.Query("Framerate"), 32)
+		if e != nil {
 			f32 := float32(f64)
 			framerate = &f32
 		}
@@ -593,8 +604,8 @@ func (d *DynamicHlsController) GetHlsVideoSegment(ctx context.Context, c *app.Re
 
 	var maxFramerate *float32
 	if _, ok := c.GetQuery("MaxFramerate"); ok {
-		f64, err := strconv.ParseFloat(c.Query("MaxFramerate"), 32)
-		if err != nil {
+		f64, e := strconv.ParseFloat(c.Query("MaxFramerate"), 32)
+		if e != nil {
 			f32 := float32(f64)
 			maxFramerate = &f32
 		}
@@ -603,29 +614,29 @@ func (d *DynamicHlsController) GetHlsVideoSegment(ctx context.Context, c *app.Re
 	startTimeTicks, _ := strconv.ParseInt(c.Query("StartTimeTicks"), 10, 64)
 	var width *int
 	if _, ok := c.GetQuery("Width"); ok {
-		tmp, err := strconv.Atoi(c.Query("Width"))
-		if err != nil {
+		tmp, e := strconv.Atoi(c.Query("Width"))
+		if e != nil {
 			width = &tmp
 		}
 	}
 	var height *int
 	if _, ok := c.GetQuery("Height"); ok {
-		tmp, err := strconv.Atoi(c.Query("Height"))
-		if err != nil {
+		tmp, e := strconv.Atoi(c.Query("Height"))
+		if e != nil {
 			height = &tmp
 		}
 	}
 	var maxWidth *int
 	if _, ok := c.GetQuery("MaxWidth"); ok {
-		tmp, err := strconv.Atoi(c.Query("MaxWidth"))
-		if err != nil {
+		tmp, e := strconv.Atoi(c.Query("MaxWidth"))
+		if e != nil {
 			maxWidth = &tmp
 		}
 	}
 	var maxHeight *int
 	if _, ok := c.GetQuery("MaxHeight"); ok {
-		tmp, err := strconv.Atoi(c.Query("MaxHeight"))
-		if err != nil {
+		tmp, e := strconv.Atoi(c.Query("MaxHeight"))
+		if e != nil {
 			maxHeight = &tmp
 		}
 	}
@@ -656,8 +667,8 @@ func (d *DynamicHlsController) GetHlsVideoSegment(ctx context.Context, c *app.Re
 	}
 
 	var streamOptions StreamOptions
-	if err := GetFromQuery(c, &streamOptions); err != nil {
-		handler.RespBadRequest(c, err.Error())
+	if e := GetFromQuery(c, &streamOptions); e != nil {
+		handler.RespBadRequest(c, e.Error())
 		return
 	}
 
@@ -771,7 +782,7 @@ func (d *DynamicHlsController) GetDynamicSegment(c *app.RequestContext, request 
 	segmentPath, _ := d.getSegmentPath(state, playlistPath, segmentId)
 	segmentExtension := mediaencoding.GetSegmentFileExtension(state.Request.SegmentContainer)
 	var job *mediaencoding.TranscodingJob
-	if _, err := os.Stat(segmentPath); err == nil {
+	if _, e := os.Stat(segmentPath); e == nil {
 		job = d.transcodeManager.OnTranscodeBeginRequest(playlistPath, transcodingJobType)
 		klog.Infof("returning %s [it exists, try 1]\n", segmentPath)
 		return d.GetSegmentResult(state, playlistPath, segmentPath, segmentExtension, segmentId, job, ctx)
@@ -784,7 +795,7 @@ func (d *DynamicHlsController) GetDynamicSegment(c *app.RequestContext, request 
 	}
 	defer unlock()
 
-	if _, err := os.Stat(segmentPath); err == nil {
+	if _, e := os.Stat(segmentPath); e == nil {
 		job = d.transcodeManager.OnTranscodeBeginRequest(playlistPath, transcodingJobType)
 		klog.Infof("returning %s [it exists, try 2]\n", segmentPath)
 		return d.GetSegmentResult(state, playlistPath, segmentPath, segmentExtension, segmentId, job, ctx)
@@ -835,7 +846,7 @@ func (d *DynamicHlsController) GetDynamicSegment(c *app.RequestContext, request 
 		streamingRequest.StartTimeTicks = &streamingRequest.CurrentRuntimeTicks
 
 		state.WaitForPath = segmentPath
-		_, err := d.transcodeManager.StartFfMpeg(
+		_, e := d.transcodeManager.StartFfMpeg(
 			*state,
 			playlistPath,
 			d.GetCommandLineArguments(playlistPath, state, false, segmentId),
@@ -844,9 +855,9 @@ func (d *DynamicHlsController) GetDynamicSegment(c *app.RequestContext, request 
 			ctx,
 			".",
 		)
-		if err != nil {
+		if e != nil {
 			state.Dispose()
-			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}), err
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}), e
 		}
 	} else {
 		job = d.transcodeManager.OnTranscodeBeginRequest(playlistPath, transcodingJobType)
@@ -1188,10 +1199,12 @@ func (d *DynamicHlsController) GetVariantHlsVideoPlaylist(ctx context.Context, c
 	if tmp := c.Query("SegmentContainer"); tmp != "" {
 		segmentContainer = &tmp
 	}
+	// NOTE: each inner err in the GetQuery blocks below is renamed
+	// to `e` to avoid shadowing the function-scope err.
 	var segmentLength *int
 	if _, ok := c.GetQuery("SegmentLength"); ok {
-		tmp, err := strconv.Atoi(c.Query("SegmentLength"))
-		if err != nil {
+		tmp, e := strconv.Atoi(c.Query("SegmentLength"))
+		if e != nil {
 			segmentLength = &tmp
 		}
 	}
@@ -1212,16 +1225,16 @@ func (d *DynamicHlsController) GetVariantHlsVideoPlaylist(ctx context.Context, c
 	level := c.Query("Level")
 	var framerate *float32
 	if fr := c.Query("Framerate"); fr != "" {
-		f64, err := strconv.ParseFloat(fr, 32)
-		if err != nil {
+		f64, e := strconv.ParseFloat(fr, 32)
+		if e != nil {
 			f32 := float32(f64)
 			framerate = &f32
 		}
 	}
 	var maxFramerate *float32
 	if p := c.Query("MaxFramerate"); p != "" {
-		f64, err := strconv.ParseFloat(p, 32)
-		if err != nil {
+		f64, e := strconv.ParseFloat(p, 32)
+		if e != nil {
 			f32 := float32(f64)
 			maxFramerate = &f32
 		}
@@ -1230,29 +1243,29 @@ func (d *DynamicHlsController) GetVariantHlsVideoPlaylist(ctx context.Context, c
 	startTimeTicks, _ := strconv.ParseInt(c.Query("StartTimeTicks"), 10, 64)
 	var width *int
 	if _, ok := c.GetQuery("Width"); ok {
-		tmp, err := strconv.Atoi(c.Query("Width"))
-		if err != nil {
+		tmp, e := strconv.Atoi(c.Query("Width"))
+		if e != nil {
 			width = &tmp
 		}
 	}
 	var height *int
 	if _, ok := c.GetQuery("Height"); ok {
-		tmp, err := strconv.Atoi(c.Query("Height"))
-		if err != nil {
+		tmp, e := strconv.Atoi(c.Query("Height"))
+		if e != nil {
 			height = &tmp
 		}
 	}
 	var maxWidth *int
 	if _, ok := c.GetQuery("MaxWidth"); ok {
-		tmp, err := strconv.Atoi(c.Query("MaxWidth"))
-		if err != nil {
+		tmp, e := strconv.Atoi(c.Query("MaxWidth"))
+		if e != nil {
 			maxWidth = &tmp
 		}
 	}
 	var maxHeight *int
 	if _, ok := c.GetQuery("MaxHeight"); ok {
-		tmp, err := strconv.Atoi(c.Query("MaxHeight"))
-		if err != nil {
+		tmp, e := strconv.Atoi(c.Query("MaxHeight"))
+		if e != nil {
 			maxHeight = &tmp
 		}
 	}
@@ -1283,9 +1296,9 @@ func (d *DynamicHlsController) GetVariantHlsVideoPlaylist(ctx context.Context, c
 	}
 
 	var streamOptions StreamOptions
-	if err := GetFromQuery(c, &streamOptions); err != nil {
-		klog.Errorf("[media] GetVariantHlsVideoPlaylist, get query error: %v", err)
-		handler.RespBadRequest(c, err.Error())
+	if e := GetFromQuery(c, &streamOptions); e != nil {
+		klog.Errorf("[media] GetVariantHlsVideoPlaylist, get query error: %v", e)
+		handler.RespBadRequest(c, e.Error())
 		return
 	}
 

--- a/pkg/media/api/controllers/videos_controller.go
+++ b/pkg/media/api/controllers/videos_controller.go
@@ -127,16 +127,20 @@ func (vc *VideosController) GetVideoStreamByContainer(w http.ResponseWriter, r *
 	//	framerate, _ := strconv.ParseFloat(r.URL.Query().Get("framerate"), 64)
 	var framerate *float32
 	if fr := r.URL.Query().Get("Framerate"); fr != "" {
-		f64, err := strconv.ParseFloat(fr, 32)
-		if err != nil {
+		// NOTE: rename inner err to e to silence govet shadow
+		// against the function-scope err. The if-body's check on
+		// e != nil mirrors the original (likely-inverted) port
+		// behavior; semantics intentionally preserved.
+		f64, e := strconv.ParseFloat(fr, 32)
+		if e != nil {
 			f32 := float32(f64)
 			framerate = &f32
 		}
 	}
 	var maxFramerate *float32
 	if p := r.URL.Query().Get("MaxFramerate"); p != "" {
-		f64, err := strconv.ParseFloat(p, 32)
-		if err != nil {
+		f64, e := strconv.ParseFloat(p, 32)
+		if e != nil {
 			f32 := float32(f64)
 			maxFramerate = &f32
 		}


### PR DESCRIPTION
28 处 shadow 仅做重命名（err → e），保留原 port 行为。详见 commit message。

Made with [Cursor](https://cursor.com)