### PR TITLE
Async upload finalize for large files to avoid proxy timeouts

### DIFF
--- a/pkg/common/constant.go
+++ b/pkg/common/constant.go
@@ -74,9 +74,12 @@ const (
 	Paused    = "paused"
 	Resumed   = "resumed"
 
-	ActionCopy   = "copy"
-	ActionMove   = "move"
-	ActionUpload = "upload"
+	ActionCopy            = "copy"
+	ActionMove            = "move"
+	ActionUpload          = "upload"
+	ActionUploadFinalize  = "upload_finalize"
+
+	AsyncFinalizeThreshold int64 = 2 * 1024 * 1024 * 1024 // 2GB
 )
 
 var (

--- a/pkg/drivers/posix/posix/posix.go
+++ b/pkg/drivers/posix/posix/posix.go
@@ -11,6 +11,7 @@ import (
 	"files/pkg/global"
 	"files/pkg/models"
 	"files/pkg/preview"
+	"files/pkg/tasks"
 	"fmt"
 	"net/url"
 	"os"
@@ -678,6 +679,40 @@ func (s *PosixStorage) UploadChunks(fileUploadArg *models.FileUploadArgs) ([]byt
 
 	if fileInfo == nil {
 		return common.ToBytes(&upload.FileUploadSucced{Success: true}), nil
+	}
+
+	// Large file: run MoveFileByInfo asynchronously via a task so the
+	// HTTP response is sent before the platform proxy timeout fires.
+	if fileInfo.FileInfo != nil && fileInfo.FileInfo.FileSize >= common.AsyncFinalizeThreshold {
+		taskFileParam := &models.FileParam{
+			Owner:    fileUploadArg.FileParam.Owner,
+			FileType: fileUploadArg.FileParam.FileType,
+			Extend:   fileUploadArg.FileParam.Extend,
+			Path:     fileUploadArg.FileParam.Path + chunkInfo.ResumableRelativePath,
+		}
+		taskDisplayParam := taskFileParam
+		if chunkInfo.Share != "" && chunkInfo.SharebyPath != "" {
+			if sp, err := models.CreateFileParam(user, chunkInfo.SharebyPath+chunkInfo.ResumableRelativePath); err == nil {
+				taskDisplayParam = sp
+			}
+		}
+		uploadParam := &models.PasteParam{
+			Owner:  user,
+			Action: common.ActionUploadFinalize,
+			Src:    taskDisplayParam,
+			Dst:    taskDisplayParam,
+		}
+		task := tasks.TaskManager.CreateTask(uploadParam)
+		task.SetTotalSize(fileInfo.FileInfo.FileSize)
+		task.ExecuteAsync(task.UploadFinalizePosix(&tasks.PosixFinalizeParams{
+			Info:            *fileInfo.FileInfo,
+			UploadTempPath:  fileInfo.UploadTempPath,
+			InnerIdentifier: fileInfo.Id,
+			FileParam:       fileUploadArg.FileParam,
+			ResumableInfo:   chunkInfo,
+		}))
+		fileInfo.TaskId = task.Id()
+		klog.Infof("Posix uploadChunks, large file, async finalize task: %s", fileInfo.TaskId)
 	}
 
 	klog.Infof("Posix uploadChunks, done! data: %s", common.ToJson(fileInfo))

--- a/pkg/drivers/posix/upload/handlefunc.go
+++ b/pkg/drivers/posix/upload/handlefunc.go
@@ -430,6 +430,16 @@ func HandleUploadChunks(fileParam *models.FileParam, uploadId string, resumableI
 			info.FullPath = uri + sharedParam.Path + resumableInfo.ResumableRelativePath
 		}
 
+		data.FileInfo = &info
+
+		// Large files: return without MoveFileByInfo so the caller can
+		// run it asynchronously in a task, avoiding platform-level
+		// proxy timeouts on the last-chunk HTTP response.
+		if info.FileSize >= common.AsyncFinalizeThreshold {
+			klog.Infof("[upload] uploadId: %s, large file (%d bytes), deferring finalize to async task", uploadId, info.FileSize)
+			return true, data, nil
+		}
+
 		klog.Infof("[upload] uploadId: %s, move by, src: %s, dst: %s", uploadId, uploadTempPath, info.FullPath)
 
 		if err = MoveFileByInfo(info, uploadTempPath); err != nil {

--- a/pkg/drivers/posix/upload/operations.go
+++ b/pkg/drivers/posix/upload/operations.go
@@ -248,7 +248,7 @@ func UpdateFileInfo(fileInfo FileInfo, uploadsDir string) error {
 }
 
 // dst, src
-func MoveFileByInfo(fileInfo FileInfo, uploadsDir string) error {
+func MoveFileByInfo(fileInfo FileInfo, uploadsDir string, onProgress ...files.ProgressFunc) error {
 	// Construct file path
 	filePath := filepath.Join(uploadsDir, fileInfo.ID)
 
@@ -256,7 +256,7 @@ func MoveFileByInfo(fileInfo FileInfo, uploadsDir string) error {
 	destinationPath := AddVersionSuffix(fileInfo.FullPath, nil, false)
 
 	// Move files to target path
-	err := files.MoveFileOs(filePath, destinationPath)
+	err := files.MoveFileOs(filePath, destinationPath, onProgress...)
 	if err != nil {
 		return err
 	}

--- a/pkg/files/fileutils.go
+++ b/pkg/files/fileutils.go
@@ -48,13 +48,13 @@ func MoveFile(fs afero.Fs, src, dst string) error {
 	return nil
 }
 
-func MoveFileOs(src, dst string) error {
+func MoveFileOs(src, dst string, onProgress ...ProgressFunc) error {
 	if os.Rename(src, dst) == nil {
 		return nil
 	}
 
 	// fallback
-	err := CopyFileOs(src, dst)
+	err := CopyFileOs(src, dst, onProgress...)
 	if err != nil {
 		_ = os.Remove(dst)
 		return err
@@ -65,7 +65,11 @@ func MoveFileOs(src, dst string) error {
 	return nil
 }
 
-func IoCopyFileWithBufferOs(sourcePath, targetPath string, bufferSize int) error {
+// ProgressFunc is called after each buffer write with the cumulative
+// number of bytes written so far. May be nil.
+type ProgressFunc func(written int64)
+
+func IoCopyFileWithBufferOs(sourcePath, targetPath string, bufferSize int, onProgress ...ProgressFunc) error {
 	klog.Infoln("***IoCopyFileWithBufferOs")
 	klog.Infoln("***sourcePath:", sourcePath)
 	klog.Infoln("***targetPath:", targetPath)
@@ -95,6 +99,12 @@ func IoCopyFileWithBufferOs(sourcePath, targetPath string, bufferSize int) error
 	}
 	defer targetFile.Close()
 
+	var progressFn ProgressFunc
+	if len(onProgress) > 0 {
+		progressFn = onProgress[0]
+	}
+
+	var totalWritten int64
 	buf := make([]byte, bufferSize)
 	for {
 		n, e := sourceFile.Read(buf)
@@ -106,6 +116,10 @@ func IoCopyFileWithBufferOs(sourcePath, targetPath string, bufferSize int) error
 		}
 		if _, e2 := targetFile.Write(buf[:n]); e2 != nil {
 			return e2
+		}
+		if progressFn != nil {
+			totalWritten += int64(n)
+			progressFn(totalWritten)
 		}
 	}
 
@@ -202,8 +216,8 @@ func CopyFile(fs afero.Fs, source, dest string) error {
 	return nil
 }
 
-func CopyFileOs(source, dest string) error {
-	err := IoCopyFileWithBufferOs(source, dest, 8*1024*1024)
+func CopyFileOs(source, dest string, onProgress ...ProgressFunc) error {
+	err := IoCopyFileWithBufferOs(source, dest, 8*1024*1024, onProgress...)
 	if err != nil {
 		return err
 	}
@@ -562,14 +576,23 @@ func UpdatePathName(oldPath string, newName string, isDir bool) string {
 }
 
 func GetPathName(p string) string {
+	if p == "" || p == "/" {
+		return ""
+	}
 	if strings.HasSuffix(p, "/") {
 		var tmp = strings.TrimSuffix(p, "/")
 		var pos = strings.LastIndex(tmp, "/")
+		if pos < 0 {
+			return tmp
+		}
 		tmp = p[pos:]
 		tmp = strings.Trim(tmp, "/")
 		return tmp
 	} else {
 		var pos = strings.LastIndex(p, "/")
+		if pos < 0 {
+			return p
+		}
 		var tmp = p[pos:]
 		tmp = strings.Trim(tmp, "/")
 		return tmp

--- a/pkg/hertz/biz/handler/upload/upload_service.go
+++ b/pkg/hertz/biz/handler/upload/upload_service.go
@@ -13,6 +13,7 @@ import (
 	"files/pkg/drivers/sync/seahub/searpc"
 	upload "files/pkg/hertz/biz/model/upload"
 	"files/pkg/models"
+	"files/pkg/tasks"
 	"fmt"
 	"io"
 	"net"
@@ -201,6 +202,7 @@ func UploadChunksMethod(ctx context.Context, c *app.RequestContext) {
 
 	uploadArg.ChunkInfo.Share = req.Share
 	uploadArg.ChunkInfo.Shareby = req.Shareby
+	uploadArg.ChunkInfo.SharebyPath = string(c.FormValue("sharebyPath"))
 	uploadArg.ChunkInfo.File = header
 
 	p := uploadArg.ChunkInfo.ParentDir
@@ -330,6 +332,77 @@ func SyncUploadChunksMethod(ctx context.Context, c *app.RequestContext) {
 		klog.V(4).Infof("[upload] Sync uploadChunks, using cached access token (path=%s, owner=%s)", requestPath, owner)
 	}
 
+	// For the last chunk of a large sync file, defer the seafile proxy
+	// call to an async task so the HTTP response returns before the
+	// platform proxy timeout fires.
+	isLastChunk := uploadReq.ResumableChunkNumber == uploadReq.ResumableTotalChunks
+	if isLastChunk && uploadReq.ResumableTotalSize >= common.AsyncFinalizeThreshold {
+		bodyBytes := make([]byte, len(c.Request.Body()))
+		copy(bodyBytes, c.Request.Body())
+
+		headers := make(map[string]string)
+		c.Request.Header.VisitAll(func(key, value []byte) {
+			headers[string(key)] = string(value)
+		})
+		headers[common.REQUEST_HEADER_OWNER] = owner
+
+		p := "/" + filepath.Join(uploadReq.DriveType, uploadReq.RepoId, strings.Trim(uploadReq.ParentDir, "/"), uploadReq.ResumableRelativePath)
+		fileParam, fpErr := models.CreateFileParam(owner, p)
+		if fpErr != nil {
+			klog.Errorf("Sync uploadChunks, create file param error: %v", fpErr)
+			c.AbortWithStatusJSON(consts.StatusBadRequest, utils.H{"error": fmt.Sprintf("file param error: %v", fpErr)})
+			return
+		}
+
+		displayParam := fileParam
+		if uploadReq.Share != "" {
+			sharebyPath := string(c.FormValue("sharebyPath"))
+			if sharebyPath != "" {
+				sharePath := sharebyPath + uploadReq.ResumableRelativePath
+				if sp, spErr := models.CreateFileParam(owner, sharePath); spErr == nil {
+					displayParam = sp
+				}
+			}
+		}
+		uploadParam := &models.PasteParam{
+			Owner:  owner,
+			Action: common.ActionUploadFinalize,
+			Src:    displayParam,
+			Dst:    displayParam,
+		}
+		task := tasks.TaskManager.CreateTask(uploadParam)
+		task.SetTotalSize(uploadReq.ResumableTotalSize)
+		task.ExecuteAsync(task.UploadFinalizeSync(&tasks.SyncFinalizeParams{
+			BodyBytes:   bodyBytes,
+			Headers:     headers,
+			UploadType:  uploadType,
+			UID:         uid,
+			OriginalUID: originalUid,
+			Owner:       owner,
+			UploadReq: tasks.SyncFinalizeUploadReq{
+				DriveType:         uploadReq.DriveType,
+				RepoId:            uploadReq.RepoId,
+				ParentDir:         uploadReq.ParentDir,
+				ResumableFilename: uploadReq.ResumableFilename,
+			},
+		}))
+
+		taskId := task.Id()
+		klog.Infof("Sync uploadChunks, large file (%d bytes), async finalize task: %s", uploadReq.ResumableTotalSize, taskId)
+
+		type syncFinalizeItem struct {
+			Name   string `json:"name"`
+			Size   int64  `json:"size"`
+			TaskId string `json:"taskId"`
+		}
+		c.JSON(consts.StatusOK, []syncFinalizeItem{{
+			Name:   uploadReq.ResumableFilename,
+			Size:   uploadReq.ResumableTotalSize,
+			TaskId: taskId,
+		}})
+		return
+	}
+
 	var executeRequest = func(uid string) (*http.Response, error) {
 		reqUrl := fmt.Sprintf("http://seafile:8082/%s/%s?ret-json=1", uploadType, uid)
 		klog.Infof("Sync uploadChunks, path: %s, owner: %s, uploadPath: %s", requestPath, owner, uploadPath)
@@ -339,7 +412,9 @@ func SyncUploadChunksMethod(ctx context.Context, c *app.RequestContext) {
 		c.Request.Header.VisitAll(func(key, value []byte) {
 			req.Header.Set(string(key), string(value))
 		})
-		req.Header.Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", url.QueryEscape(uploadReq.ResumableFilename)))
+		if req.Header.Get("Content-Disposition") == "" {
+			req.Header.Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", url.PathEscape(uploadReq.ResumableFilename)))
+		}
 		req.Header.Set(common.REQUEST_HEADER_OWNER, owner)
 		req.ContentLength = int64(len(c.Request.Body()))
 
@@ -439,7 +514,7 @@ func SyncUploadChunksMethod(ctx context.Context, c *app.RequestContext) {
 	}
 
 	result := new(upload.UploadChunksResp)
-	if uploadReq.ResumableChunkNumber == uploadReq.ResumableTotalChunks {
+	if isLastChunk {
 		result.Success = nil
 		result.Items = make([]*upload.UploadChunksFileItem, 0)
 		if err = json.Unmarshal(bodyRes, &result.Items); err != nil {

--- a/pkg/hertz/biz/router/middleware.go
+++ b/pkg/hertz/biz/router/middleware.go
@@ -902,6 +902,9 @@ func ShareUpload() app.HandlerFunc {
 		if !hasShareBy && shared.FileType == common.Drive {
 			err = createPart("shareby", []string{shared.Owner}, mw)
 		}
+		if err == nil {
+			err = createPart("sharebyPath", []string{uploadReq.ParentDir}, mw)
+		}
 
 		if err != nil {
 			klog.Errorf("Sync uploadChunks, create MultipartForm error: %v", err)

--- a/pkg/hertz/hertz.go
+++ b/pkg/hertz/hertz.go
@@ -49,12 +49,8 @@ func HertzServer(cfg *common.Server, coord *lifecycle.Coordinator) {
 		server.WithHostPorts(hostPort),
 		server.WithMaxRequestBodySize(20<<20),
 		server.WithTransport(standard.NewTransporter),
-		// 30min covers the worst-case finalize for very large uploads
-		// (e.g. tens of GB cross-PVC io.Copy). Must stay >= the
-		// matching nginx proxy_read_timeout / proxy_send_timeout /
-		// send_timeout / client_body_timeout for the /upload location.
-		server.WithReadTimeout(30*time.Minute),
-		server.WithWriteTimeout(30*time.Minute),
+		server.WithReadTimeout(5*time.Minute),
+		server.WithWriteTimeout(5*time.Minute),
 		server.WithKeepAliveTimeout(3*time.Minute),
 		server.WithStreamBody(true),
 		server.WithReadBufferSize(64*1024),

--- a/pkg/tasks/manager.go
+++ b/pkg/tasks/manager.go
@@ -203,7 +203,7 @@ func (t *taskManager) GetTask(owner string, taskId string, status string) []*Tas
 	var dst = task.param.Dst
 
 	var srcUri, dstUri string
-	if task.isShare {
+	if task.isShare && task.param.SrcSharePath != nil && task.param.DstSharePath != nil {
 		srcUri = fmt.Sprintf("/%s/%s/%s", task.param.SrcSharePath.FileType, task.param.SrcSharePath.Extend, strings.TrimPrefix(task.param.SrcSharePath.Path, "/"))
 		dstUri = fmt.Sprintf("/%s/%s/%s", task.param.DstSharePath.FileType, task.param.DstSharePath.Extend, strings.TrimPrefix(task.param.DstSharePath.Path, "/"))
 	} else {
@@ -217,6 +217,9 @@ func (t *taskManager) GetTask(owner string, taskId string, status string) []*Tas
 	var pauseAble bool = true
 
 	if src.IsSync() && dst.IsSync() {
+		pauseAble = false
+	}
+	if task.param.Action == common.ActionUploadFinalize {
 		pauseAble = false
 	}
 
@@ -280,7 +283,7 @@ func (t *taskManager) GetTasksByStatus(owner, status string) []*TaskInfo {
 
 		var srcUri, dstUri string
 
-		if task.isShare {
+		if task.isShare && task.param.SrcSharePath != nil && task.param.DstSharePath != nil {
 			srcUri = fmt.Sprintf("/%s/%s/%s", task.param.SrcSharePath.FileType, task.param.SrcSharePath.Extend, strings.TrimPrefix(task.param.SrcSharePath.Path, "/"))
 			dstUri = fmt.Sprintf("/%s/%s/%s", task.param.DstSharePath.FileType, task.param.DstSharePath.Extend, strings.TrimPrefix(task.param.DstSharePath.Path, "/"))
 		} else {

--- a/pkg/tasks/task.go
+++ b/pkg/tasks/task.go
@@ -408,6 +408,81 @@ func (t *Task) Execute(fs ...func() error) error {
 	return nil
 }
 
+// ExecuteAsync runs the given phase functions in a bare goroutine,
+// bypassing the per-user pond pool. This allows upload-finalize tasks
+// to run concurrently with paste/copy tasks without pool contention.
+func (t *Task) ExecuteAsync(fs ...func() error) {
+	userPool := t.manager.getOrCreateUserPool(t.param.Owner)
+	userPool.tasks.LoadOrStore(t.id, t)
+
+	t.mu.Lock()
+	if t.funcs == nil {
+		t.funcs = append(t.funcs, fs...)
+	}
+	t.mu.Unlock()
+
+	go func() {
+		var err error
+
+		defer func() {
+			t.mu.Lock()
+			t.endAt = time.Now()
+			t.running = false
+			state := t.state
+			progress := t.progress
+			transfer := t.transfer
+			totalSize := t.totalSize
+			elapsed := time.Since(t.execAt)
+			t.mu.Unlock()
+
+			klog.Infof("[Task] Id: %s defer! status: %s, progress: %d, size: %d, transfer: %d, elapse: %d, error: %v",
+				t.id, state, progress, totalSize, transfer, elapsed, err)
+		}()
+
+		if common.ListContains([]string{common.Canceled, common.Paused, common.Failed, common.Running, common.Completed}, t.getState()) {
+			return
+		}
+
+		t.mu.Lock()
+		t.totalPhases = len(fs)
+		t.execAt = time.Now()
+		t.state = common.Running
+		t.running = true
+		t.details = nil
+		t.mu.Unlock()
+
+		for phase, f := range t.funcs {
+			t.mu.Lock()
+			t.currentPhase = phase + 1
+			currentPhase := t.currentPhase
+			totalPhases := t.totalPhases
+			t.mu.Unlock()
+
+			klog.Infof("[Task] Id: %s, exec phase: %d/%d", t.id, currentPhase, totalPhases)
+			err = f()
+
+			if err != nil {
+				klog.Errorf("[Task] Id: %s, exec failed, error: %s", t.id, err.Error())
+
+				t.mu.Lock()
+				errmsg := common.RemoveBlank(err.Error())
+				t.message = errmsg
+				t.state = common.Failed
+				t.details = append(t.details, errmsg)
+				t.mu.Unlock()
+				return
+			}
+		}
+
+		t.mu.Lock()
+		t.state = common.Completed
+		t.progress = 100
+		t.transfer = t.totalSize
+		t.details = append(t.details, "successed")
+		t.mu.Unlock()
+	}()
+}
+
 func (t *Task) updateProgress(progress int, transfer int64) {
 	t.mu.Lock()
 	defer t.mu.Unlock()

--- a/pkg/tasks/task_upload_finalize.go
+++ b/pkg/tasks/task_upload_finalize.go
@@ -1,0 +1,318 @@
+package tasks
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"files/pkg/drivers/posix/upload"
+	"files/pkg/drivers/sync/seahub"
+	"files/pkg/drivers/sync/seahub/seaserv"
+	"files/pkg/files"
+	"files/pkg/models"
+	uploadwh "files/pkg/webhook/upload"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+// PosixFinalizeParams holds everything the async posix finalize goroutine
+// needs after the HTTP handler has returned.
+type PosixFinalizeParams struct {
+	Info            upload.FileInfo
+	UploadTempPath  string
+	InnerIdentifier string
+	FileParam       *models.FileParam
+	ResumableInfo   *models.ResumableInfo
+}
+
+// UploadFinalizePosix returns a phase function that moves the assembled
+// temp file to its final destination and cleans up metadata.
+func (t *Task) UploadFinalizePosix(p *PosixFinalizeParams) func() error {
+	return func() error {
+		klog.Infof("[Task] Id: %s, UploadFinalizePosix start, src: %s, dst: %s, size: %d",
+			t.id, p.UploadTempPath, p.Info.FullPath, p.Info.FileSize)
+
+		onProgress := files.ProgressFunc(func(written int64) {
+			if p.Info.FileSize > 0 {
+				pct := int(written * 99 / p.Info.FileSize)
+				if pct > 99 {
+					pct = 99
+				}
+				t.mu.Lock()
+				t.progress = pct
+				t.transfer = written
+				t.mu.Unlock()
+			}
+		})
+
+		if err := upload.MoveFileByInfo(p.Info, p.UploadTempPath, onProgress); err != nil {
+			klog.Errorf("[Task] Id: %s, UploadFinalizePosix move failed: %v", t.id, err)
+			return err
+		}
+
+		upload.FileInfoManager.DelFileInfo(p.InnerIdentifier, p.InnerIdentifier, p.UploadTempPath)
+
+		uploadwh.Enqueue(uploadwh.NewItem{
+			Path:        uploadwh.BuildFrontendPath(p.FileParam, p.ResumableInfo),
+			StoragePath: p.Info.FullPath,
+			Mime:        uploadwh.GuessMime(p.Info.FullPath),
+			UploadedAt:  uploadwh.NowMillis(),
+			Owner:       t.param.Owner,
+		})
+
+		klog.Infof("[Task] Id: %s, UploadFinalizePosix completed", t.id)
+		return nil
+	}
+}
+
+// SyncFinalizeParams holds everything the async sync finalize goroutine
+// needs to proxy the last chunk to seafile after the HTTP handler returns.
+type SyncFinalizeParams struct {
+	BodyBytes       []byte
+	Headers         map[string]string
+	UploadType      string
+	UID             string
+	OriginalUID     string
+	Owner           string
+	UploadReq       SyncFinalizeUploadReq
+}
+
+// SyncFinalizeUploadReq is a minimal snapshot of the upload request fields
+// needed for token-refresh retry logic inside the async goroutine.
+type SyncFinalizeUploadReq struct {
+	DriveType          string
+	RepoId             string
+	ParentDir          string
+	ResumableFilename  string
+}
+
+// UploadFinalizeSync returns a phase function that proxies the last chunk
+// request to seafile and waits for its response in the background.
+func (t *Task) UploadFinalizeSync(p *SyncFinalizeParams) func() error {
+	return func() error {
+		klog.Infof("[Task] Id: %s, UploadFinalizeSync start, uid: %s", t.id, p.UID)
+
+		var done atomic.Bool
+		var maxPct atomic.Int32
+		maxPct.Store(95)
+		go t.simulateProgress(&done, &maxPct, t.totalSize)
+
+		executeRequest := func(uid string) (*http.Response, error) {
+			reqUrl := fmt.Sprintf("http://seafile:8082/%s/%s?ret-json=1", p.UploadType, uid)
+			klog.Infof("[Task] Id: %s, UploadFinalizeSync request: %s", t.id, reqUrl)
+
+			req, err := http.NewRequest(http.MethodPost, reqUrl, bytes.NewReader(p.BodyBytes))
+			if err != nil {
+				return nil, err
+			}
+			for k, v := range p.Headers {
+				req.Header.Set(k, v)
+			}
+			if req.Header.Get("Content-Disposition") == "" {
+				req.Header.Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", url.PathEscape(p.UploadReq.ResumableFilename)))
+			}
+			req.ContentLength = int64(len(p.BodyBytes))
+
+			return http.DefaultClient.Do(req)
+		}
+
+		closeBody := func(r *http.Response) {
+			if r != nil && r.Body != nil {
+				r.Body.Close()
+			}
+		}
+
+		readBody := func(r *http.Response) []byte {
+			if r == nil || r.Body == nil {
+				return nil
+			}
+			b, _ := io.ReadAll(r.Body)
+			return b
+		}
+
+		pollWait := func() error {
+			maxPct.Store(99)
+			waitErr := t.waitForSeafileCommit(
+				p.UploadReq.RepoId,
+				p.UploadReq.ParentDir,
+				p.UploadReq.ResumableFilename,
+				30*time.Minute,
+			)
+			done.Store(true)
+			seahub.DeleteAccessToken(p.OriginalUID)
+			return waitErr
+		}
+
+		resp, err := executeRequest(p.UID)
+
+		if err != nil || (resp != nil && resp.StatusCode != http.StatusOK) {
+			if isSeafileTimeout(err, resp) {
+				klog.Infof("[Task] Id: %s, seafile timeout/reset detected, entering poll-wait", t.id)
+				closeBody(resp)
+				return pollWait()
+			}
+
+			retryNeeded := false
+			var firstBody []byte
+			if err != nil {
+				retryNeeded = isConnectionReset(err)
+			} else {
+				firstBody = readBody(resp)
+				var errMsg struct{ Error string `json:"error"` }
+				_ = json.Unmarshal(firstBody, &errMsg)
+				retryNeeded = errMsg.Error == "Access token not found."
+			}
+			closeBody(resp)
+
+			if !retryNeeded {
+				done.Store(true)
+				seahub.DeleteAccessToken(p.OriginalUID)
+				if err != nil {
+					return fmt.Errorf("seafile request failed: %v", err)
+				}
+				return fmt.Errorf("seafile returned status %d: %s", resp.StatusCode, string(firstBody))
+			}
+
+			trimmed := strings.Trim(p.UploadReq.ParentDir, "/")
+			path := "/" + p.UploadReq.DriveType + "/" + p.UploadReq.RepoId + "/" + trimmed + "/"
+			fileParam, fpErr := models.CreateFileParam(p.Owner, path)
+			if fpErr != nil {
+				done.Store(true)
+				return fmt.Errorf("create file param for token refresh: %v", fpErr)
+			}
+			newUid, refreshErr := seahub.GetUploadLink(fileParam, "web", false, true)
+			if refreshErr != nil {
+				seahub.DeleteAccessToken(p.OriginalUID)
+				done.Store(true)
+				return fmt.Errorf("token refresh failed: %v", refreshErr)
+			}
+			seahub.SetAccessToken(p.OriginalUID, newUid)
+
+			resp, err = executeRequest(newUid)
+			if err != nil {
+				closeBody(resp)
+				if isSeafileTimeout(err, resp) {
+					klog.Infof("[Task] Id: %s, retry also timed out, entering poll-wait", t.id)
+					return pollWait()
+				}
+				seahub.DeleteAccessToken(p.OriginalUID)
+				done.Store(true)
+				return fmt.Errorf("retry after token refresh failed: %v", err)
+			}
+		}
+
+		defer closeBody(resp)
+		done.Store(true)
+
+		if resp.StatusCode != http.StatusOK {
+			bodyRes := readBody(resp)
+			seahub.DeleteAccessToken(p.OriginalUID)
+			return fmt.Errorf("seafile returned status %d: %s", resp.StatusCode, string(bodyRes))
+		}
+
+		bodyRes := readBody(resp)
+		klog.Infof("[Task] Id: %s, UploadFinalizeSync seafile response: %s", t.id, string(bodyRes))
+		seahub.DeleteAccessToken(p.OriginalUID)
+		return nil
+	}
+}
+
+// simulateProgress drives progress/transferred forward at an estimated rate
+// until done is set to true. maxPct can be adjusted dynamically (e.g. raised
+// from 95 to 99 when entering the 504 poll-wait phase).
+func (t *Task) simulateProgress(done *atomic.Bool, maxPct *atomic.Int32, totalSize int64) {
+	if totalSize <= 0 {
+		return
+	}
+
+	const estimatedSpeed int64 = 10 * 1024 * 1024 // 10 MB/s
+	const tickInterval = 2 * time.Second
+
+	bytesPerTick := estimatedSpeed * int64(tickInterval/time.Second)
+
+	ticker := time.NewTicker(tickInterval)
+	defer ticker.Stop()
+
+	var simulated int64
+	for range ticker.C {
+		if done.Load() {
+			return
+		}
+		cap := int(maxPct.Load())
+		maxTransferred := totalSize * int64(cap) / 100
+
+		simulated += bytesPerTick
+		if simulated > maxTransferred {
+			simulated = maxTransferred
+		}
+		pct := int(simulated * 100 / totalSize)
+		if pct > cap {
+			pct = cap
+		}
+		t.mu.Lock()
+		t.progress = pct
+		t.transfer = simulated
+		t.mu.Unlock()
+	}
+}
+
+// isSeafileTimeout returns true when the error or response indicates a
+// gateway timeout (504) or a connection-level timeout (EOF, reset) that
+// suggests seafile is still processing the file in the background.
+func isSeafileTimeout(err error, resp *http.Response) bool {
+	if resp != nil && resp.StatusCode == http.StatusGatewayTimeout {
+		return true
+	}
+	if err != nil {
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			return true
+		}
+		msg := err.Error()
+		return strings.Contains(msg, "connection reset by peer") ||
+			strings.Contains(msg, "i/o timeout") ||
+			strings.Contains(msg, "context deadline exceeded")
+	}
+	return false
+}
+
+// waitForSeafileCommit polls GetFileIdByPath until the file appears in
+// seafile or maxWait is exceeded.
+func (t *Task) waitForSeafileCommit(repoId, parentDir, filename string, maxWait time.Duration) error {
+	filePath := strings.TrimRight(parentDir, "/") + "/" + filename
+	klog.Infof("[Task] Id: %s, waitForSeafileCommit start, repo: %s, path: %s, maxWait: %v",
+		t.id, repoId, filePath, maxWait)
+
+	const pollInterval = 10 * time.Second
+	deadline := time.Now().Add(maxWait)
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		fileId, err := seaserv.GlobalSeafileAPI.GetFileIdByPath(repoId, filePath)
+		if err != nil {
+			klog.Warningf("[Task] Id: %s, waitForSeafileCommit poll error: %v", t.id, err)
+		}
+		if fileId != "" {
+			klog.Infof("[Task] Id: %s, waitForSeafileCommit file committed, fileId: %s", t.id, fileId)
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("seafile did not commit file within %v", maxWait)
+		}
+		klog.Infof("[Task] Id: %s, waitForSeafileCommit still waiting...", t.id)
+	}
+	return fmt.Errorf("waitForSeafileCommit ticker stopped unexpectedly")
+}
+
+func isConnectionReset(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "connection reset")
+}


### PR DESCRIPTION
## Summary

- For files ≥ 2 GB, the last-chunk upload handler now returns immediately with a `taskId` and defers the expensive finalize step (file move for Posix, seafile proxy for Sync) to a background task. This prevents platform-level reverse proxy timeouts (typically 60–120s) from killing the HTTP response on very large uploads.
- For share uploads, the original user-facing share path (e.g. `/share/{token}/...`) is preserved and surfaced in the task's `src`/`dest` fields, matching the behavior of share paste/copy tasks.
- Hertz read/write timeout reduced from 30 min back to 5 min, since the long-running finalize work no longer blocks the HTTP handler.

## Changes

### New: async upload-finalize task (`pkg/tasks/task_upload_finalize.go`)
- `UploadFinalizePosix`: moves the assembled temp file to its final destination with progress reporting, then cleans up metadata and fires the upload webhook.
- `UploadFinalizeSync`: proxies the last chunk to seafile in the background, with token-refresh retry, timeout/reset detection and poll-wait recovery via `waitForSeafileCommit`.
- `ExecuteAsync` on `Task`: runs phase functions in a bare goroutine (bypassing the per-user pond pool) so upload-finalize tasks don't contend with paste/copy tasks.

### Upload handlers
- **Posix** (`posix.go`): when `FileSize >= AsyncFinalizeThreshold`, creates a task and calls `ExecuteAsync` instead of blocking on `MoveFileByInfo`. Returns `taskId` in the upload response.
- **Sync** (`upload_service.go`): when the last chunk of a large sync file arrives, snapshots the request body/headers and defers the seafile proxy call to `UploadFinalizeSync`. Returns `taskId` in the upload response.
- **Posix handlefunc** (`handlefunc.go`): for large files, returns the `FileUploadState` without calling `MoveFileByInfo`, letting the caller handle it asynchronously.

### Share path preservation
- **ShareUpload middleware** (`middleware.go`): injects a `sharebyPath` form field containing the original share path (before rewrite) into the modified multipart form.
- **UploadChunksMethod** (`upload_service.go`): manually reads `sharebyPath` from `c.FormValue()` (not auto-bound by thrift struct) and assigns it to `ChunkInfo.SharebyPath`.
- Both Posix and Sync finalize paths use `sharebyPath` to construct a share-perspective `displayParam` for the task's `Src`/`Dst`, so the frontend sees `/share/{token}/...` instead of `/drive/Home/...`.

### Task manager hardening (`manager.go`)
- Nil-safety check on `SrcSharePath`/`DstSharePath` before constructing share URIs in `GetTask` and `GetTasksByStatus`.
- `upload_finalize` tasks are marked as non-pausable.

### Utilities
- `MoveFileOs`, `CopyFileOs`, `IoCopyFileWithBufferOs` (`fileutils.go`): accept an optional `ProgressFunc` callback for progress tracking during cross-device file copies.
- `GetPathName` (`fileutils.go`): nil-safe for empty/root paths.

### Config
- `AsyncFinalizeThreshold = 2 GB` (`constant.go`).
- `ActionUploadFinalize = "upload_finalize"` added to task action constants.
- Hertz read/write timeout reduced to 5 min (`hertz.go`).

## Test plan
- [ ] Upload a file > 2 GB to a Posix drive — verify task is created, progress updates, file appears after completion.
- [ ] Upload a file > 2 GB to a Sync drive — verify task is created, seafile commit completes, file appears in listing.
- [ ] Upload a file > 2 GB via Posix share — verify task `dest` shows `/share/{token}/...` path.
- [ ] Upload a file > 2 GB via Sync share — verify task `dest` shows `/share/{token}/...` path.
- [ ] Upload a file < 2 GB (all paths: Posix, Sync, share, non-share) — verify no task is created, behavior unchanged.
- [ ] Verify existing paste/copy tasks are unaffected (not blocked by upload-finalize tasks in the pool).
- [ ] Verify non-share uploads show correct `/drive/...` or `/sync/...` paths in task info.


Made with [Cursor](https://cursor.com)