### PR TITLE
perf: spool ShareUpload rebuilt multipart body to disk above threshold

### DIFF
--- a/pkg/common/spool.go
+++ b/pkg/common/spool.go
@@ -1,0 +1,129 @@
+package common
+
+import (
+	"bytes"
+	"io"
+	"os"
+)
+
+// SpoolDefaultMemLimit is a conservative in-memory threshold for
+// spooling rebuilt request bodies; anything past this spills to a
+// temp file under os.TempDir(). The number is intentionally smaller
+// than Hertz's max-body-size cap (20 MiB) so a single in-flight
+// request stays well under the framework limit even with a copy.
+const SpoolDefaultMemLimit = 4 << 20
+
+// SpoolWriter buffers writes in memory up to memLimit bytes, then
+// transparently spills the entire content (and subsequent writes) to
+// a temporary file. Use Reader once, after all writes complete, to
+// obtain a positioned-at-zero reader, and Cleanup to release any
+// temp file that was created.
+//
+// SpoolWriter is NOT safe for concurrent use.
+//
+// The intended pattern:
+//
+//	spool := common.NewSpoolWriter(common.SpoolDefaultMemLimit)
+//	defer spool.Cleanup()
+//	// ... write into spool ...
+//	r, err := spool.Reader()
+//	// ... pass r to a downstream consumer; do not Close it ...
+type SpoolWriter struct {
+	memLimit int64
+	buf      bytes.Buffer
+	file     *os.File
+	size     int64
+}
+
+// NewSpoolWriter constructs a SpoolWriter with the given in-memory
+// threshold. A non-positive memLimit is replaced with
+// SpoolDefaultMemLimit.
+func NewSpoolWriter(memLimit int64) *SpoolWriter {
+	if memLimit <= 0 {
+		memLimit = SpoolDefaultMemLimit
+	}
+	return &SpoolWriter{memLimit: memLimit}
+}
+
+// Write appends p to the spool, spilling to disk if the total size
+// would exceed memLimit. The returned count never exceeds len(p).
+func (s *SpoolWriter) Write(p []byte) (int, error) {
+	if s.file != nil {
+		n, err := s.file.Write(p)
+		s.size += int64(n)
+		return n, err
+	}
+	if s.size+int64(len(p)) > s.memLimit {
+		if err := s.spill(); err != nil {
+			return 0, err
+		}
+		n, err := s.file.Write(p)
+		s.size += int64(n)
+		return n, err
+	}
+	n, err := s.buf.Write(p)
+	s.size += int64(n)
+	return n, err
+}
+
+func (s *SpoolWriter) spill() error {
+	f, err := os.CreateTemp("", "files-spool-")
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(s.buf.Bytes()); err != nil {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+		return err
+	}
+	s.buf.Reset()
+	s.file = f
+	return nil
+}
+
+// Size returns the total number of bytes written so far.
+func (s *SpoolWriter) Size() int64 { return s.size }
+
+// SpilledToDisk reports whether this spool has overflowed to a temp
+// file. Useful for tests and observability.
+func (s *SpoolWriter) SpilledToDisk() bool { return s.file != nil }
+
+// Reader returns a Reader over all content written so far, positioned
+// at byte zero. It must be called at most once. The returned Reader
+// is owned by the SpoolWriter; callers must not Close it - call
+// Cleanup when done.
+func (s *SpoolWriter) Reader() (io.Reader, error) {
+	if s.file != nil {
+		if _, err := s.file.Seek(0, io.SeekStart); err != nil {
+			return nil, err
+		}
+		return readNoCloser{Reader: s.file}, nil
+	}
+	return bytes.NewReader(s.buf.Bytes()), nil
+}
+
+// Cleanup releases any resources held by the spool. It is safe to
+// call multiple times and should typically be deferred immediately
+// after construction.
+func (s *SpoolWriter) Cleanup() error {
+	if s.file == nil {
+		return nil
+	}
+	name := s.file.Name()
+	cerr := s.file.Close()
+	rerr := os.Remove(name)
+	s.file = nil
+	if cerr != nil {
+		return cerr
+	}
+	return rerr
+}
+
+// readNoCloser hides the Closer of an *os.File so a downstream
+// consumer that opportunistically calls Close on its body reader
+// cannot race with SpoolWriter.Cleanup.
+type readNoCloser struct {
+	io.Reader
+}
+
+func (readNoCloser) Close() error { return nil }

--- a/pkg/common/spool_test.go
+++ b/pkg/common/spool_test.go
@@ -1,0 +1,155 @@
+package common
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSpoolWriter_StaysInMemoryBelowLimit(t *testing.T) {
+	s := NewSpoolWriter(64)
+	defer s.Cleanup()
+
+	payload := []byte("hello world")
+	if _, err := s.Write(payload); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if s.SpilledToDisk() {
+		t.Fatal("expected spool to stay in memory below limit")
+	}
+	if s.Size() != int64(len(payload)) {
+		t.Fatalf("Size = %d, want %d", s.Size(), len(payload))
+	}
+
+	r, err := s.Reader()
+	if err != nil {
+		t.Fatalf("Reader: %v", err)
+	}
+	got, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("Reader returned %q, want %q", got, payload)
+	}
+}
+
+func TestSpoolWriter_SpillsAcrossThreshold(t *testing.T) {
+	const limit = 16
+	s := NewSpoolWriter(limit)
+	defer s.Cleanup()
+
+	first := bytes.Repeat([]byte("a"), 10)
+	if _, err := s.Write(first); err != nil {
+		t.Fatalf("Write first: %v", err)
+	}
+	if s.SpilledToDisk() {
+		t.Fatal("did not expect spill before threshold")
+	}
+
+	second := bytes.Repeat([]byte("b"), 20)
+	if _, err := s.Write(second); err != nil {
+		t.Fatalf("Write second: %v", err)
+	}
+	if !s.SpilledToDisk() {
+		t.Fatal("expected spill after exceeding threshold")
+	}
+	if got, want := s.Size(), int64(len(first)+len(second)); got != want {
+		t.Fatalf("Size = %d, want %d", got, want)
+	}
+
+	r, err := s.Reader()
+	if err != nil {
+		t.Fatalf("Reader: %v", err)
+	}
+	got, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	want := append(append([]byte{}, first...), second...)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("Reader returned %q, want %q", got, want)
+	}
+}
+
+func TestSpoolWriter_LargeSingleWriteSpills(t *testing.T) {
+	s := NewSpoolWriter(8)
+	defer s.Cleanup()
+
+	payload := bytes.Repeat([]byte{'z'}, 1024)
+	if _, err := s.Write(payload); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if !s.SpilledToDisk() {
+		t.Fatal("large single write should spill")
+	}
+
+	r, err := s.Reader()
+	if err != nil {
+		t.Fatalf("Reader: %v", err)
+	}
+	got, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("payload mismatch: got %d bytes, want %d", len(got), len(payload))
+	}
+}
+
+func TestSpoolWriter_CleanupRemovesTempFile(t *testing.T) {
+	s := NewSpoolWriter(4)
+	if _, err := s.Write([]byte(strings.Repeat("x", 256))); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if !s.SpilledToDisk() {
+		t.Fatal("expected spill")
+	}
+	tempName := s.file.Name()
+
+	if err := s.Cleanup(); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	if _, err := os.Stat(tempName); !os.IsNotExist(err) {
+		t.Fatalf("temp file %q still exists after Cleanup: err=%v", tempName, err)
+	}
+
+	if err := s.Cleanup(); err != nil {
+		t.Fatalf("second Cleanup: %v", err)
+	}
+}
+
+func TestSpoolWriter_DefaultMemLimit(t *testing.T) {
+	s := NewSpoolWriter(0)
+	defer s.Cleanup()
+
+	if s.memLimit != SpoolDefaultMemLimit {
+		t.Fatalf("default memLimit = %d, want %d", s.memLimit, SpoolDefaultMemLimit)
+	}
+
+	s2 := NewSpoolWriter(-1)
+	defer s2.Cleanup()
+	if s2.memLimit != SpoolDefaultMemLimit {
+		t.Fatalf("negative memLimit = %d, want %d", s2.memLimit, SpoolDefaultMemLimit)
+	}
+}
+
+func TestSpoolWriter_TempFileLivesUnderTempDir(t *testing.T) {
+	s := NewSpoolWriter(1)
+	defer s.Cleanup()
+
+	if _, err := s.Write([]byte("spill")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if !s.SpilledToDisk() {
+		t.Fatal("expected spill")
+	}
+	got := s.file.Name()
+	want := os.TempDir()
+	if filepath.Dir(got) != filepath.Clean(want) {
+		t.Fatalf("temp file %q is not under TempDir %q", got, want)
+	}
+}

--- a/pkg/hertz/biz/router/middleware.go
+++ b/pkg/hertz/biz/router/middleware.go
@@ -847,8 +847,20 @@ func ShareUpload() app.HandlerFunc {
 
 		var hasPathname, hasRepoId, hasDriveType bool
 		var hasShareBy bool
-		var buf bytes.Buffer
-		mw := multipart.NewWriter(&buf)
+		// Spool the rebuilt multipart body to disk above
+		// SpoolDefaultMemLimit. Hertz already caps inbound bodies
+		// at 20 MiB, but copying every uploaded file into a single
+		// in-memory bytes.Buffer doubled the per-request peak; the
+		// spool keeps it bounded regardless of how many uploads are
+		// in flight concurrently. Cleanup deletes the temp file once
+		// the downstream handler has finished consuming the stream.
+		spool := common.NewSpoolWriter(common.SpoolDefaultMemLimit)
+		defer func() {
+			if e := spool.Cleanup(); e != nil {
+				klog.Warningf("share upload spool cleanup: %v", e)
+			}
+		}()
+		mw := multipart.NewWriter(spool)
 
 		for name := range mf.Value {
 			switch name {
@@ -943,9 +955,16 @@ func ShareUpload() app.HandlerFunc {
 		}
 
 		newCT := mw.FormDataContentType()
-		ctx.Request.SetBody(buf.Bytes())
+		bodyReader, err := spool.Reader()
+		if err != nil {
+			klog.Errorf("Sync uploadChunks, spool reader error: %v", err)
+			handler.RespBadRequest(ctx, err.Error())
+			return
+		}
+		bodySize := spool.Size()
+		ctx.Request.SetBodyStream(bodyReader, int(bodySize))
 		ctx.Request.Header.Set("Content-Type", newCT)
-		ctx.Request.Header.Set("Content-Length", strconv.Itoa(buf.Len()))
+		ctx.Request.Header.Set("Content-Length", strconv.FormatInt(bodySize, 10))
 
 		ctx.Next(c)
 	}


### PR DESCRIPTION
## Summary

`ShareUpload` ([pkg/hertz/biz/router/middleware.go](pkg/hertz/biz/router/middleware.go)) rebuilds the inbound multipart form (rewriting `parent_dir`, `pathname`, `repoId`, `driveType`, etc.) before forwarding it downstream. Every uploaded file was `io.Copy`'d into a single in-memory `bytes.Buffer` and then handed to `ctx.Request.SetBody`, so each in-flight share upload doubled the per-request memory footprint up to Hertz's 20 MiB body cap. Many concurrent uploads compounded that into real OOM pressure even though no individual request exceeded the framework limit.

This PR is the first step of the share-streaming plan ("threshold spool now, full pipe-based streaming next"):

1. Adds [pkg/common/spool.go](pkg/common/spool.go) with `SpoolWriter`: an `io.Writer` that buffers in memory up to a configurable threshold (default 4 MiB, intentionally well under Hertz's 20 MiB `MaxRequestBodySize`) and transparently spills to a temp file under `os.TempDir` when exceeded. `Reader` returns a zero-positioned reader (`*os.File` for the spilled case, hidden behind a no-op Closer so a downstream consumer can't race `Cleanup`), `Size` reports the total bytes written, and `Cleanup` removes the temp file. Single-threaded by design and reusable for the next streaming PR in the share proxy path.

2. Wires `SpoolWriter` into `ShareUpload`:
   - the rebuilt multipart body now writes into the spool;
   - a deferred `Cleanup` releases the temp file once the downstream handler has finished with the request body;
   - the body is forwarded via `ctx.Request.SetBodyStream` so the spool is consumed lazily instead of materialized as a single `[]byte`.

[pkg/common/spool_test.go](pkg/common/spool_test.go) covers in-memory operation below threshold, spill at threshold (split across writes), spill on a single oversized write, Cleanup removing the temp file (including idempotency), the default-memLimit fallback for non-positive input, and that the temp file is created under `os.TempDir`.

## Test plan

- [x] `go vet ./pkg/common/... ./pkg/hertz/biz/router/...`
- [x] `go test ./pkg/common/... -count=1 -race`
- [x] `go build ./pkg/hertz/biz/router/...`

A follow-up PR will replace the spool + intermediate buffer entirely with an `io.Pipe`-based streaming rebuild, dropping per-request memory to a constant (and optionally raising the 20 MiB Hertz cap so legitimate large uploads don't have to chunk).

Made with [Cursor](https://cursor.com)