### PR TITLE
chore(lint): 收尾 — 6 shadow + 2 vet printf + 收紧 govet 配置

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -61,6 +61,10 @@ linters-settings:
     enable:
       - copylocks
       - shadow
+      - printf      # catches `klog.Warningf(userInput)` style bugs
+      - nilfunc     # catches `if obj.SomeMethod != nil` (always true)
+      - composites  # catches unkeyed struct literals like Version{1,2,3}
+      - structtag   # catches malformed struct tags
 
 issues:
   max-issues-per-linter: 0

--- a/cmd/backend/app/root.go
+++ b/cmd/backend/app/root.go
@@ -167,8 +167,8 @@ user created with the credentials from options "username" and "password".`,
 		// Best-effort cleanup of any leftover rclone jobs from a
 		// previous process; if rclone hasn't fully started or is
 		// unreachable we'd rather warn and continue than fail boot.
-		if err := rclone.Command.StopJobs(); err != nil {
-			klog.Warningf("rclone StopJobs at boot failed: %v", err)
+		if e := rclone.Command.StopJobs(); e != nil {
+			klog.Warningf("rclone StopJobs at boot failed: %v", e)
 		}
 
 		// step5: build driver handler

--- a/pkg/drivers/clouds/cloud.go
+++ b/pkg/drivers/clouds/cloud.go
@@ -750,8 +750,8 @@ func (s *CloudStorage) UploadChunks(fileUploadArg *models.FileUploadArgs) ([]byt
 		uploadTempPath = uploadTempPath + "/"
 	}
 	var srcParam = &models.FileParam{}
-	if err := srcParam.GetFileParam(uploadTempPath); err != nil {
-		klog.Warningf("[cloud] UploadFileToCloud: parse temp upload path %q failed: %v", uploadTempPath, err)
+	if e := srcParam.GetFileParam(uploadTempPath); e != nil {
+		klog.Warningf("[cloud] UploadFileToCloud: parse temp upload path %q failed: %v", uploadTempPath, e)
 	}
 	srcParam.Path = srcParam.Path + fileInfo.Id
 

--- a/pkg/hertz/biz/handler/api/external/external_service.go
+++ b/pkg/hertz/biz/handler/api/external/external_service.go
@@ -145,7 +145,10 @@ func MountMethod(ctx context.Context, c *app.RequestContext) {
 	}
 
 	if int(res["code"].(float64)) != consts.StatusOK {
-		klog.Warningf(res["message"].(string))
+		// res["message"] is a runtime string from terminusd; using
+		// it as the format string would interpret stray %-directives
+		// and trigger `go vet` printf failures.
+		klog.Warningf("%s", res["message"].(string))
 		if strings.Contains(res["message"].(string), "mount error(13)") {
 			res["message"] = "Incorrect username or password"
 		}

--- a/pkg/hertz/biz/handler/upload/upload_service.go
+++ b/pkg/hertz/biz/handler/upload/upload_service.go
@@ -398,7 +398,9 @@ func SyncUploadChunksMethod(ctx context.Context, c *app.RequestContext) {
 			seahub.DeleteAccessToken(originalUid)
 			klog.Errorf("Sync uploadChunks, redirect error: %v", err)
 			if err == nil {
-				err = fmt.Errorf(errMsg.Error)
+				// errMsg.Error is a runtime string; passing it as
+				// a format would interpret stray %-directives.
+				err = fmt.Errorf("%s", errMsg.Error)
 			}
 			c.String(http.StatusBadRequest, searpc.SyncConnectionFailedError(err).Error())
 			return

--- a/pkg/hertz/biz/router/middleware.go
+++ b/pkg/hertz/biz/router/middleware.go
@@ -840,8 +840,8 @@ func ShareUpload() app.HandlerFunc {
 		}
 		// Best-effort cleanup of multipart temp files.
 		defer func() {
-			if err := mf.RemoveAll(); err != nil {
-				klog.Warningf("multipart RemoveAll failed: %v", err)
+			if e := mf.RemoveAll(); e != nil {
+				klog.Warningf("multipart RemoveAll failed: %v", e)
 			}
 		}()
 

--- a/pkg/preview/preview.go
+++ b/pkg/preview/preview.go
@@ -77,9 +77,9 @@ func CreatePreview(owner string, key string,
 		return nil, err
 	}
 
-	if _, err := fd.Seek(0, 0); err != nil {
+	if _, e := fd.Seek(0, 0); e != nil {
 		fd.Close()
-		return nil, fmt.Errorf("seek preview source failed: %w", err)
+		return nil, fmt.Errorf("seek preview source failed: %w", e)
 	}
 	defer fd.Close()
 

--- a/pkg/samba/samba.go
+++ b/pkg/samba/samba.go
@@ -309,8 +309,8 @@ func (s *samba) generateConf() {
 		klog.Infof("samba shares not found")
 	}
 
-	if err := s.deleteExcludeUsers(smbUsers, smbShares); err != nil {
-		klog.Warningf("samba delete excluded users failed: %v", err)
+	if e := s.deleteExcludeUsers(smbUsers, smbShares); e != nil {
+		klog.Warningf("samba delete excluded users failed: %v", e)
 	}
 
 	for id, p := range smbShares {
@@ -392,8 +392,8 @@ func (s *samba) generateConf() {
 		} else {
 			// anonymous
 			anonymous = true
-			if err := s.commands.SetAnonymousPermission(item.Owner, fileUri+fp.Path); err != nil {
-				klog.Warningf("samba set anonymous permission failed: owner=%s path=%s: %v", item.Owner, fileUri+fp.Path, err)
+			if e := s.commands.SetAnonymousPermission(item.Owner, fileUri+fp.Path); e != nil {
+				klog.Warningf("samba set anonymous permission failed: owner=%s path=%s: %v", item.Owner, fileUri+fp.Path, e)
 			}
 		}
 


### PR DESCRIPTION
走完 18 个 batch 之后剩下的 6 个 shadow 回归和 2 个 vet printf bug（导致 go test 构建失败）。同时把 govet 的 printf/nilfunc/composites/structtag 都启用，防止以后再回归。修完 lint 报告 0 条。

Made with [Cursor](https://cursor.com)