### PR TITLE
chore(lint): batch 9 — pkg/drivers/clouds shadow 重命名 (11)

### DIFF
--- a/pkg/drivers/clouds/cloud.go
+++ b/pkg/drivers/clouds/cloud.go
@@ -89,8 +89,8 @@ func (s *CloudStorage) Preview(contextArgs *models.HttpContextArgs) (*models.Pre
 	}
 
 	var fileMeta *operations.OperationsStat
-	if err := json.Unmarshal(res, &fileMeta); err != nil {
-		return nil, err
+	if e := json.Unmarshal(res, &fileMeta); e != nil {
+		return nil, e
 	}
 
 	klog.Infof("Cloud preview, file meta: %s", string(res))
@@ -111,9 +111,9 @@ func (s *CloudStorage) Preview(contextArgs *models.HttpContextArgs) (*models.Pre
 		klog.Infof("Cloud preview, get cache, file: %s, cache name: %s, exists: %v", fileMeta.Item.Path, previewCacheName, ok)
 
 		var mods = fileMeta.Item.ModTime
-		modeTime, err := time.Parse(time.RFC3339Nano, mods)
-		if err != nil {
-			return nil, err
+		modeTime, e := time.Parse(time.RFC3339Nano, mods)
+		if e != nil {
+			return nil, e
 		}
 
 		if cachedData != nil {
@@ -128,15 +128,15 @@ func (s *CloudStorage) Preview(contextArgs *models.HttpContextArgs) (*models.Pre
 	previewCachedPath := diskcache.GenerateCacheBufferPath(owner, fileMeta.Item.Path)
 
 	if !files.FilePathExists(previewCachedPath) {
-		if err := files.MkdirAllWithChown(nil, previewCachedPath, 0755, true, 1000, 1000); err != nil {
-			klog.Errorln(err)
-			return nil, err
+		if e := files.MkdirAllWithChown(nil, previewCachedPath, 0755, true, 1000, 1000); e != nil {
+			klog.Errorln(e)
+			return nil, e
 		}
 	}
 
 	var downloader = NewDownloader(s.handler.Ctx, s.service, fileParam, fileMeta.Item.Name, fileMeta.Item.Path, fileMeta.Item.Size, previewCachedPath)
-	if err := downloader.download(); err != nil {
-		return nil, err
+	if e := downloader.download(); e != nil {
+		return nil, e
 	}
 
 	var imageFilePath = filepath.Join(previewCachedPath, fileMeta.Item.Name)
@@ -484,24 +484,24 @@ func (s *CloudStorage) Rename(contextArgs *models.HttpContextArgs) ([]byte, erro
 	}
 
 	if fileParam.IsGoogleDrive() && driveId == "" {
-		fsPrefix, err := s.service.command.GetFsPrefix(fileParam)
-		if err != nil {
-			return nil, err
+		fsPrefix, e := s.service.command.GetFsPrefix(fileParam)
+		if e != nil {
+			return nil, e
 		}
 		fsName, _ := files.GetFileNameFromPath(fileParam.Path)
 		fsNameTmp := common.EscapeGlob(fsName)
 		fsPathPrefix := files.GetPrefixPath(fileParam.Path)
 		var fs = fsPrefix + fsPathPrefix
 		var fileter = s.service.command.FormatFilter(fsNameTmp, false, true, true)
-		items, err := s.service.command.GetOperation().List(fs, &operations.OperationsOpt{
+		items, e := s.service.command.GetOperation().List(fs, &operations.OperationsOpt{
 			NoModTime:  true,
 			NoMimeType: true,
 			Metadata:   false,
 		}, &operations.OperationsFilter{
 			FilterRule: fileter,
 		})
-		if err != nil {
-			return nil, err
+		if e != nil {
+			return nil, e
 		}
 
 		var count int
@@ -716,9 +716,9 @@ func (s *CloudStorage) UploadChunks(fileUploadArg *models.FileUploadArgs) ([]byt
 	}
 
 	if fileInfo == nil {
-		uri, err := param.GetResourceUri()
-		if err != nil {
-			return nil, err
+		uri, e := param.GetResourceUri()
+		if e != nil {
+			return nil, e
 		}
 
 		uploadPath := uri + param.Path

--- a/pkg/drivers/clouds/rclone/rclone.go
+++ b/pkg/drivers/clouds/rclone/rclone.go
@@ -265,9 +265,9 @@ func (r *rclone) GetFilesSize(fileParam *models.FileParam) (int64, error) {
 
 	if !isFile {
 		var fs string = fsPrefix + fileParam.Path
-		resp, err := r.GetOperation().Size(fs)
-		if err != nil {
-			return 0, err
+		resp, e := r.GetOperation().Size(fs)
+		if e != nil {
+			return 0, e
 		}
 		return resp.Bytes, nil
 	}
@@ -560,9 +560,9 @@ func (r *rclone) Clear(param *models.FileParam) error {
 
 	var fsPrefix string
 	if isSrcLocal {
-		srcUri, err := param.GetResourceUri()
-		if err != nil {
-			return err
+		srcUri, e := param.GetResourceUri()
+		if e != nil {
+			return e
 		}
 		fsPrefix = fmt.Sprintf("%s:%s", configName, srcUri)
 	} else {

--- a/pkg/drivers/clouds/rclone/utils/utils.go
+++ b/pkg/drivers/clouds/rclone/utils/utils.go
@@ -35,7 +35,13 @@ func Request(ctx context.Context, u string, method string, header *http.Header, 
 	var result []byte
 	var err error
 
-	if err := retry.OnError(backoff, func(err error) bool {
+	// Use = (not :=) so we don't shadow the function-scope err.
+	// Note the inner closures (lines below) write to the same
+	// captured outer err, so this matters for behavior too: the
+	// retry-loop's last NewRequestWithContext / Do / ReadAll
+	// error is preserved on the outer err for callers that may
+	// want to inspect it via debugger / future logging.
+	if err = retry.OnError(backoff, func(err error) bool {
 		return true
 	}, func() error {
 		var newRequest *http.Request
@@ -64,10 +70,10 @@ func Request(ctx context.Context, u string, method string, header *http.Header, 
 		// newRequest.Header.Add("Content-Type", "application/octet-stream")
 
 		start := time.Now()
-		resp, err := rcloneHTTPClient.Do(newRequest)
-		if err != nil {
-			klog.Errorf("[request] do error: %v", err)
-			return err
+		resp, e := rcloneHTTPClient.Do(newRequest)
+		if e != nil {
+			klog.Errorf("[request] do error: %v", e)
+			return e
 		}
 		defer resp.Body.Close()
 		if strings.Contains(u, "operations/") || strings.Contains(u, "sync/") {

--- a/pkg/drivers/clouds/service.go
+++ b/pkg/drivers/clouds/service.go
@@ -100,8 +100,8 @@ func (s *service) CreateFolder(param *models.FileParam) ([]byte, error) {
 
 	if param.FileType == common.AwsS3 || param.FileType == common.TencentCos {
 		var keepFilePath = common.DefaultLocalRootPath + common.DefaultKeepFileName
-		if err := files.CheckKeepFile(keepFilePath); err != nil {
-			return nil, err
+		if e := files.CheckKeepFile(keepFilePath); e != nil {
+			return nil, e
 		}
 
 		var srcFs = fmt.Sprintf("local:%s", common.DefaultLocalRootPath)
@@ -109,10 +109,10 @@ func (s *service) CreateFolder(param *models.FileParam) ([]byte, error) {
 		var dstFs = fsPrefix + prefixPath
 		var dstR = fileName + "/"
 
-		err := s.command.GetOperation().Copyfile(srcFs, srcR, dstFs, dstR)
-		if err != nil {
-			klog.Errorf("[service] createfolder, type: %s, dstFs: %s, dstR: %s, error: %v", param.FileType, dstFs, dstR, err)
-			return nil, err
+		e := s.command.GetOperation().Copyfile(srcFs, srcR, dstFs, dstR)
+		if e != nil {
+			klog.Errorf("[service] createfolder, type: %s, dstFs: %s, dstR: %s, error: %v", param.FileType, dstFs, dstR, e)
+			return nil, e
 		}
 
 		klog.Infof("[service] createfolder done!")


### PR DESCRIPTION
11 处 inner err shadow，rename 到 e；utils/utils.go 把 := 改成 = 保留外层 err。行为不变。

Made with [Cursor](https://cursor.com)