### PR TITLE
ci: reuse pinned hertz generation script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,29 +40,10 @@ jobs:
           cache: true
 
       - name: Generate Hertz IDL bindings
-        # Mirror the IDL regeneration that update-server.yml does
-        # before `go build`. Without these files several handler
-        # packages do not compile.
-        #
-        # Tool versions are pinned: @latest gave us non-reproducible
-        # builds (each CI run could pick up a new hz/thriftgo and
-        # regenerate the IDL bindings differently). Bump these when
-        # we deliberately want to take a new generator version.
+        # Keep CI, release builds, and Docker builds on the same
+        # pinned generator versions and IDL list.
         run: |
-          export GOPATH=$HOME/go
-          export PATH=$GOPATH/bin:$PATH
-          go install github.com/cloudwego/hertz/cmd/hz@v0.9.7
-          go install github.com/cloudwego/thriftgo@v0.4.3
-          go mod tidy
-          go mod edit -replace github.com/apache/thrift=github.com/apache/thrift@v0.13.0
-          go mod tidy
-          cd pkg/hertz
-          for f in idl/*.thrift; do
-            echo "hz update -idl $f"
-            hz update -idl "$f"
-          done
-          cd ../..
-          go mod tidy
+          bash scripts/generate-hertz.sh
 
       - name: Compute build/test package list
         # pkg/media/mediabrowser/common/net and pkg/media/api have

--- a/.github/workflows/update-server.yml
+++ b/.github/workflows/update-server.yml
@@ -61,51 +61,14 @@ jobs:
 
       - name: Build
         run: |
-          go mod tidy
+          bash scripts/generate-hertz.sh
           for GOOS in linux; do
             for GOARCH in amd64 arm64; do
               export GOOS=$GOOS
               export GOARCH=$GOARCH
 
-              export GOPATH=~/go
-              export PATH=$GOPATH/bin:$PATH
-              go install github.com/cloudwego/hertz/cmd/hz@latest
-              hz -v
-              GO111MODULE=on go install github.com/cloudwego/thriftgo@latest
-
-              go mod tidy
-              go mod edit -replace github.com/apache/thrift=github.com/apache/thrift@v0.13.0
-              go mod tidy
-
-              cd pkg/hertz
-              echo "callback.thrift"
-              hz update -idl idl/callback.thrift
-              echo "api thrifts"
-              hz update -idl idl/external.thrift
-              hz update -idl idl/md5.thrift
-              hz update -idl idl/nodes.thrift
-              hz update -idl idl/paste.thrift
-              hz update -idl idl/permission.thrift
-              hz update -idl idl/preview.thrift
-              hz update -idl idl/raw.thrift
-              hz update -idl idl/repos.thrift
-              hz update -idl idl/resources.thrift
-              hz update -idl idl/tree.thrift
-              hz update -idl idl/user.thrift
-              echo "upload.thrift"
-              hz update -idl idl/upload.thrift
-              echo "share.thrift"
-              hz update -idl idl/share.thrift
-              hz update -idl idl/search.thrift
-              hz update -idl idl/media.thrift
-
-              cd ../..
-              go mod tidy
-              cd cmd/backend
-              go build -o filebrowser main.go
-              mkdir -p dist/$GOOS-$GOARCH
-              mv filebrowser dist/$GOOS-$GOARCH/
-              cd ../..
+              mkdir -p "cmd/backend/dist/$GOOS-$GOARCH"
+              go build -o "cmd/backend/dist/$GOOS-$GOARCH/filebrowser" ./cmd/backend
             done
           done
 
@@ -117,4 +80,3 @@ jobs:
           push: true
           tags: ${{ format('docker.io/beclab/files-server:{0}', github.event.inputs.tags || steps.get-latest-tag.outputs.tag) }}
           platforms: linux/amd64,linux/arm64
-          progress: plain

--- a/Dockerfile.samba
+++ b/Dockerfile.samba
@@ -9,31 +9,9 @@ RUN \
 COPY cmd/samba ./cmd/samba
 COPY config/ ./config/
 COPY pkg/ ./pkg/
+COPY scripts/generate-hertz.sh ./scripts/generate-hertz.sh
 
-RUN go install github.com/cloudwego/hertz/cmd/hz@latest && \
-  hz -v &&  \
-  GO111MODULE=on go install github.com/cloudwego/thriftgo@latest &&  \
-  go mod tidy &&  \
-  go mod edit -replace github.com/apache/thrift=github.com/apache/thrift@v0.13.0 &&  \
-  go mod tidy &&  \
-  cd pkg/hertz &&  \
-  hz update -idl idl/callback.thrift &&  \
-  hz update -idl idl/external.thrift &&  \
-  hz update -idl idl/md5.thrift &&  \
-  hz update -idl idl/nodes.thrift &&  \
-  hz update -idl idl/paste.thrift &&  \
-  hz update -idl idl/permission.thrift &&  \
-  hz update -idl idl/preview.thrift &&  \
-  hz update -idl idl/raw.thrift &&  \
-  hz update -idl idl/repos.thrift &&  \
-  hz update -idl idl/resources.thrift &&  \
-  hz update -idl idl/tree.thrift &&  \
-  hz update -idl idl/user.thrift &&  \
-  hz update -idl idl/upload.thrift &&  \
-  hz update -idl idl/share.thrift &&  \
-  hz update -idl idl/search.thrift &&  \
-  cd /workspace &&  \
-  go mod tidy
+RUN bash scripts/generate-hertz.sh
 
 RUN CGO_ENABLED=0 go build -ldflags "-w -s" -o samba_share cmd/samba/main.go
 

--- a/scripts/generate-hertz.sh
+++ b/scripts/generate-hertz.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+HZ_VERSION="${HZ_VERSION:-v0.9.7}"
+THRIFTGO_VERSION="${THRIFTGO_VERSION:-v0.4.3}"
+APACHE_THRIFT_VERSION="${APACHE_THRIFT_VERSION:-v0.13.0}"
+
+export GOPATH="${GOPATH:-$HOME/go}"
+export PATH="$GOPATH/bin:$PATH"
+
+cd "$ROOT_DIR"
+
+go install "github.com/cloudwego/hertz/cmd/hz@$HZ_VERSION"
+go install "github.com/cloudwego/thriftgo@$THRIFTGO_VERSION"
+
+go mod tidy
+go mod edit -replace "github.com/apache/thrift=github.com/apache/thrift@$APACHE_THRIFT_VERSION"
+go mod tidy
+
+cd "$ROOT_DIR/pkg/hertz"
+for thrift_file in idl/*.thrift; do
+  echo "hz update -idl $thrift_file"
+  hz update -idl "$thrift_file"
+done
+
+cd "$ROOT_DIR"
+go mod tidy


### PR DESCRIPTION
## Summary
- Adds a shared Hertz IDL generation script with pinned hz/thriftgo versions.
- Updates CI, the server release workflow, and the Samba Dockerfile to reuse that script instead of duplicating generator installs and IDL lists.
- Removes an invalid `progress` input from the server image publish step.

## Test plan
- `bash -n scripts/generate-hertz.sh`
- `git diff --check`
- Checked edited workflow, Dockerfile, and script diagnostics.


Made with [Cursor](https://cursor.com)