### PR TITLE
chore(lint): batch 8 — pkg/tasks shadow 重命名 (11)

### DIFF
--- a/pkg/tasks/task_paste_cloud.go
+++ b/pkg/tasks/task_paste_cloud.go
@@ -161,10 +161,10 @@ func (t *Task) DownloadFromCloud() error {
 
 	} else {
 
-		jobResp, err := cmd.Copy(src, dst)
-		if err != nil {
-			klog.Errorf("[Task] Id: %s, copy error: %v", t.id, err)
-			return fmt.Errorf("copy error: %v, src: %s, dst: %s", err, common.ToJson(src), common.ToJson(dst))
+		jobResp, e := cmd.Copy(src, dst)
+		if e != nil {
+			klog.Errorf("[Task] Id: %s, copy error: %v", t.id, e)
+			return fmt.Errorf("copy error: %v, src: %s, dst: %s", e, common.ToJson(src), common.ToJson(dst))
 		}
 
 		if jobResp.JobId == nil {
@@ -421,10 +421,10 @@ func (t *Task) CopyToCloud() error {
 		}
 	} else {
 		// create download job
-		jobResp, err := cmd.Copy(src, dst)
-		if err != nil {
-			klog.Errorf("[Task] Id: %s, copy error: %v", t.id, err)
-			return fmt.Errorf("copy error: %v, src: %s, dst: %s", err, common.ToJson(src), common.ToJson(dst))
+		jobResp, e := cmd.Copy(src, dst)
+		if e != nil {
+			klog.Errorf("[Task] Id: %s, copy error: %v", t.id, e)
+			return fmt.Errorf("copy error: %v, src: %s, dst: %s", e, common.ToJson(src), common.ToJson(dst))
 		}
 
 		if jobResp.JobId == nil {
@@ -618,14 +618,20 @@ func (t *Task) copyId(src, dst *models.FileParam, driveId string) error {
 	if isSrcFile {
 
 		var done bool
-		var fs = fsPrefix
+		// NOTE: the inner fs and err renamed (innerFs / e) to
+		// silence govet shadow against the outer fs and err
+		// declared at the top of copyId. Behavior is preserved:
+		// the outer err is still the one returned at the bottom
+		// of the function, and remains nil unless the else branch
+		// below (or t.checkJobStats below) assigns to it.
+		innerFs := fsPrefix
 		var args = []string{
 			driveId,
 			dstFsPrefix,
 		}
-		jobCopyAsyncJob, err := cmd.GetOperation().CopyIdAsync(fs, args)
-		if err != nil {
-			return err
+		jobCopyAsyncJob, e := cmd.GetOperation().CopyIdAsync(innerFs, args)
+		if e != nil {
+			return e
 		}
 		var jobId = *jobCopyAsyncJob.JobId
 		done, err = t.checkJobStats(jobId, dst.Path)

--- a/pkg/tasks/task_paste_download.go
+++ b/pkg/tasks/task_paste_download.go
@@ -94,9 +94,9 @@ func (t *Task) DownloadFromFiles() error {
 		result = append(result, fi)
 	}
 
-	if err := scanner.Err(); err != nil {
-		klog.Errorf("[Task] Id: %s, scan resp body error: %v", t.id, err)
-		return err
+	if e := scanner.Err(); e != nil {
+		klog.Errorf("[Task] Id: %s, scan resp body error: %v", t.id, e)
+		return e
 	}
 
 	if len(result) == 0 {
@@ -126,10 +126,10 @@ func (t *Task) DownloadFromFiles() error {
 	dstPath := dstUri + dstPathPrefix
 
 	if !t.pausedSnap().WasPaused {
-		dupNames, err := files.CollectDupNames(dstPath, srcFilePrefix, srcFileExt, isSrcFile)
-		if err != nil {
-			klog.Errorf("[Task] Id: %s, get dup name error: %v", t.id, err)
-			return err
+		dupNames, e := files.CollectDupNames(dstPath, srcFilePrefix, srcFileExt, isSrcFile)
+		if e != nil {
+			klog.Errorf("[Task] Id: %s, get dup name error: %v", t.id, e)
+			return e
 		}
 
 		klog.Infof("[Task] Id: %s, srcName: %s, dstPath: %s, isfile: %v, dupName: %v", t.id, srcFileName, dstPath, isSrcFile, dupNames)

--- a/pkg/tasks/task_paste_posix.go
+++ b/pkg/tasks/task_paste_posix.go
@@ -67,9 +67,9 @@ func (t *Task) Rsync() error {
 	klog.Infof("[Task] Id: %s, dstFree: %d", t.id, dstFree)
 
 	if !t.pausedSnap().WasPaused {
-		generatedDstNewName, generatedDstNewPath, err := t.generateNewName(pathMeta)
-		if err != nil {
-			return fmt.Errorf("generate dst name error: %v", err)
+		generatedDstNewName, generatedDstNewPath, e := t.generateNewName(pathMeta)
+		if e != nil {
+			return fmt.Errorf("generate dst name error: %v", e)
 		}
 
 		if generatedDstNewName != "" {

--- a/pkg/tasks/task_paste_sync.go
+++ b/pkg/tasks/task_paste_sync.go
@@ -738,10 +738,10 @@ func (t *Task) UploadDirToSync(src, dst *models.FileParam, root bool) error {
 	}
 
 	if created {
-		res, err := seahub.HandleDirOperation(src.Owner, dst.Extend, fdstBase, "", "mkdir", true)
-		if err != nil {
-			klog.Errorf("Sync create error: %v, path: %s", err, dst.Path)
-			return err
+		res, e := seahub.HandleDirOperation(src.Owner, dst.Extend, fdstBase, "", "mkdir", true)
+		if e != nil {
+			klog.Errorf("Sync create error: %v, path: %s", e, dst.Path)
+			return e
 		}
 		klog.Infof("Sync create success, result: %s, path: %s", string(res), dst.Path)
 
@@ -855,9 +855,9 @@ func (t *Task) UploadFileToSync(src, dst *models.FileParam) error {
 
 	wasPaused := t.pausedSnap().WasPaused
 	if isUploadFile && !wasPaused {
-		newDstPath, err := t.manager.GetSyncDupName(t.id, src, dst, t.param.Src, t.param.Dst)
-		if err != nil {
-			return err
+		newDstPath, e := t.manager.GetSyncDupName(t.id, src, dst, t.param.Src, t.param.Dst)
+		if e != nil {
+			return e
 		}
 		dst.Path = newDstPath
 
@@ -887,9 +887,9 @@ func (t *Task) UploadFileToSync(src, dst *models.FileParam) error {
 	if diskSize == 0 {
 		parentDir := "/" + strings.TrimSuffix(prefix, "/")
 		username := dst.Owner + "@auth.local"
-		if _, err := seaserv.GlobalSeafileAPI.PostEmptyFile(dst.Extend, parentDir, filename, username); err != nil {
-			klog.Errorf("[Task] Id: %s, post empty file %s failed: %v", t.id, dst.Path, err)
-			return err
+		if _, e := seaserv.GlobalSeafileAPI.PostEmptyFile(dst.Extend, parentDir, filename, username); e != nil {
+			klog.Errorf("[Task] Id: %s, post empty file %s failed: %v", t.id, dst.Path, e)
+			return e
 		}
 		t.updateProgress(left, 0)
 		t.updateProgress(right, 0)
@@ -1325,9 +1325,9 @@ func AddVersionSuffix(source string, fileParam *models.FileParam, isDir bool, up
 	for {
 		if fileParam.FileType == "sync" {
 			if isDir {
-				dirInfoRes, err := seahub.HandleGetRepoDir(fileParam)
-				if err != nil {
-					klog.Error(err)
+				dirInfoRes, e := seahub.HandleGetRepoDir(fileParam)
+				if e != nil {
+					klog.Error(e)
 					break
 				}
 				if dirInfoRes == nil {


### PR DESCRIPTION
11 处 inner err / fs shadow，仅做 err→e / fs→innerFs 重命名，行为保留。

Made with [Cursor](https://cursor.com)