### PR TITLE
chore(lint): batch 17 — pkg/media errcheck (~19)

### DIFF
--- a/pkg/media/api/controllers/dynamic_hls_controller.go
+++ b/pkg/media/api/controllers/dynamic_hls_controller.go
@@ -1368,7 +1368,8 @@ func (d *DynamicHlsController) GetVariantHlsVideoPlaylist(ctx context.Context, c
 	klog.Infof("[media] GetVariantHlsVideoPlaylist playlist: %s", playlist)
 
 	c.Response.Header.Set("Content-Type", "application/x-mpegURL")
-	c.Write([]byte(playlist))
+	// Hertz response buffer; err can't surface this late.
+	_, _ = c.Write([]byte(playlist))
 }
 
 func (d *DynamicHlsController) GetVariantPlaylistInternal(c *app.RequestContext, ctx context.Context, request interface{}) (string, error) {

--- a/pkg/media/api/controllers/media_info_controller.go
+++ b/pkg/media/api/controllers/media_info_controller.go
@@ -145,7 +145,10 @@ func (m *MediaInfoController) GetPostedPlaybackInfo(w http.ResponseWriter, r *ht
 
 	if info.ErrorCode != nil {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(info)
+		// json.Encoder.Encode err is unactionable here (we already
+		// set the Content-Type header and there's no graceful
+		// error response we can write). Discard explicitly.
+		_ = json.NewEncoder(w).Encode(info)
 		return
 	}
 
@@ -158,5 +161,6 @@ func (m *MediaInfoController) GetPostedPlaybackInfo(w http.ResponseWriter, r *ht
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(info)
+	// see comment on the ErrorCode branch above.
+	_ = json.NewEncoder(w).Encode(info)
 }

--- a/pkg/media/emby/server/implementations/appbase/base_configuration_manager.go
+++ b/pkg/media/emby/server/implementations/appbase/base_configuration_manager.go
@@ -157,7 +157,9 @@ func (cm *BaseConfigurationManager) UpdateCachePath() {
 	//      to resolve
 	//	cm.commonApplicationPaths.(*BaseApplicationPaths).SetCachePath(cachePath)
 	//	cm.commonApplicationPaths.SetCachePath(cachePath)
-	cm.commonApplicationPaths.CreateAndCheckMarker(cachePath, "cache", false)
+	if err := cm.commonApplicationPaths.CreateAndCheckMarker(cachePath, "cache", false); err != nil {
+		cm.logger.Error("create cache marker failed at %s: %v", cachePath, err)
+	}
 }
 
 // ValidateCachePath validates the cache path

--- a/pkg/media/emby/server/implementations/configuration/server_configuration_manager.go
+++ b/pkg/media/emby/server/implementations/configuration/server_configuration_manager.go
@@ -45,7 +45,10 @@ func NewServerConfigurationManager(
 	scm := &ServerConfigurationManager{
 		BaseConfigurationManager: appbase.NewBaseConfigurationManager(applicationPaths, loggerFactory, serializer, reflect.TypeOf(configuration.ServerConfiguration{})),
 	}
-	scm.UpdateMetadataPath()
+	// UpdateMetadataPath is currently a TODO scaffold returning nil;
+	// silence errcheck explicitly so a future implementation that
+	// returns real errors is forced to revisit this site.
+	_ = scm.UpdateMetadataPath()
 	return scm
 }
 
@@ -74,7 +77,8 @@ func (scm *ServerConfigurationManager) Configuration() *configuration.ServerConf
 
 // OnConfigurationUpdated is called when configuration is updated
 func (scm *ServerConfigurationManager) OnConfigurationUpdated() {
-	scm.UpdateMetadataPath()
+	// see ctor: TODO scaffold.
+	_ = scm.UpdateMetadataPath()
 	scm.BaseConfigurationManager.OnConfigurationUpdated()
 }
 

--- a/pkg/media/mediabrowser/controller/mediaencoding/transcoding_job.go
+++ b/pkg/media/mediabrowser/controller/mediaencoding/transcoding_job.go
@@ -113,7 +113,9 @@ func (t *TranscodingJob) Stop() {
 	defer t.processLock.Unlock()
 
 	if t.TranscodingThrottler != nil {
-		t.TranscodingThrottler.Stop()
+		// Best-effort shutdown; throttler stop errors are not
+		// actionable from this side.
+		_ = t.TranscodingThrottler.Stop()
 	}
 
 	if t.TranscodingSegmentCleaner != nil {
@@ -136,13 +138,16 @@ func (t *TranscodingJob) Stop() {
 		_, err := t.Stdin.Write([]byte("q"))
 		if err != nil {
 			t.Logger.Errorf("Error writing to ffmpeg stdin: %v", err)
-			process.Kill()
+			// Force-kill on stdin write failure; if Kill itself
+			// fails the process is already gone or unkillable
+			// (errcheck unactionable).
+			_ = process.Kill()
 		}
 
 		// Need to wait because killing is asynchronous.
 		if err := process.WaitForExit(5 * time.Second); err != nil {
 			t.Logger.Information("Killing FFmpeg process for %s %v", *t.Path, err)
-			process.Kill()
+			_ = process.Kill()
 		}
 	}
 }

--- a/pkg/media/mediabrowser/controller/mediaencoding/transcoding_segment_cleaner.go
+++ b/pkg/media/mediabrowser/controller/mediaencoding/transcoding_segment_cleaner.go
@@ -103,7 +103,9 @@ func (t *TranscodingSegmentCleaner) timerCallback(state interface{}) {
 				idxMaxToDelete := (downloadPositionSeconds - segmentKeepSeconds) / int64(t.segmentLength)
 
 				if idxMaxToDelete > 0 {
-					t.DeleteSegmentFiles(t.job, 0, idxMaxToDelete, 1500)
+					// Best-effort cleanup; partial-delete errors
+					// are surfaced via klog inside the helper.
+					_ = t.DeleteSegmentFiles(t.job, 0, idxMaxToDelete, 1500)
 				}
 			}
 		}

--- a/pkg/media/mediabrowser/mediaencoding/encoder/encoder_validator.go
+++ b/pkg/media/mediabrowser/mediaencoding/encoder/encoder_validator.go
@@ -224,14 +224,14 @@ type Logger interface {
 func (ev *EncoderValidator) ValidateVersion() bool {
 	output, err := ev.getProcessOutput(ev.encoderPath, "-version", false, "")
 	if err != nil {
-		//ev.logger.LogError(err, "Error validating encoder")
-		fmt.Errorf("Error validating encoder %v\n", err)
+		// Was a stray fmt.Errorf whose result was thrown away;
+		// route to the logger so the message actually surfaces.
+		ev.logger.Errorf("Error validating encoder: %v", err)
 		return false
 	}
 
 	if output == "" {
-		//ev.logger.LogError(errors.New("FFmpeg validation: The process returned no result"), "")
-		fmt.Errorf("FFmpeg validation: The process returned no result")
+		ev.logger.Errorf("FFmpeg validation: The process returned no result")
 		return false
 	}
 

--- a/pkg/media/mediabrowser/mediaencoding/encoder/media_encoder.go
+++ b/pkg/media/mediabrowser/mediaencoding/encoder/media_encoder.go
@@ -274,7 +274,9 @@ func (m *MediaEncoder) SetFFmpegPath() bool {
 	} else {
 		options.EncoderAppPathDisplay = ""
 	}
-	m.configurationManager.SaveConfigurationByKey("encoding", options)
+	if err := m.configurationManager.SaveConfigurationByKey("encoding", options); err != nil {
+		klog.Warningf("media encoder: SaveConfigurationByKey(encoding) failed: %v", err)
+	}
 
 	// Only if mpeg path is set, try and set path to probe
 	if m.ffmpegPath != nil {
@@ -635,7 +637,7 @@ func (m *MediaEncoder) GetMediaInfoInternal(
 
 	var memoryBuffer bytes.Buffer
 	if _, err := io.Copy(&memoryBuffer, stdout); err != nil {
-		cmd.Process.Kill()
+		_ = cmd.Process.Kill()
 		klog.Infoln("Copy Errrrrrrrrrrrrr")
 		klog.Infoln(err)
 		return nil, err

--- a/pkg/media/mediabrowser/mediaencoding/probing/probe_result_normalizer.go
+++ b/pkg/media/mediabrowser/mediaencoding/probing/probe_result_normalizer.go
@@ -420,12 +420,16 @@ func (p *ProbeResultNormalizer) fetchFromItunesInfo(xmlData string, info *mediai
 			case "dict":
 				//				if decoder.IsEmpty() {
 				if se.Name.Space == "" && len(se.Attr) == 0 {
-					decoder.Skip()
+					// Best-effort skip; the loop below continues
+					// to advance the decoder so a Skip error here
+					// just means we'll process odd tokens next
+					// iteration.
+					_ = decoder.Skip()
 					continue
 				}
 				p.readFromDictNode(decoder, info)
 			default:
-				decoder.Skip()
+				_ = decoder.Skip()
 			}
 		default:
 			// ignore other token types

--- a/pkg/media/mediabrowser/mediaencoding/transcoding/transcode_manager.go
+++ b/pkg/media/mediabrowser/mediaencoding/transcoding/transcode_manager.go
@@ -155,7 +155,9 @@ func (m *TranscodeManager) onTranscodeKillTimerStopped(state interface{}) {
 	}
 
 	m.logger.Infof("Transcoding kill timer stopped for JobId %d PlaySessionId %d. Killing transcoding", job.ID, job.PlaySessionID)
-	m.killTranscodingJob(job, true, func(path string) bool { return true })
+	if err := m.killTranscodingJob(job, true, func(path string) bool { return true }); err != nil {
+		m.logger.Errorf("Transcoding kill timer cleanup failed for JobId %d: %v", job.ID, err)
+	}
 }
 
 func (m *TranscodeManager) KillTranscodingJobs(deviceID, playSessionID string, deleteFiles func(string) bool) error {
@@ -577,7 +579,10 @@ func (m *TranscodeManager) DeletePartialStreamFiles(path string, jobType mediaen
 
 	if err != nil {
 		m.logger.Errorf("Error deleting partial stream file(s) %s: %v", path, err)
-		m.DeletePartialStreamFiles(path, jobType, retryCount+1, 500)
+		// Recursive retry; the result is intentionally discarded
+		// (the caller already saw the original error and we just
+		// surface a single delete attempt's worth of logging).
+		_ = m.DeletePartialStreamFiles(path, jobType, retryCount+1, 500)
 	}
 
 	return nil

--- a/pkg/media/service/service.go
+++ b/pkg/media/service/service.go
@@ -39,7 +39,10 @@ var fileSystem *iio.ManagedFileSystem
 
 func Init() {
 
-	CreateApplicationPaths()
+	if err := CreateApplicationPaths(); err != nil {
+		klog.Errorf("media service Init: CreateApplicationPaths failed: %v", err)
+		// fall through; downstream code logs subsequent failures.
+	}
 
 	logger = utils.NewLogger("media-server ", log.LstdFlags)
 	sessionManager := session.NewSessionManager()


### PR DESCRIPTION
嵌入式 Emby/Jellyfin 端口的 errcheck 收尾。其中 encoder_validator.go 的 fmt.Errorf 是真 bug（消息被丢失），改成走 logger.Errorf。

Made with [Cursor](https://cursor.com)