### PR TITLE
fix: image preview for unsupported-resize formats (HEIC, WebP, AVIF, etc.)

### DIFF
--- a/pkg/img/service.go
+++ b/pkg/img/service.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/disintegration/imaging"
 	"github.com/dsoprea/go-exif/v3"
+	_ "github.com/gen2brain/heic"
 	"github.com/marusama/semaphore/v2"
 	"k8s.io/klog/v2"
 
@@ -205,12 +206,18 @@ func (s *Service) detectFormat(in io.Reader) (Format, io.Reader, error) {
 		return 0, nil, fmt.Errorf("%s: %w", err.Error(), ErrUnsupportedFormat)
 	}
 
+	wrappedReader := io.MultiReader(buf, in)
+
+	if imgFormat == "heic" {
+		return FormatJpeg, wrappedReader, nil
+	}
+
 	format, err := ParseFormat(imgFormat)
 	if err != nil {
 		return 0, nil, ErrUnsupportedFormat
 	}
 
-	return format, io.MultiReader(buf, in), nil
+	return format, wrappedReader, nil
 }
 
 func getEmbeddedThumbnail(in io.Reader) ([]byte, io.Reader, error) {

--- a/pkg/preview/preview.go
+++ b/pkg/preview/preview.go
@@ -10,6 +10,7 @@ import (
 	"files/pkg/models"
 	"fmt"
 	"io"
+	"strings"
 
 	"k8s.io/klog/v2"
 )
@@ -69,7 +70,17 @@ func CreatePreview(owner string, key string,
 			return nil, e2
 		}
 
-		return data, err
+		ext := strings.ToLower(bufferFile.Extension)
+		if (ext == ".heic" || ext == ".heif") && previewSize == PreviewSizeThumb {
+			buf := &bytes.Buffer{}
+			if e3 := imgSvc.Resize(context.TODO(), bytes.NewReader(data), W256, H256, buf,
+				img.WithMode(img.ResizeModeFill), img.WithQuality(img.QualityLow),
+				img.WithFormat(img.FormatJpeg)); e3 == nil {
+				return buf.Bytes(), nil
+			}
+		}
+
+		return data, nil
 	}
 
 	fd, err := bufferFile.Fs.Open(bufferFile.Path)


### PR DESCRIPTION
## Summary

- A recent lint refactor (`76cc449`) renamed shadow variables inside `CreatePreview`, which inadvertently changed `return data, nil` (where `err` was shadowed to `nil`) into `return data, err` (where `err` is `ErrUnsupportedFormat`). This caused preview requests for any format not resizable by `imaging` (WebP, HEIC, AVIF, ICO, SVG, etc.) to return HTTP 400 instead of serving the raw image data.
- Fix by explicitly returning `nil` error when raw image data is successfully read.
- Additionally, add HEIC small thumbnail support: register the `gen2brain/heic` decoder and resize HEIC to 256×256 JPEG for thumbnails, matching the behavior of other formats. Big thumbnails and original files still return raw HEIC data. If resize fails, it gracefully falls back to raw data.

## Changes

- `pkg/preview/preview.go`: change `return data, err` → `return data, nil`; add HEIC/HEIF thumb-specific resize path.
- `pkg/img/service.go`: import `_ "github.com/gen2brain/heic"` to register the HEIC decoder; map `"heic"` format to `FormatJpeg` in `detectFormat` so `Resize` can decode and encode HEIC as JPEG.

## Test plan

- Upload a HEIC file and verify both small thumbnail (256×256 JPEG) and big thumbnail (raw HEIC) display correctly.
- Upload WebP, AVIF, ICO, SVG files and verify previews (both sizes) still work.
- Upload JPEG, PNG, BMP, TIFF files and verify resize previews are unaffected.
- Upload a GIF and verify it returns raw data as before.


Made with [Cursor](https://cursor.com)