### PR TITLE
refactor(handler): share response helpers

### DIFF
--- a/pkg/hertz/biz/handler/api/md5/md5_service.go
+++ b/pkg/hertz/biz/handler/api/md5/md5_service.go
@@ -4,9 +4,9 @@ package md5
 
 import (
 	"context"
-	"encoding/json"
 	"files/pkg/common"
 	"files/pkg/files"
+	"files/pkg/hertz/biz/handler"
 	"files/pkg/models"
 	"fmt"
 	"github.com/cloudwego/hertz/pkg/common/utils"
@@ -73,9 +73,7 @@ func Md5Method(ctx context.Context, c *app.RequestContext) {
 	}
 
 	resp := new(md5.Md5Resp)
-	if err = json.Unmarshal(common.ToBytes(res), &resp); err != nil {
-		klog.Errorf("Failed to unmarshal response body: %v", err)
-		c.AbortWithStatusJSON(consts.StatusInternalServerError, utils.H{"error": "Failed to unmarshal response body"})
+	if !handler.DecodeResponse(c, common.ToBytes(res), resp) {
 		return
 	}
 	c.JSON(consts.StatusOK, resp)

--- a/pkg/hertz/biz/handler/api/paste/paste_service.go
+++ b/pkg/hertz/biz/handler/api/paste/paste_service.go
@@ -4,10 +4,10 @@ package paste
 
 import (
 	"context"
-	"encoding/json"
 	"files/pkg/common"
 	"files/pkg/drivers"
 	"files/pkg/drivers/base"
+	bizhandler "files/pkg/hertz/biz/handler"
 	"files/pkg/models"
 	"files/pkg/tasks"
 	"fmt"
@@ -115,9 +115,7 @@ func PasteMethod(ctx context.Context, c *app.RequestContext) {
 	var res = map[string]string{"task_id": task.Id()}
 
 	resp := new(paste.PasteResp)
-	if err = json.Unmarshal(common.ToBytes(res), &resp); err != nil {
-		klog.Errorf("Failed to unmarshal response body: %v", err)
-		c.AbortWithStatusJSON(consts.StatusInternalServerError, utils.H{"error": "Failed to unmarshal response body"})
+	if !bizhandler.DecodeResponse(c, common.ToBytes(res), resp) {
 		return
 	}
 	c.JSON(consts.StatusOK, resp)
@@ -162,9 +160,7 @@ func GetTaskMethod(ctx context.Context, c *app.RequestContext) {
 	klog.Infof("Task - id: %s, status: %s, res: %s", req.TaskId, status, common.ToJson(res))
 
 	resp := new(paste.GetTaskResp)
-	if err = json.Unmarshal(common.ToBytes(res), &resp); err != nil {
-		klog.Errorf("Failed to unmarshal response body: %v", err)
-		c.AbortWithStatusJSON(consts.StatusInternalServerError, utils.H{"error": "Failed to unmarshal response body"})
+	if !bizhandler.DecodeResponse(c, common.ToBytes(res), resp) {
 		return
 	}
 	c.JSON(consts.StatusOK, resp)
@@ -200,9 +196,7 @@ func DeleteTaskMethod(ctx context.Context, c *app.RequestContext) {
 	}
 
 	resp := new(paste.DeleteTaskResp)
-	if err = json.Unmarshal(common.ToBytes(res), &resp); err != nil {
-		klog.Errorf("Failed to unmarshal response body: %v", err)
-		c.AbortWithStatusJSON(consts.StatusInternalServerError, utils.H{"error": "Failed to unmarshal response body"})
+	if !bizhandler.DecodeResponse(c, common.ToBytes(res), resp) {
 		return
 	}
 	c.JSON(consts.StatusOK, resp)
@@ -236,9 +230,7 @@ func PauseResumeTaskMethod(ctx context.Context, c *app.RequestContext) {
 	}
 
 	resp := new(paste.PauseResumeTaskResp)
-	if err = json.Unmarshal(common.ToBytes(res), &resp); err != nil {
-		klog.Errorf("Failed to unmarshal response body: %v", err)
-		c.AbortWithStatusJSON(consts.StatusInternalServerError, utils.H{"error": "Failed to unmarshal response body"})
+	if !bizhandler.DecodeResponse(c, common.ToBytes(res), resp) {
 		return
 	}
 	c.JSON(consts.StatusOK, resp)

--- a/pkg/hertz/biz/handler/api/permission/permission_service.go
+++ b/pkg/hertz/biz/handler/api/permission/permission_service.go
@@ -4,9 +4,9 @@ package permission
 
 import (
 	"context"
-	"encoding/json"
 	"files/pkg/common"
 	"files/pkg/files"
+	"files/pkg/hertz/biz/handler"
 	permission "files/pkg/hertz/biz/model/api/permission"
 	"files/pkg/models"
 	"fmt"
@@ -67,9 +67,7 @@ func GetPermissionMethod(ctx context.Context, c *app.RequestContext) {
 	}
 
 	resp := new(permission.GetPermissionResp)
-	if err = json.Unmarshal(common.ToBytes(res), &resp); err != nil {
-		klog.Errorf("Failed to unmarshal response body: %v", err)
-		c.AbortWithStatusJSON(consts.StatusInternalServerError, utils.H{"error": "Failed to unmarshal response body"})
+	if !handler.DecodeResponse(c, common.ToBytes(res), resp) {
 		return
 	}
 	c.JSON(consts.StatusOK, resp)

--- a/pkg/hertz/biz/handler/api/resources/resources_service.go
+++ b/pkg/hertz/biz/handler/api/resources/resources_service.go
@@ -8,6 +8,7 @@ import (
 	"files/pkg/common"
 	"files/pkg/drivers"
 	"files/pkg/drivers/base"
+	bizhandler "files/pkg/hertz/biz/handler"
 	"files/pkg/hertz/biz/handler/api/share"
 	resources "files/pkg/hertz/biz/model/api/resources"
 	"files/pkg/models"
@@ -23,25 +24,12 @@ import (
 // GetResourcesMethod .
 // @router /api/resources [GET]
 func GetResourcesMethod(ctx context.Context, c *app.RequestContext) {
-	contextArg, err := models.NewHttpContextArgs(ctx, c, "/api/resources", false, false)
-	if err != nil {
-		klog.Errorf("context args error: %v, path: %s", err, string(c.Path()))
-		c.AbortWithStatusJSON(consts.StatusBadRequest, utils.H{"error": err.Error()})
+	contextArg, handler, ok := bizhandler.ResolveFileHandler(ctx, c, "/api/resources", "", consts.StatusInternalServerError)
+	if !ok {
 		return
 	}
 
 	klog.Infof("[Incoming-Resource] user: %s, fsType: %s, method: %s, args: %s", contextArg.FileParam.Owner, contextArg.FileParam.FileType, c.Method(), common.ToJson(contextArg))
-
-	var handlerParam = &base.HandlerParam{
-		Ctx:   ctx,
-		Owner: contextArg.FileParam.Owner,
-	}
-
-	var handler = drivers.Adaptor.NewFileHandler(contextArg.FileParam.FileType, handlerParam)
-	if handler == nil {
-		c.AbortWithStatusJSON(consts.StatusInternalServerError, utils.H{"error": fmt.Sprintf("handler not found, type: %s", contextArg.FileParam.FileType)})
-		return
-	}
 
 	res, err := handler.List(contextArg)
 	if err != nil {
@@ -53,9 +41,7 @@ func GetResourcesMethod(ctx context.Context, c *app.RequestContext) {
 	}
 
 	resp := new(map[string]interface{}) // different disk type with different responses
-	if err := json.Unmarshal(res, &resp); err != nil {
-		klog.Errorf("Failed to unmarshal response body: %v", err)
-		c.AbortWithStatusJSON(consts.StatusInternalServerError, utils.H{"error": "Failed to unmarshal response body"})
+	if !bizhandler.DecodeResponse(c, res, resp) {
 		return
 	}
 	c.JSON(consts.StatusOK, resp)
@@ -72,25 +58,12 @@ func PostResourcesMethod(ctx context.Context, c *app.RequestContext) {
 		return
 	}
 
-	contextArg, err := models.NewHttpContextArgs(ctx, c, "/api/resources", false, false)
-	if err != nil {
-		klog.Errorf("context args error: %v, path: %s", err, string(c.Path()))
-		c.AbortWithStatusJSON(consts.StatusBadRequest, utils.H{"error": err.Error()})
+	contextArg, handler, ok := bizhandler.ResolveFileHandler(ctx, c, "/api/resources", "", consts.StatusInternalServerError)
+	if !ok {
 		return
 	}
 
 	klog.Infof("[Incoming-Resource] user: %s, fsType: %s, method: %s, args: %s", contextArg.FileParam.Owner, contextArg.FileParam.FileType, c.Method(), common.ToJson(contextArg))
-
-	var handlerParam = &base.HandlerParam{
-		Ctx:   ctx,
-		Owner: contextArg.FileParam.Owner,
-	}
-
-	var handler = drivers.Adaptor.NewFileHandler(contextArg.FileParam.FileType, handlerParam)
-	if handler == nil {
-		c.AbortWithStatusJSON(consts.StatusInternalServerError, utils.H{"error": fmt.Sprintf("handler not found, type: %s", contextArg.FileParam.FileType)})
-		return
-	}
 
 	_, err = handler.Create(contextArg)
 	if err != nil {
@@ -116,25 +89,12 @@ func PatchResourcesMethod(ctx context.Context, c *app.RequestContext) {
 		return
 	}
 
-	contextArg, err := models.NewHttpContextArgs(ctx, c, "/api/resources", false, false)
-	if err != nil {
-		klog.Errorf("context args error: %v, path: %s", err, string(c.Path()))
-		c.AbortWithStatusJSON(consts.StatusBadRequest, utils.H{"error": err.Error()})
+	contextArg, handler, ok := bizhandler.ResolveFileHandler(ctx, c, "/api/resources", "", consts.StatusInternalServerError)
+	if !ok {
 		return
 	}
 
 	klog.Infof("[Incoming-Resource] user: %s, fsType: %s, method: %s, args: %s", contextArg.FileParam.Owner, contextArg.FileParam.FileType, c.Method(), common.ToJson(contextArg))
-
-	var handlerParam = &base.HandlerParam{
-		Ctx:   ctx,
-		Owner: contextArg.FileParam.Owner,
-	}
-
-	var handler = drivers.Adaptor.NewFileHandler(contextArg.FileParam.FileType, handlerParam)
-	if handler == nil {
-		c.AbortWithStatusJSON(consts.StatusInternalServerError, utils.H{"error": fmt.Sprintf("handler not found, type: %s", contextArg.FileParam.FileType)})
-		return
-	}
 
 	_, err = handler.Rename(contextArg)
 	if err != nil {
@@ -169,25 +129,12 @@ func PutResourcesMethod(ctx context.Context, c *app.RequestContext) {
 		return
 	}
 
-	contextArg, err := models.NewHttpContextArgs(ctx, c, "/api/resources", false, false)
-	if err != nil {
-		klog.Errorf("context args error: %v, path: %s", err, string(c.Path()))
-		c.AbortWithStatusJSON(consts.StatusBadRequest, utils.H{"error": err.Error()})
+	contextArg, handler, ok := bizhandler.ResolveFileHandler(ctx, c, "/api/resources", "", consts.StatusInternalServerError)
+	if !ok {
 		return
 	}
 
 	klog.Infof("[Incoming-Resource] user: %s, fsType: %s, method: %s, args: %s", contextArg.FileParam.Owner, contextArg.FileParam.FileType, c.Method(), common.ToJson(contextArg))
-
-	var handlerParam = &base.HandlerParam{
-		Ctx:   ctx,
-		Owner: contextArg.FileParam.Owner,
-	}
-
-	var handler = drivers.Adaptor.NewFileHandler(contextArg.FileParam.FileType, handlerParam)
-	if handler == nil {
-		c.AbortWithStatusJSON(consts.StatusInternalServerError, utils.H{"error": fmt.Sprintf("handler not found, type: %s", contextArg.FileParam.FileType)})
-		return
-	}
 
 	res, err := handler.Edit(contextArg)
 	if err != nil {

--- a/pkg/hertz/biz/handler/upload/upload_service.go
+++ b/pkg/hertz/biz/handler/upload/upload_service.go
@@ -11,6 +11,7 @@ import (
 	"files/pkg/drivers/base"
 	"files/pkg/drivers/sync/seahub"
 	"files/pkg/drivers/sync/seahub/searpc"
+	"files/pkg/hertz/biz/handler"
 	upload "files/pkg/hertz/biz/model/upload"
 	"files/pkg/models"
 	"files/pkg/tasks"
@@ -147,9 +148,7 @@ func UploadedBytesMethod(ctx context.Context, c *app.RequestContext) {
 	}
 
 	resp := new(upload.UploadedBytesResp)
-	if err = json.Unmarshal(respBytes, &resp); err != nil {
-		klog.Errorf("Failed to unmarshal response body: %v", err)
-		c.AbortWithStatusJSON(consts.StatusInternalServerError, utils.H{"error": "Failed to unmarshal response body"})
+	if !handler.DecodeResponse(c, respBytes, resp) {
 		return
 	}
 	c.JSON(consts.StatusOK, resp)
@@ -243,17 +242,13 @@ func UploadChunksMethod(ctx context.Context, c *app.RequestContext) {
 	if req.ResumableChunkNumber == req.ResumableTotalChunks {
 		resp.Success = nil
 		resp.Items = make([]*upload.UploadChunksFileItem, 0)
-		if err = json.Unmarshal(respBytes, &resp.Items); err != nil {
-			klog.Errorf("Failed to unmarshal response body: %v", err)
-			c.AbortWithStatusJSON(consts.StatusInternalServerError, utils.H{"error": "Failed to unmarshal response body"})
+		if !handler.DecodeResponse(c, respBytes, &resp.Items) {
 			return
 		}
 	} else {
 		resp.Items = nil
 		resp.Success = new(upload.UploadChunksSuccess)
-		if err = json.Unmarshal(respBytes, &resp.Success); err != nil {
-			klog.Errorf("Failed to unmarshal response body: %v", err)
-			c.AbortWithStatusJSON(consts.StatusInternalServerError, utils.H{"error": "Failed to unmarshal response body"})
+		if !handler.DecodeResponse(c, respBytes, &resp.Success) {
 			return
 		}
 	}

--- a/pkg/hertz/biz/handler/utils.go
+++ b/pkg/hertz/biz/handler/utils.go
@@ -1,10 +1,18 @@
 package handler
 
 import (
+	"context"
+	"encoding/json"
+	"files/pkg/drivers"
+	"files/pkg/drivers/base"
+	"files/pkg/models"
+	"fmt"
 	"net/http"
 
 	"github.com/cloudwego/hertz/pkg/app"
 	"github.com/cloudwego/hertz/pkg/common/utils"
+	"github.com/cloudwego/hertz/pkg/protocol/consts"
+	"k8s.io/klog/v2"
 )
 
 func RespSuccess(c *app.RequestContext, data interface{}) {
@@ -35,4 +43,38 @@ func RespForbidden(c *app.RequestContext, msg string) {
 func RespStatusInternalServerError(c *app.RequestContext, msg string) {
 	c.JSON(http.StatusInternalServerError, utils.H{"code": 1, "message": msg})
 	c.Abort()
+}
+
+func DecodeResponse(c *app.RequestContext, data []byte, dst interface{}) bool {
+	if err := json.Unmarshal(data, dst); err != nil {
+		klog.Errorf("Failed to unmarshal response body: %v", err)
+		c.AbortWithStatusJSON(consts.StatusInternalServerError, utils.H{"error": "Failed to unmarshal response body"})
+		return false
+	}
+	return true
+}
+
+func ResolveFileHandler(ctx context.Context, c *app.RequestContext, routePrefix string, owner string, missingHandlerStatus int) (*models.HttpContextArgs, base.Execute, bool) {
+	contextArg, err := models.NewHttpContextArgs(ctx, c, routePrefix, false, false)
+	if err != nil {
+		klog.Errorf("context args error: %v, path: %s", err, string(c.Path()))
+		c.AbortWithStatusJSON(consts.StatusBadRequest, utils.H{"error": err.Error()})
+		return nil, nil, false
+	}
+
+	if owner == "" {
+		owner = contextArg.FileParam.Owner
+	}
+	handlerParam := &base.HandlerParam{
+		Ctx:   ctx,
+		Owner: owner,
+	}
+
+	fileHandler := drivers.Adaptor.NewFileHandler(contextArg.FileParam.FileType, handlerParam)
+	if fileHandler == nil {
+		c.AbortWithStatusJSON(missingHandlerStatus, utils.H{"error": fmt.Sprintf("handler not found, type: %s", contextArg.FileParam.FileType)})
+		return nil, nil, false
+	}
+
+	return contextArg, fileHandler, true
 }


### PR DESCRIPTION
## Summary
- Adds shared handler helpers for repeated JSON response decoding and file-handler resolution.
- Migrates resource routes to the shared resolver while preserving existing status codes and response bodies.
- Replaces repeated decode failure branches in md5, permission, paste, resources, and upload handlers.

## Test plan
- `go test ./pkg/hertz/biz/handler/... ./pkg/tasks`
- `git diff --check`


Made with [Cursor](https://cursor.com)