### PR TITLE
chore(lint): batch 16 — pkg/hertz + drivers + others errcheck (~14)

### DIFF
--- a/pkg/drivers/clouds/cloud.go
+++ b/pkg/drivers/clouds/cloud.go
@@ -750,7 +750,9 @@ func (s *CloudStorage) UploadChunks(fileUploadArg *models.FileUploadArgs) ([]byt
 		uploadTempPath = uploadTempPath + "/"
 	}
 	var srcParam = &models.FileParam{}
-	srcParam.GetFileParam(uploadTempPath)
+	if err := srcParam.GetFileParam(uploadTempPath); err != nil {
+		klog.Warningf("[cloud] UploadFileToCloud: parse temp upload path %q failed: %v", uploadTempPath, err)
+	}
 	srcParam.Path = srcParam.Path + fileInfo.Id
 
 	var dstParam = fileUploadArg.FileParam

--- a/pkg/drivers/clouds/service.go
+++ b/pkg/drivers/clouds/service.go
@@ -87,7 +87,10 @@ func (s *service) CreateFile(fileParam *models.FileParam, dstR string, body io.R
 	var srcR = filepath.Base(createCacheFilePath)
 	var dstFs = filepath.Join(fsPrefix, filepath.Dir(fileParam.Path)) + "/"
 
-	s.command.GetOperation().Copyfile(srcFs, srcR, dstFs, dstR)
+	if err := s.command.GetOperation().Copyfile(srcFs, srcR, dstFs, dstR); err != nil {
+		klog.Errorf("[service] copyfile failed, srcFs=%s srcR=%s dstFs=%s dstR=%s: %v", srcFs, srcR, dstFs, dstR, err)
+		return nil, err
+	}
 	return nil, nil
 }
 

--- a/pkg/drivers/sync/seahub/share.go
+++ b/pkg/drivers/sync/seahub/share.go
@@ -198,9 +198,13 @@ func UpdateUserDirPermission(repoID, path, owner, shareTo, permission string) {
 	}
 
 	if path == "/" {
-		seaserv.GlobalSeafileAPI.SetSharePermission(repoID, owner, shareTo, permission)
+		if _, err := seaserv.GlobalSeafileAPI.SetSharePermission(repoID, owner, shareTo, permission); err != nil {
+			klog.Warningf("UpdateUserDirPermission SetSharePermission failed repo=%s shareTo=%s perm=%s: %v", repoID, shareTo, permission, err)
+		}
 	} else {
-		seaserv.GlobalSeafileAPI.UpdateShareSubdirPermForUser(repoID, path, owner, shareTo, permission)
+		if _, err := seaserv.GlobalSeafileAPI.UpdateShareSubdirPermForUser(repoID, path, owner, shareTo, permission); err != nil {
+			klog.Warningf("UpdateUserDirPermission UpdateShareSubdirPermForUser failed repo=%s path=%s shareTo=%s perm=%s: %v", repoID, path, shareTo, permission, err)
+		}
 	}
 }
 

--- a/pkg/drivers/sync/seahub/upload.go
+++ b/pkg/drivers/sync/seahub/upload.go
@@ -60,7 +60,9 @@ func ClearAccessTokens() {
 
 func GenerateUniqueIdentifier(relativePath string) string {
 	h := md5.New()
-	io.WriteString(h, relativePath+time.Now().String())
+	// hash.Hash.Write never returns an error, so io.WriteString
+	// here cannot fail in practice.
+	_, _ = io.WriteString(h, relativePath+time.Now().String())
 	return fmt.Sprintf("%x%s", h.Sum(nil), relativePath)
 }
 

--- a/pkg/hertz/biz/router/middleware.go
+++ b/pkg/hertz/biz/router/middleware.go
@@ -445,7 +445,10 @@ func ShareMiddleware() app.HandlerFunc {
 		} else {
 			bodyRes, _ := io.ReadAll(resp.Body)
 			resp.Body.Close()
-			c.Write(bodyRes)
+			// c.Write writes to the Hertz response buffer; failures
+			// here are unactionable (we can't alter the response any
+			// more), drop explicitly to satisfy errcheck.
+			_, _ = c.Write(bodyRes)
 		}
 		c.Abort()
 	}
@@ -771,7 +774,8 @@ func proxySharePaste(ctx context.Context, c *app.RequestContext, owner string, a
 	}
 	c.Status(resp.StatusCode)
 	bodyRes, _ := io.ReadAll(resp.Body)
-	c.Write(bodyRes)
+	// see notes above: Hertz response buffer; can't surface err.
+	_, _ = c.Write(bodyRes)
 	c.Abort()
 }
 
@@ -838,7 +842,12 @@ func ShareUpload() app.HandlerFunc {
 			handler.RespBadRequest(ctx, err.Error())
 			return
 		}
-		defer mf.RemoveAll()
+		// Best-effort cleanup of multipart temp files.
+		defer func() {
+			if err := mf.RemoveAll(); err != nil {
+				klog.Warningf("multipart RemoveAll failed: %v", err)
+			}
+		}()
 
 		var hasPathname, hasRepoId, hasDriveType bool
 		var hasShareBy bool

--- a/pkg/integration/integration.go
+++ b/pkg/integration/integration.go
@@ -105,7 +105,9 @@ func (i *integration) watch() {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				i.GetIntegrations()
+				if err := i.GetIntegrations(); err != nil {
+					klog.Warningf("[integration] tick refresh failed: %v", err)
+				}
 			}
 		}
 	}()
@@ -316,7 +318,9 @@ func (i *integration) GetIntegrations() error {
 
 	// klog.Infof("integration new configs: %d", len(configs))
 
-	rclone.Command.StartHttp(configs)
+	if err := rclone.Command.StartHttp(configs); err != nil {
+		klog.Warningf("[integration] StartHttp failed (rclone may not be ready yet): %v", err)
+	}
 
 	return nil
 }

--- a/pkg/preview/preview.go
+++ b/pkg/preview/preview.go
@@ -8,6 +8,7 @@ import (
 	"files/pkg/files"
 	"files/pkg/img"
 	"files/pkg/models"
+	"fmt"
 	"io"
 
 	"k8s.io/klog/v2"
@@ -76,7 +77,10 @@ func CreatePreview(owner string, key string,
 		return nil, err
 	}
 
-	fd.Seek(0, 0)
+	if _, err := fd.Seek(0, 0); err != nil {
+		fd.Close()
+		return nil, fmt.Errorf("seek preview source failed: %w", err)
+	}
 	defer fd.Close()
 
 	var (


### PR DESCRIPTION
覆盖 pkg/hertz, pkg/drivers/{clouds,sync}, pkg/preview, pkg/integration。其中 4 处是真 bug（fd.Seek、Copyfile、GetFileParam、StartHttp）。

Made with [Cursor](https://cursor.com)