### PR TITLE
security: stop reflecting arbitrary CORS origins with credentials

### DIFF
--- a/pkg/common/cors.go
+++ b/pkg/common/cors.go
@@ -1,0 +1,83 @@
+package common
+
+import (
+	"net/url"
+	"os"
+	"strings"
+)
+
+// CorsAllowedOriginsEnv is the optional comma-separated list of extra
+// CORS-allowed origins, in addition to the request's own host. Each
+// entry may be a bare hostname ("foo.example.com"), host:port, or a
+// full origin URL ("https://foo.example.com"); the host portion is
+// compared case-insensitively.
+const CorsAllowedOriginsEnv = "CORS_ALLOWED_ORIGINS"
+
+// AllowedOrigin reports the value to echo back in
+// Access-Control-Allow-Origin for a request. An empty result means
+// the header should be omitted; the browser then blocks the response
+// from JavaScript.
+//
+// An origin is allowed when:
+//
+//  1. It is non-empty and parses to a host.
+//  2. Its host equals the request's effective host - the
+//     X-Forwarded-Host header set by the gateway, falling back to
+//     the Host header for direct connections.
+//  3. Or its host matches one of the values configured via
+//     $CORS_ALLOWED_ORIGINS.
+//
+// Previously the file service reflected the inbound Origin header
+// verbatim while also setting Access-Control-Allow-Credentials: true,
+// which let any cross-site page issue credentialed XHR against the
+// service. This helper restores the same-origin invariant by default
+// and lets operators opt extra origins back in via env.
+func AllowedOrigin(originHeader, forwardedHost, host string) string {
+	if originHeader == "" {
+		return ""
+	}
+	u, err := url.Parse(originHeader)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	target := forwardedHost
+	if target == "" {
+		target = host
+	}
+	if target != "" && strings.EqualFold(u.Host, target) {
+		return originHeader
+	}
+	for _, allowed := range corsExtraAllowedHosts() {
+		if strings.EqualFold(u.Host, allowed) {
+			return originHeader
+		}
+	}
+	return ""
+}
+
+func corsExtraAllowedHosts() []string {
+	return parseAllowedOrigins(os.Getenv(CorsAllowedOriginsEnv))
+}
+
+// parseAllowedOrigins extracts the comparable host portion from each
+// comma-separated entry. Entries are accepted in three forms: bare
+// hostname, host:port, or full URL (whose host is taken).
+func parseAllowedOrigins(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if u, err := url.Parse(p); err == nil && u.Host != "" {
+			out = append(out, u.Host)
+		} else {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/pkg/common/cors_test.go
+++ b/pkg/common/cors_test.go
@@ -1,0 +1,114 @@
+package common
+
+import "testing"
+
+func TestParseAllowedOrigins(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"only whitespace", "  , , ,", nil},
+		{"single bare host", "foo.example.com", []string{"foo.example.com"}},
+		{"host with port", "foo.example.com:8443", []string{"foo.example.com:8443"}},
+		{"full origin URL", "https://foo.example.com", []string{"foo.example.com"}},
+		{"mix", "https://a.example.com, b.example.com:9000 ,c.example.com",
+			[]string{"a.example.com", "b.example.com:9000", "c.example.com"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseAllowedOrigins(tc.in)
+			if !equalStringSlice(got, tc.want) {
+				t.Fatalf("parseAllowedOrigins(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAllowedOrigin_SameHost(t *testing.T) {
+	got := AllowedOrigin("https://files.alice.example.com",
+		"files.alice.example.com", "")
+	if got != "https://files.alice.example.com" {
+		t.Fatalf("AllowedOrigin same forwarded host: got %q", got)
+	}
+}
+
+func TestAllowedOrigin_FallsBackToHost(t *testing.T) {
+	got := AllowedOrigin("http://files.local:8080", "", "files.local:8080")
+	if got != "http://files.local:8080" {
+		t.Fatalf("AllowedOrigin same Host fallback: got %q", got)
+	}
+}
+
+func TestAllowedOrigin_RejectsCrossOrigin(t *testing.T) {
+	got := AllowedOrigin("https://evil.example.com",
+		"files.alice.example.com", "")
+	if got != "" {
+		t.Fatalf("AllowedOrigin cross-origin: got %q, want empty", got)
+	}
+}
+
+func TestAllowedOrigin_RejectsEmpty(t *testing.T) {
+	if got := AllowedOrigin("", "files.alice.example.com", ""); got != "" {
+		t.Fatalf("AllowedOrigin empty origin: got %q, want empty", got)
+	}
+}
+
+func TestAllowedOrigin_RejectsMalformed(t *testing.T) {
+	if got := AllowedOrigin("not a url", "files.alice.example.com", ""); got != "" {
+		t.Fatalf("AllowedOrigin malformed origin: got %q, want empty", got)
+	}
+}
+
+func TestAllowedOrigin_RejectsNoTarget(t *testing.T) {
+	if got := AllowedOrigin("https://anything.example.com", "", ""); got != "" {
+		t.Fatalf("AllowedOrigin missing target host: got %q, want empty", got)
+	}
+}
+
+func TestAllowedOrigin_AllowsExtraOriginsFromEnv(t *testing.T) {
+	t.Setenv(CorsAllowedOriginsEnv,
+		"https://dashboard.olares.example.com, foo.example.com:8443")
+
+	cases := []struct {
+		name   string
+		origin string
+		want   string
+	}{
+		{"extra origin URL form", "https://dashboard.olares.example.com",
+			"https://dashboard.olares.example.com"},
+		{"extra host:port", "https://foo.example.com:8443",
+			"https://foo.example.com:8443"},
+		{"extra mismatch port still rejected", "https://foo.example.com:9000", ""},
+		{"unknown still rejected", "https://other.example.com", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := AllowedOrigin(tc.origin, "files.alice.example.com", "")
+			if got != tc.want {
+				t.Fatalf("AllowedOrigin(%q) = %q, want %q", tc.origin, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAllowedOrigin_CaseInsensitiveHost(t *testing.T) {
+	got := AllowedOrigin("https://FILES.alice.example.com",
+		"files.alice.example.com", "")
+	if got != "https://FILES.alice.example.com" {
+		t.Fatalf("AllowedOrigin case-insensitive same host: got %q", got)
+	}
+}
+
+func equalStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/hertz/biz/router/middleware.go
+++ b/pkg/hertz/biz/router/middleware.go
@@ -83,10 +83,23 @@ var shareProxyClient = &http.Client{
 	},
 }
 
+// Cors sets per-response CORS headers. It echoes Origin only when
+// common.AllowedOrigin authorizes it (same effective host, or a host
+// listed in $CORS_ALLOWED_ORIGINS). Reflecting an arbitrary Origin
+// alongside Allow-Credentials: true - the previous behavior - lets
+// any cross-site page issue credentialed XHR against this service,
+// so the header is now omitted for unrelated origins and the browser
+// blocks the response from JavaScript.
 func Cors() app.HandlerFunc {
 	return func(ctx context.Context, c *app.RequestContext) {
-		c.Response.Header.Set("Access-Control-Allow-Origin", string(c.Request.Header.Get("Origin")))
-		c.Response.Header.Set("Access-Control-Allow-Credentials", "true")
+		origin := string(c.Request.Header.Get("Origin"))
+		forwardedHost := string(c.GetHeader("X-Forwarded-Host"))
+		host := string(c.Request.Host())
+		if allowed := common.AllowedOrigin(origin, forwardedHost, host); allowed != "" {
+			c.Response.Header.Set("Access-Control-Allow-Origin", allowed)
+			c.Response.Header.Set("Access-Control-Allow-Credentials", "true")
+			c.Response.Header.Add("Vary", "Origin")
+		}
 		c.Response.Header.Set("Access-Control-Allow-Headers", "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization")
 		c.Response.Header.Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 		c.Response.Header.Set("Access-Control-Max-Age", "600")
@@ -99,8 +112,11 @@ func Options() app.HandlerFunc {
 	return func(c context.Context, ctx *app.RequestContext) {
 		if bytes.Equal(ctx.Method(), []byte("OPTIONS")) {
 			origin := string(ctx.Request.Header.Peek("Origin"))
-			if origin != "" {
-				ctx.Header("Access-Control-Allow-Origin", origin)
+			forwardedHost := string(ctx.GetHeader("X-Forwarded-Host"))
+			host := string(ctx.Request.Host())
+			if allowed := common.AllowedOrigin(origin, forwardedHost, host); allowed != "" {
+				ctx.Header("Access-Control-Allow-Origin", allowed)
+				ctx.Header("Access-Control-Allow-Credentials", "true")
 				ctx.Header("Vary", "Origin")
 			}
 			ctx.Header("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, PATCH, OPTIONS")

--- a/pkg/media/api/http.go
+++ b/pkg/media/api/http.go
@@ -3,6 +3,7 @@ package api
 import (
 	"net/http"
 
+	"files/pkg/common"
 	"files/pkg/media/service"
 
 	"github.com/gorilla/mux"
@@ -30,11 +31,16 @@ func UpdateNamedConfiguration(w http.ResponseWriter, r *http.Request) {
 	// service.GetConfigurationController().UpdateNamedConfiguration(w, r)
 }
 
+// setupCORS sets per-response CORS headers for the media subsystem.
+// Origin is echoed only when common.AllowedOrigin authorizes it
+// (same effective host, or a host listed in $CORS_ALLOWED_ORIGINS),
+// matching the policy applied to the main HTTP server.
 func setupCORS(w http.ResponseWriter, r *http.Request) {
-	// Set CORS headers for all responses
-	w.Header().Set("Access-Control-Allow-Origin", r.Header.Get("Origin"))
-	//	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.Header().Set("Access-Control-Allow-Credentials", "true")
+	if allowed := common.AllowedOrigin(r.Header.Get("Origin"), r.Header.Get("X-Forwarded-Host"), r.Host); allowed != "" {
+		w.Header().Set("Access-Control-Allow-Origin", allowed)
+		w.Header().Set("Access-Control-Allow-Credentials", "true")
+		w.Header().Add("Vary", "Origin")
+	}
 	w.Header().Set("Access-Control-Allow-Headers", "access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,content-type,x-auth,x-unauth-error,x-authorization")
 	w.Header().Set("Access-Control-Allow-Methods", "PUT, GET, DELETE, POST, OPTIONS")
 }


### PR DESCRIPTION
## Summary

`Cors()` / `Options()` ([pkg/hertz/biz/router/middleware.go](pkg/hertz/biz/router/middleware.go)) and `setupCORS` ([pkg/media/api/http.go](pkg/media/api/http.go)) reflected the inbound `Origin` header verbatim into `Access-Control-Allow-Origin` while also always setting `Access-Control-Allow-Credentials: true`. Any cross-site page could issue credentialed XHR against the file service and read the response - a CORS-class CSRF bypass on whichever subdomains the service is exposed on (notably `share.<user>.<domain>`).

Introduces a small helper [pkg/common/cors.go](pkg/common/cors.go):

```go
func AllowedOrigin(originHeader, forwardedHost, host string) string
```

An origin is echoed back only when:

1. it is non-empty and parses to a host;
2. its host equals the request's effective host (`X-Forwarded-Host`, falling back to `Host`); or
3. its host matches one of the values in the new `CORS_ALLOWED_ORIGINS` env var (comma-separated; bare host, `host:port`, or full URL).

`Cors()`, `Options()`, and `setupCORS` now route through the helper. When the origin is not allowed, `Access-Control-Allow-Origin` is omitted entirely and the browser blocks the response from JavaScript. `Vary: Origin` is added whenever an origin is echoed so caches don't poison cross-tenant responses. The existing `Allow-Headers` / `Allow-Methods` / `Max-Age` values are preserved.

[pkg/common/cors_test.go](pkg/common/cors_test.go) covers empty/malformed origins, same-host echo (forwarded and direct), case-insensitive host match, env-driven extra origins (URL form, `host:port`, port-mismatch rejection), and explicit rejection of cross-origin and target-less requests.

## Operational note

If any frontend currently relies on cross-subdomain credentialed access to this service that was previously masked by the open reflection, set `CORS_ALLOWED_ORIGINS=https://dashboard.<domain>,https://other.<domain>` (or similar) in the deployment env to opt those origins back in.

## Test plan

- [x] `go vet ./pkg/common/... ./pkg/hertz/biz/router/...`
- [x] `go test ./pkg/common/... -count=1 -race`
- [x] `go build ./pkg/common/... ./pkg/hertz/biz/router/...`

Made with [Cursor](https://cursor.com)