### PR TITLE
security: fail closed when internal share token RNG fails

### DIFF
--- a/pkg/common/internal_auth.go
+++ b/pkg/common/internal_auth.go
@@ -5,6 +5,8 @@ import (
 	"crypto/subtle"
 	"encoding/hex"
 	"sync"
+
+	"k8s.io/klog/v2"
 )
 
 // HeaderInternalShareToken is the request header name used for the
@@ -23,15 +25,18 @@ var (
 
 // InternalShareToken returns the process-local secret. It is generated
 // lazily on first use; callers must not log it.
+//
+// If the OS RNG ever fails (effectively impossible on supported
+// platforms), the token stays empty. EqualInternalShareToken treats an
+// empty expected value as a hard mismatch, so every internal forward
+// fails closed until the process is restarted. The previous behavior
+// fell back to a constant string, which made the trust boundary
+// trivially bypassable any time RNG initialization failed.
 func InternalShareToken() string {
 	internalTokenOnce.Do(func() {
 		var b [32]byte
 		if _, err := rand.Read(b[:]); err != nil {
-			// rand.Read failure is effectively impossible on supported
-			// platforms; fall back to a deterministic-but-unique tag so
-			// initialization never panics. The mismatch will simply
-			// reject every internal call until the process is restarted.
-			internalToken = "fallback-internal-share-token"
+			klog.Errorf("internal share token init failed; internal forwards disabled until restart: %v", err)
 			return
 		}
 		internalToken = hex.EncodeToString(b[:])
@@ -41,10 +46,20 @@ func InternalShareToken() string {
 
 // EqualInternalShareToken returns true iff got matches the process
 // secret using a constant-time comparison.
+//
+// An empty got or empty expected (i.e. uninitialized token) always
+// returns false; callers cannot accidentally authorize requests by
+// sending an empty header against an empty secret.
 func EqualInternalShareToken(got string) bool {
-	if got == "" {
+	return equalInternalShareToken(got, InternalShareToken())
+}
+
+// equalInternalShareToken is the testable core of EqualInternalShareToken.
+// It exists so tests can cover the empty-expected and mismatch cases
+// without having to fake the package-level token.
+func equalInternalShareToken(got, expected string) bool {
+	if got == "" || expected == "" {
 		return false
 	}
-	expected := InternalShareToken()
 	return subtle.ConstantTimeCompare([]byte(got), []byte(expected)) == 1
 }

--- a/pkg/common/internal_auth_test.go
+++ b/pkg/common/internal_auth_test.go
@@ -1,0 +1,62 @@
+package common
+
+import "testing"
+
+func TestEqualInternalShareTokenCore(t *testing.T) {
+	cases := []struct {
+		name          string
+		got, expected string
+		want          bool
+	}{
+		{"both empty rejected", "", "", false},
+		{"empty expected rejected", "anything", "", false},
+		{"empty got rejected", "", "secret", false},
+		{"mismatch rejected", "wrong", "secret", false},
+		{"different length rejected", "secret-extra", "secret", false},
+		{"exact match accepted", "secret", "secret", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := equalInternalShareToken(c.got, c.expected); got != c.want {
+				t.Fatalf("equalInternalShareToken(%q,%q) = %v, want %v", c.got, c.expected, got, c.want)
+			}
+		})
+	}
+}
+
+func TestInternalShareTokenIsHexAndStable(t *testing.T) {
+	first := InternalShareToken()
+	if first == "" {
+		t.Fatal("InternalShareToken returned empty value (rand init failed?)")
+	}
+	if first == "fallback-internal-share-token" {
+		t.Fatal("InternalShareToken returned the previously-known constant fallback")
+	}
+	const wantLen = 32 * 2
+	if len(first) != wantLen {
+		t.Fatalf("InternalShareToken length = %d, want %d", len(first), wantLen)
+	}
+	for i, r := range first {
+		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f')) {
+			t.Fatalf("InternalShareToken[%d] = %q, want lowercase hex", i, r)
+		}
+	}
+	if second := InternalShareToken(); second != first {
+		t.Fatalf("InternalShareToken not stable: first=%q second=%q", first, second)
+	}
+}
+
+func TestEqualInternalShareTokenAgainstProcessSecret(t *testing.T) {
+	if !EqualInternalShareToken(InternalShareToken()) {
+		t.Fatal("EqualInternalShareToken rejected its own token")
+	}
+	if EqualInternalShareToken("") {
+		t.Fatal("EqualInternalShareToken accepted empty header")
+	}
+	if EqualInternalShareToken("not-the-token") {
+		t.Fatal("EqualInternalShareToken accepted an unrelated value")
+	}
+	if EqualInternalShareToken("fallback-internal-share-token") {
+		t.Fatal("EqualInternalShareToken accepted the previously-known constant fallback")
+	}
+}


### PR DESCRIPTION
## Summary

- `InternalShareToken` previously fell back to the constant string `"fallback-internal-share-token"` if `crypto/rand` ever failed, turning the internal-forward trust boundary into a publicly-known shared secret. This change drops the constant fallback and lets the token stay empty on RNG failure, while logging the event via `klog`.
- `EqualInternalShareToken` now also rejects an empty expected value, so internal forwards fail closed until the process is restarted (defense in depth against the empty-token-vs-empty-header case).
- Adds `pkg/common/internal_auth_test.go` covering empty got/expected rejection, mismatch rejection, exact match, the hex/length/stability of the generated token, and an explicit assertion that the previously-known fallback string no longer authenticates.

## Test plan

- [x] `go vet ./pkg/common/...`
- [x] `go test ./pkg/common/... -count=1 -race`
- [x] `go build ./pkg/common/... ./pkg/hertz/biz/router/... ./pkg/hertz/biz/handler/api/paste/...`

Made with [Cursor](https://cursor.com)