### PR TITLE
fix: double slash in sync copy destination path when target is root dir

### DIFF
--- a/pkg/tasks/task_paste_sync.go
+++ b/pkg/tasks/task_paste_sync.go
@@ -525,7 +525,7 @@ func (t *Task) DownloadFileFromSync(src, dst *models.FileParam, root bool) error
 		return err
 	}
 
-	downloadPath = dstUri + filepath.Dir(dst.Path)
+	downloadPath = filepath.Join(dstUri, filepath.Dir(dst.Path))
 
 	fileInfo := seahub.GetFileInfo(src.Extend, src.Path)
 	fileSize := fileInfo["size"].(int64)
@@ -557,7 +557,7 @@ func (t *Task) DownloadFileFromSync(src, dst *models.FileParam, root bool) error
 	}
 
 	if !t.pausedSnap().WasPaused {
-		downloadFilePath = AddVersionSuffix(downloadPath+"/"+dstFileName, dst, false, "")
+		downloadFilePath = AddVersionSuffix(filepath.Join(downloadPath, dstFileName), dst, false, "")
 	} else {
 		downloadFilePath = filepath.Join(downloadPath, dstFileName)
 	}


### PR DESCRIPTION
## Summary

- Replace string concatenation with `filepath.Join` in `DownloadFileFromSync` to avoid producing malformed paths like `/drive/Data//file.txt` when copying files to the root of a target directory.
- Two call sites in `pkg/tasks/task_paste_sync.go` are fixed: the `downloadPath` construction (line 528) and the `downloadFilePath` construction in the non-paused branch (line 560).

## Test plan

- Copy a file from sync storage to the root of a posix/cloud destination and verify the destination path contains no double slashes.
- Copy a file from sync storage to a subdirectory and verify behavior is unchanged.


Made with [Cursor](https://cursor.com)